### PR TITLE
feat: ship RULES.md with each dev agent for octobots dispatch rules

### DIFF
--- a/agents/ba/RULES.md
+++ b/agents/ba/RULES.md
@@ -1,0 +1,11 @@
+RULES: You MUST respond to this message.
+
+If it is a task (requirements, user stories, acceptance criteria):
+1. Do the work (write stories, structure requirements, create epics/issues)
+2. Comment on the GitHub issue with your output or a link to what was created
+3. Ack: `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "short summary"`
+4. Notify: call the `notify` MCP tool: notify(message="Done: <summary>")
+
+If it is a question: answer via `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "your answer"`.
+
+NEVER ignore a message. Silence breaks the pipeline.

--- a/agents/ios-dev/RULES.md
+++ b/agents/ios-dev/RULES.md
@@ -1,0 +1,13 @@
+RULES: You MUST respond to this message.
+
+If it is a task:
+1. Do the work on a feature branch
+2. Commit with a descriptive message explaining why, not just what
+3. Push and open a PR (include "Closes #<issue>" when applicable)
+4. Comment on the GitHub issue with a summary of what shipped
+5. Ack: `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "short summary"`
+6. Notify: call the `notify` MCP tool: notify(message="Done: <summary>")
+
+If it is a question: answer via `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "your answer"`.
+
+NEVER ignore a message. Silence breaks the pipeline.

--- a/agents/js-dev/RULES.md
+++ b/agents/js-dev/RULES.md
@@ -1,0 +1,13 @@
+RULES: You MUST respond to this message.
+
+If it is a task:
+1. Do the work on a feature branch
+2. Commit with a descriptive message explaining why, not just what
+3. Push and open a PR (include "Closes #<issue>" when applicable)
+4. Comment on the GitHub issue with a summary of what shipped
+5. Ack: `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "short summary"`
+6. Notify: call the `notify` MCP tool: notify(message="Done: <summary>")
+
+If it is a question: answer via `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "your answer"`.
+
+NEVER ignore a message. Silence breaks the pipeline.

--- a/agents/personal-assistant/RULES.md
+++ b/agents/personal-assistant/RULES.md
@@ -1,0 +1,13 @@
+RULES: You MUST respond to this message.
+
+If it is a task (calendar, email, notes, research, errands):
+1. Do the work using your available MCP tools
+2. Ack: `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "short summary"`
+3. Notify: call the `notify` MCP tool: notify(message="Done: <summary>")
+
+Personal-assistant tasks rarely involve GitHub issues. Skip the issue comment unless
+the task is explicitly linked to one.
+
+If it is a question: answer via `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "your answer"`.
+
+NEVER ignore a message. Silence breaks the pipeline.

--- a/agents/project-manager/RULES.md
+++ b/agents/project-manager/RULES.md
@@ -1,0 +1,11 @@
+RULES: You MUST respond to this message.
+
+If it is a task (routing, coordination, merge):
+1. Do the work (route tasks, update issues, merge approved PRs)
+2. Comment on the relevant GitHub issue(s) with status update
+3. Ack: `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "short summary"`
+4. Notify: call the `notify` MCP tool: notify(message="Done: <summary>")
+
+If it is a question: answer via `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "your answer"`.
+
+NEVER ignore a message. Silence breaks the pipeline.

--- a/agents/python-dev/RULES.md
+++ b/agents/python-dev/RULES.md
@@ -1,0 +1,13 @@
+RULES: You MUST respond to this message.
+
+If it is a task:
+1. Do the work on a feature branch
+2. Commit with a descriptive message explaining why, not just what
+3. Push and open a PR (include "Closes #<issue>" when applicable)
+4. Comment on the GitHub issue with a summary of what shipped
+5. Ack: `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "short summary"`
+6. Notify: call the `notify` MCP tool: notify(message="Done: <summary>")
+
+If it is a question: answer via `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "your answer"`.
+
+NEVER ignore a message. Silence breaks the pipeline.

--- a/agents/qa-engineer/RULES.md
+++ b/agents/qa-engineer/RULES.md
@@ -1,0 +1,12 @@
+RULES: You MUST respond to this message.
+
+If it is a task:
+1. Do the work (reproduce, write tests, verify, document evidence)
+2. If writing test code: commit on a feature branch, push, and open a PR
+3. Comment on the GitHub issue with findings, test counts, and verdict
+4. Ack: `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "short summary"`
+5. Notify: call the `notify` MCP tool: notify(message="Done: <summary>")
+
+If it is a question: answer via `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "your answer"`.
+
+NEVER ignore a message. Silence breaks the pipeline.

--- a/agents/scout/RULES.md
+++ b/agents/scout/RULES.md
@@ -1,0 +1,13 @@
+RULES: You MUST respond to this message.
+
+If it is a task (onboarding, exploration, documentation):
+1. Do the work (explore, generate AGENTS.md / CLAUDE.md / .octobots/ content)
+2. Ack: `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "short summary"`
+3. Notify: call the `notify` MCP tool: notify(message="Done: <summary>")
+
+Scout does not open PRs — output is delivered as files in the project directory.
+If asked to commit and push, do so on a branch and report the branch name.
+
+If it is a question: answer via `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "your answer"`.
+
+NEVER ignore a message. Silence breaks the pipeline.

--- a/agents/tech-lead/RULES.md
+++ b/agents/tech-lead/RULES.md
@@ -1,0 +1,12 @@
+RULES: You MUST respond to this message.
+
+If it is a task (decomposition, architecture, code review):
+1. Do the work (decompose, review, or design as requested)
+2. Comment on the GitHub issue with your output (tasks created, review decision, ADR summary)
+3. If you opened sub-issues or PRs, list them in the comment
+4. Ack: `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "short summary"`
+5. Notify: call the `notify` MCP tool: notify(message="Done: <summary>")
+
+If it is a question: answer via `python3 {octobots_dir}/skills/taskbox/scripts/relay.py ack {msg_id} "your answer"`.
+
+NEVER ignore a message. Silence breaks the pipeline.


### PR DESCRIPTION
## Summary

- Adds `RULES.md` alongside `AGENT.md` for all 9 agents in this repo
- Each file contains role-appropriate post-task instructions (ack via `relay.py`, notify MCP, git workflow for dev roles)
- Implements the consumer side of the mechanism shipped in [arozumenko/octobots#15](https://github.com/arozumenko/octobots/pull/15)

## Dependency

**Requires arozumenko/octobots PR #15 merged before this takes effect.** The `RULES.md` files are silently ignored by older supervisor builds — safe to merge in either order, but the feature only activates once octobots PR #15 is deployed.

## Role breakdown

| Agent | Rules style |
|---|---|
| `python-dev`, `js-dev`, `ios-dev` | Full git workflow: branch → commit → PR → issue comment → ack → notify |
| `qa-engineer` | Same flow, test-evidence framing (commit only when writing test code) |
| `tech-lead` | Review/decomposition framing — reviews and approves PRs, doesn't open them |
| `project-manager` | Coordination framing — routes tasks, merges approved PRs, updates issues |
| `ba` | Requirements framing — writes stories/epics, links output to issues |
| `scout` | Exploration framing — delivers files on disk, branches only if explicitly asked |
| `personal-assistant` | Errand framing — MCP-tool-based, skips issue comments unless task is linked |

## Test plan

- [x] All 9 `RULES.md` files created alongside their `AGENT.md`
- [x] `{msg_id}` and `{octobots_dir}` placeholders present in all files that need relay.py
- [x] Content verified to render without leftover placeholders (compatible with octobots `render_dispatch_rules`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)