### PR TITLE
Installer: Copilot CLI flatten + fix-copilot + external skills + conditional skills-inventory injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ once if you want the full catalog.
 | Claude Code | `/plugin marketplace add arozumenko/sdlc-skills` → `/plugin install sdlc-skills@sdlc-skills` | No |
 | Cursor | Point Cursor's plugin system at `.cursor-plugin/plugin.json` (this repo) | No |
 | Gemini CLI | `gemini extensions install https://github.com/arozumenko/sdlc-skills` | No |
-| GitHub Copilot CLI | Reads this `AGENTS.md` when the repo is cloned into your project | No |
+| GitHub Copilot CLI | Reads this `AGENTS.md` when the repo is cloned in, **or** use the npx installer with `--target copilot` (it flattens agents to `.agent.md` + normalizes the `model:` field). Repair existing installs with `init fix-copilot`. | No |
 | Any IDE (full) | `npx github:arozumenko/sdlc-skills init --all` | **Yes** |
 
 ## Using an agent

--- a/README.md
+++ b/README.md
@@ -166,13 +166,57 @@ Install locations:
 | Claude Code | `.claude/` | `.claude/agents/<name>/`, `.claude/skills/<name>/` |
 | Cursor | `.cursor/` | `.cursor/agents/<name>/`, `.cursor/skills/<name>/` |
 | Windsurf | `.windsurf/` | `.windsurf/agents/<name>/`, `.windsurf/skills/<name>/` |
-| GitHub Copilot | `.github/` | `.github/agents/<name>/`, `.github/skills/<name>/` |
+| GitHub Copilot CLI | `.github/` | `.github/agents/<name>.agent.md` (flat file), `.github/skills/<name>/` |
+
+**Copilot CLI note.** Copilot CLI expects agents as flat
+`<name>.agent.md` files, not as directories. The installer handles this
+automatically when `--target copilot` is selected: it flattens
+`AGENT.md` + `SOUL.md` into a single file with a `## Persona` section,
+and rewrites `model: sonnet` → `model: claude-sonnet-4.6` so Copilot CLI
+picks a concrete model. The other targets keep the directory layout.
+
+**Skills-inventory injection (non-Claude targets).** Claude Code
+preloads each SKILL.md declared in the agent's `skills:` frontmatter
+directly into the subagent's context at startup, so the agent already
+has the skill content before it reads its own AGENT.md. Copilot CLI,
+Cursor, and Windsurf have no documented preload — Copilot silently
+discards unknown frontmatter keys. The installer fills the gap only
+where it exists: for Copilot / Cursor / Windsurf targets, every
+installed AGENT.md gets a bracketed `<!-- SKILLS-INJECTED: START -->`
+section listing declared skills with their descriptions from
+`skills.json`. Claude Code agents do not receive this section (it
+would duplicate the preload). The block is idempotent on `--update` —
+re-runs replace in place, never duplicate.
 
 External skills are symlinked into the skills dir from the shared cache
 at `~/.cache/sdlc-skills/registry/<owner>__<repo>/`. Override the cache
 location with `SDLC_SKILLS_CACHE_DIR` or `XDG_CACHE_HOME`.
 
 Run `npx github:arozumenko/sdlc-skills init --help` for the full flag list.
+
+### Repairing an existing Copilot CLI install — `fix-copilot`
+
+If a project already has agents installed as directories under
+`.github/agents/<name>/` (older sdlc-skills release, manual drop,
+install from upstream before this fix landed), run:
+
+```bash
+npx github:arozumenko/sdlc-skills init fix-copilot
+```
+
+This scans `.github/agents/`, flattens each directory into
+`<name>.agent.md`, and rewrites the `model:` line for Copilot
+compatibility. Four modes for handling the paired `SOUL.md`:
+
+| `--soul <mode>` | What happens to `SOUL.md` |
+|---|---|
+| `memory` (default) | Relocated to `.agents/memory/<name>/SOUL.md` (IDE-neutral per-role dir, co-located with memory-skill content); source directory removed; in-file reference rewritten as an `@`-prefixed auto-import (matches the existing `@.agents/memory/<name>/snapshot.md` convention) |
+| `inline` | Appended as `## Persona` inside the flat agent file; source directory removed |
+| `keep` | Left in place at `<name>/SOUL.md`; flat agent file's reference rewritten |
+| `sibling` | Moved to `<name>.soul.md` next to the agent file; reference rewritten |
+
+Add `--dry-run` to preview, or `--no-normalize-model` to keep the
+original `model:` value. Full help: `init fix-copilot --help`.
 
 ### 2. Octobots supervisor
 

--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -18,6 +18,18 @@
  *        npx github:arozumenko/sdlc-skills init --update   # overwrite existing
  *        npx github:arozumenko/sdlc-skills init --target claude
  *
+ *      GitHub Copilot CLI target (--target copilot) flattens agents to
+ *      `.github/agents/<name>.agent.md` (not a directory) with SOUL.md
+ *      appended as a `## Persona` section, and rewrites `model: sonnet`
+ *      → `model: claude-sonnet-4.6`. Other targets keep the directory
+ *      layout.
+ *
+ *      To repair an already-directory-installed project for Copilot:
+ *        npx github:arozumenko/sdlc-skills init fix-copilot
+ *        npx github:arozumenko/sdlc-skills init fix-copilot --soul keep
+ *        npx github:arozumenko/sdlc-skills init fix-copilot --dry-run
+ *        npx github:arozumenko/sdlc-skills init fix-copilot --help
+ *
  *   3. agentskills.io / Vercel / any third-party tool: point directly at
  *      skills/<name>/SKILL.md — the agentskills.io spec frontmatter is
  *      authoritative at that path.
@@ -37,6 +49,7 @@ import {
   statSync,
   symlinkSync,
   unlinkSync,
+  writeFileSync,
 } from "fs";
 import { join, dirname, basename, resolve } from "path";
 import { fileURLToPath } from "url";
@@ -212,15 +225,11 @@ function parseAgentSkillDeps(agentName) {
     .filter(Boolean);
 }
 
-function inferSkillsFromAgents(agentNames, availableSkills, registry) {
-  const declared = new Set();
-  for (const name of agentNames) {
-    for (const skill of parseAgentSkillDeps(name)) declared.add(skill);
-  }
+function partitionSkillIds(ids, availableSkills, registry) {
   const monorepo = [];
   const external = [];
   const unknown = [];
-  for (const id of declared) {
+  for (const id of ids) {
     if (availableSkills.includes(id)) {
       monorepo.push(id);
       continue;
@@ -230,6 +239,14 @@ function inferSkillsFromAgents(agentNames, availableSkills, registry) {
     else unknown.push(id);
   }
   return { monorepo, external, unknown };
+}
+
+function inferSkillsFromAgents(agentNames, availableSkills, registry) {
+  const declared = new Set();
+  for (const name of agentNames) {
+    for (const skill of parseAgentSkillDeps(name)) declared.add(skill);
+  }
+  return partitionSkillIds([...declared], availableSkills, registry);
 }
 
 // ---------------------------------------------------------------------------
@@ -309,14 +326,280 @@ function resolveSelection(requested, available, kind) {
   return requested;
 }
 
-function copyItem(kind, name, targetDir, update) {
-  // kind: "agents" | "skills"
+function copyItem(kind, name, target, update, registry) {
+  // kind: "agents" | "skills"; target: {id, dir, label}
   const src = join(PKG_ROOT, kind, name);
   if (!existsSync(src)) return { status: "missing" };
-  const dest = join(CWD, targetDir, kind, name);
+
+  // GitHub Copilot CLI expects agents as flat `<name>.agent.md` files,
+  // not directories. Flatten AGENT.md + SOUL.md into a single file.
+  if (kind === "agents" && target.id === "copilot") {
+    return flattenAgentForCopilot(src, name, target.dir, update, registry);
+  }
+
+  const dest = join(CWD, target.dir, kind, name);
   if (existsSync(dest) && !update) return { status: "exists", dest };
   mkdirSync(dirname(dest), { recursive: true });
   cpSync(src, dest, { recursive: true, force: update });
+
+  // Inject a skills-inventory section into the installed agent body —
+  // but only for hosts that don't preload the `skills:` frontmatter
+  // field. Claude Code preloads each listed SKILL.md into subagent
+  // context at startup, so a body list would duplicate what's already
+  // in context. Cursor and Windsurf have no documented preload
+  // mechanism and get the body list so agents can discover declared
+  // skills. Copilot runs through flattenAgentForCopilot() above.
+  if (
+    kind === "agents" &&
+    registry &&
+    target.id !== "claude"
+  ) {
+    injectSkillsIntoCopiedAgent(dest, name, registry);
+  }
+
+  return { status: "installed", dest };
+}
+
+// ---------------------------------------------------------------------------
+// Skills-section injection — the frontmatter `skills:` list behaves
+// differently per host, and the installer compensates only where it has
+// to:
+//   - Claude Code:  `skills:` is a preload. Each listed SKILL.md is
+//                   injected into the subagent's context at startup, so
+//                   the agent already has the content before it reads a
+//                   line of AGENT.md. No body injection — it would just
+//                   duplicate the preloaded content. (See code.claude.com
+//                   docs on subagent `skills:` frontmatter.)
+//   - Copilot CLI:  `skills:` is an unknown frontmatter field and is
+//                   silently discarded. Without a body mention, the
+//                   agent has no way to know which skills it ships with.
+//                   Injection is essential here.
+//   - Cursor / Windsurf: no documented preload mechanism; treated like
+//                   Copilot — inject the body list so the agent can
+//                   discover declared skills and load SKILL.md by path.
+// Source files in the repo stay untouched; this is install-time output
+// scoped to the non-Claude targets.
+// ---------------------------------------------------------------------------
+
+const SKILLS_MARKER_START = "<!-- SKILLS-INJECTED: START -->";
+const SKILLS_MARKER_END = "<!-- SKILLS-INJECTED: END -->";
+
+function buildSkillsSection(skills, registry) {
+  if (!skills || skills.length === 0) return null;
+
+  const lookup = {};
+  for (const s of registry.skills || []) lookup[s.id] = s;
+
+  const bullets = skills.map((id) => {
+    const entry = lookup[id];
+    const desc = entry?.description || "(description not in skills.json)";
+    return `- **\`${id}\`** — ${desc}`;
+  });
+
+  return (
+    `${SKILLS_MARKER_START}\n` +
+    "## Skills\n\n" +
+    "_Load any of these on demand; conditional-load triggers live in § Session Start._\n\n" +
+    bullets.join("\n") + "\n\n" +
+    SKILLS_MARKER_END
+  );
+}
+
+function parseSkillsFromFrontmatter(agentText) {
+  const fm = agentText.match(/^---\s*\n([\s\S]*?)\n---/m);
+  if (!fm) return [];
+
+  // Inline form: `skills: [a, b, c]`
+  const inline = fm[1].match(/^skills:\s*\[([^\]]*)\]/m);
+  if (inline) {
+    return inline[1]
+      .split(",")
+      .map((s) => s.trim().replace(/^["']|["']$/g, ""))
+      .filter(Boolean);
+  }
+
+  // Block form:
+  //   skills:
+  //     - a
+  //     - b
+  const block = fm[1].match(/^skills:\s*\n((?:[ \t]*-[ \t]*[^\n]+\n?)+)/m);
+  if (block) {
+    return block[1]
+      .split("\n")
+      .map((l) => l.replace(/^[ \t]*-[ \t]*/, "").trim().replace(/^["']|["']$/g, ""))
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+function injectSkillsSection(agentText, name, registry) {
+  if (!registry) return agentText;
+
+  // 1. Strip any existing SKILLS-INJECTED block (idempotence on re-run).
+  const stripPattern = new RegExp(
+    `\\n*${SKILLS_MARKER_START}[\\s\\S]*?${SKILLS_MARKER_END}\\n*`,
+    "g",
+  );
+  const stripped = agentText.replace(stripPattern, "\n\n");
+
+  // 2. Parse declared skills from frontmatter.
+  const skills = parseSkillsFromFrontmatter(stripped);
+  const section = buildSkillsSection(skills, registry);
+  if (!section) return stripped;
+
+  // 3. Insert right after Session Start ends — that's where the
+  //    conditional-load prose already lives, so reader flow is:
+  //    Identity → Session Start → Skills inventory → Role / Responsibilities.
+  const startMatch = stripped.match(/\n## Session Start[^\n]*\n/);
+  if (startMatch) {
+    const startIdx = startMatch.index + startMatch[0].length;
+    const rest = stripped.slice(startIdx);
+    const nextHeading = rest.match(/\n## /);
+    if (nextHeading) {
+      const insertIdx = startIdx + nextHeading.index + 1;
+      return (
+        stripped.slice(0, insertIdx) +
+        section +
+        "\n\n" +
+        stripped.slice(insertIdx)
+      );
+    }
+  }
+
+  // 4. Fallback — insert before the first `## ` heading after the
+  //    frontmatter.
+  const fmEnd = stripped.indexOf("\n---", 4);
+  if (fmEnd >= 0) {
+    const fallbackMatch = stripped.slice(fmEnd + 4).match(/\n## /);
+    if (fallbackMatch) {
+      const insertIdx = fmEnd + 4 + fallbackMatch.index + 1;
+      return (
+        stripped.slice(0, insertIdx) +
+        section +
+        "\n\n" +
+        stripped.slice(insertIdx)
+      );
+    }
+  }
+
+  // 5. Last resort — append at end.
+  return stripped.trimEnd() + "\n\n" + section + "\n";
+}
+
+function injectSkillsIntoCopiedAgent(destDir, name, registry) {
+  const agentFile = join(destDir, "AGENT.md");
+  if (!existsSync(agentFile)) return;
+  const text = readFileSync(agentFile, "utf8");
+  const rewritten = injectSkillsSection(text, name, registry);
+  if (rewritten !== text) writeFileSync(agentFile, rewritten);
+}
+
+// Core transform used by both install-time (--target copilot) and the
+// fix-copilot subcommand. Given AGENT.md (+ optional SOUL.md) content,
+// returns { agent, soul } — the text to write to <name>.agent.md and
+// (when soulMode requires it) to a separate soul destination.
+function transformAgentForCopilot(
+  agentText,
+  soulText,
+  name,
+  { soulMode = "inline", normalizeModel = true, registry = null } = {},
+) {
+  const SOUL_REF = /Read `SOUL\.md` in this directory for your personality, voice, and values\. That's who you are\./;
+  let agent = agentText;
+  let soul = null;
+
+  if (soulText) {
+    const soulBody = soulText.replace(/^#\s+[^\n]*\n+/, "").trimStart();
+    if (soulMode === "inline") {
+      agent = agent.replace(/\s+$/, "") + "\n\n---\n\n## Persona\n\n" + soulBody;
+    } else if (soulMode === "sibling") {
+      soul = soulText;
+      agent = agent.replace(
+        SOUL_REF,
+        `Read \`${name}.soul.md\` for your personality, voice, and values. That's who you are.`,
+      );
+    } else if (soulMode === "keep") {
+      soul = soulText; // caller keeps it in the source dir
+      agent = agent.replace(
+        SOUL_REF,
+        `Read \`${name}/SOUL.md\` for your personality, voice, and values. That's who you are.`,
+      );
+    } else if (soulMode === "memory") {
+      // Relocate SOUL.md into the IDE-neutral per-role memory dir so the
+      // flat agent file stays lean and the persona is discoverable at a
+      // predictable path across hosts. Caller writes the file to
+      // `<project>/.agents/memory/<name>/SOUL.md`.
+      //
+      // The in-file reference is rewritten as an `@`-prefixed auto-import
+      // directive (same convention as the existing
+      // `@.agents/memory/<name>/snapshot.md` line): Claude Code loads
+      // the file into context automatically, and on hosts that don't
+      // honor `@`-imports the agent still sees the path and can read it.
+      soul = soulText;
+      agent = agent.replace(
+        SOUL_REF,
+        `@.agents/memory/${name}/SOUL.md`,
+      );
+    }
+  }
+
+  if (normalizeModel) {
+    // Map agentskills.io / Claude Code's short-form model aliases to
+    // Anthropic's canonical model IDs (dashed form, matching the SDK).
+    // Copilot CLI requires a concrete ID — shipping `model: sonnet`
+    // leaves Copilot unable to resolve a provider. Keep this map in
+    // lockstep with the current Claude model family; one-line edit on
+    // a family bump.
+    const COPILOT_MODEL_MAP = {
+      sonnet: "claude-sonnet-4-6",
+      opus: "claude-opus-4-7",
+      haiku: "claude-haiku-4-5",
+    };
+    agent = agent.replace(
+      /^model:\s*(sonnet|opus|haiku)\s*$/m,
+      (_, alias) => `model: ${COPILOT_MODEL_MAP[alias]}`,
+    );
+  }
+
+  // Inject the skills-inventory section as the final transform step so
+  // it lands in Copilot's flat `.agent.md` file too (Copilot ignores
+  // unknown frontmatter keys, so without this the `skills:` list is
+  // invisible to the agent at runtime).
+  if (registry) {
+    agent = injectSkillsSection(agent, name, registry);
+  }
+
+  return { agent, soul };
+}
+
+function flattenAgentForCopilot(src, name, targetDir, update, registry) {
+  const agentFile = join(src, "AGENT.md");
+  if (!existsSync(agentFile)) return { status: "missing" };
+  const dest = join(CWD, targetDir, "agents", `${name}.agent.md`);
+  if (existsSync(dest) && !update) return { status: "exists", dest };
+
+  const soulFile = join(src, "SOUL.md");
+  const { agent, soul } = transformAgentForCopilot(
+    readFileSync(agentFile, "utf8"),
+    existsSync(soulFile) ? readFileSync(soulFile, "utf8") : null,
+    name,
+    { soulMode: "memory", normalizeModel: true, registry },
+  );
+
+  mkdirSync(dirname(dest), { recursive: true });
+  writeFileSync(dest, agent);
+
+  // With memory mode (the default), SOUL.md is relocated to the
+  // IDE-neutral per-role dir under .agents/memory/<name>/SOUL.md so the
+  // persona is discoverable at a predictable path across hosts. The
+  // agent's in-file reference was rewritten to match.
+  if (soul) {
+    const soulDest = join(CWD, ".agents", "memory", name, "SOUL.md");
+    mkdirSync(dirname(soulDest), { recursive: true });
+    writeFileSync(soulDest, soul);
+  }
+
   return { status: "installed", dest };
 }
 
@@ -360,9 +643,42 @@ async function interactivePick(catalog, args) {
     }
   }
 
-  // If neither --agents nor --skills nor --all was passed, default to all.
+  // Resolve agents via strict monorepo-only check.
   let agentsSelection = resolveSelection(args.agents, catalog.agents, "agent");
-  let skillsSelection = resolveSelection(args.skills, catalog.skills, "skill");
+
+  // Resolve skills with awareness of externals from skills.json. An
+  // explicit --skills list may contain both monorepo ids (installed by
+  // copy from this repo) and external ids (cloned from skills.json
+  // `repo:` entries and symlinked into the target dir).
+  let skillsSelection;          // monorepo ids to install via copyItem
+  let externalFromFlag = [];    // external registry entries to install via installExternalSkill
+  if (args.skills === null) {
+    skillsSelection = null;
+  } else if (args.skills.length === 0) {
+    skillsSelection = [];
+  } else if (args.skills.length === 1 && args.skills[0] === "all") {
+    skillsSelection = catalog.skills;
+  } else {
+    const { monorepo, external, unknown } = partitionSkillIds(
+      args.skills,
+      catalog.skills,
+      catalog.registry,
+    );
+    if (unknown.length) {
+      const externalIds = (catalog.registry?.skills || [])
+        .filter((e) => e.repo)
+        .map((e) => e.id);
+      console.error(`  ! Unknown skill: ${unknown.join(", ")}`);
+      console.error(`    Monorepo skills: ${catalog.skills.join(", ") || "(none)"}`);
+      if (externalIds.length) {
+        console.error(`    External skills (from skills.json): ${externalIds.join(", ")}`);
+      }
+      process.exit(1);
+    }
+    skillsSelection = monorepo;
+    externalFromFlag = external;
+  }
+
   if (args.all) {
     if (agentsSelection === null) agentsSelection = catalog.agents;
     if (skillsSelection === null) skillsSelection = catalog.skills;
@@ -404,8 +720,6 @@ async function interactivePick(catalog, args) {
           );
         }
         skillsSelection = monorepo;
-        // Stash externals on the return so main() can install them after
-        // the monorepo-skills loop.
         return { targets, agentsSelection, skillsSelection, externalSkills: external };
       } else {
         skillsSelection = [];
@@ -413,11 +727,202 @@ async function interactivePick(catalog, args) {
     }
   }
 
-  return { targets, agentsSelection, skillsSelection, externalSkills: [] };
+  // Announce any externals pulled in by an explicit --skills flag.
+  if (externalFromFlag.length) {
+    console.log(
+      `\n  External skills from --skills (will be fetched):\n    ${externalFromFlag.map((e) => `${e.id} (${e.repo}${e.subdir ? "/" + e.subdir : ""})`).join("\n    ")}`
+    );
+  }
+
+  return { targets, agentsSelection, skillsSelection, externalSkills: externalFromFlag };
+}
+
+// ---------------------------------------------------------------------------
+// fix-copilot subcommand — repair already-installed agent directories so
+// GitHub Copilot CLI can find them. Useful when a project was installed by
+// an older sdlc-skills release (or by hand) and now has
+// `.github/agents/<name>/AGENT.md` directories instead of flat
+// `.github/agents/<name>.agent.md` files.
+// ---------------------------------------------------------------------------
+
+function parseFixCopilotArgs(argv) {
+  const out = {
+    dir: ".github/agents",
+    dryRun: false,
+    soul: "memory",        // memory | inline | keep | sibling
+    normalizeModel: true,  // default-on — Copilot CLI needs a concrete model id
+  };
+  const VALID_SOUL = ["inline", "keep", "sibling", "memory"];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dir") out.dir = argv[++i];
+    else if (a === "--dry-run") out.dryRun = true;
+    else if (a === "--soul") {
+      const v = argv[++i];
+      if (!VALID_SOUL.includes(v)) {
+        console.error(`  ! Invalid --soul mode: ${v} (expected: ${VALID_SOUL.join("|")})`);
+        process.exit(1);
+      }
+      out.soul = v;
+    }
+    else if (a === "--no-normalize-model") out.normalizeModel = false;
+    else if (a === "--normalize-model") out.normalizeModel = true;
+    else if (a === "-h" || a === "--help") {
+      printFixCopilotHelp();
+      process.exit(0);
+    } else {
+      console.error(`  ! Unknown flag for fix-copilot: ${a}`);
+      printFixCopilotHelp();
+      process.exit(1);
+    }
+  }
+  return out;
+}
+
+function printFixCopilotHelp() {
+  console.log(`
+  sdlc-skills fix-copilot — flatten .github/agents/<name>/ to <name>.agent.md
+
+  Run in a project root that has agents installed as directories under
+  .github/agents/. Each <name>/AGENT.md (plus optional SOUL.md) is
+  rewritten into a flat <name>.agent.md file — the format GitHub Copilot
+  CLI expects.
+
+  Options:
+    --dir <path>            Agents directory (default: .github/agents)
+    --dry-run               Preview actions, don't touch disk
+
+    --soul <mode>           How to handle the paired SOUL.md (default: memory)
+        memory    relocate SOUL.md to \`.agents/memory/<name>/SOUL.md\`
+                  (IDE-neutral per-role dir, co-located with the memory
+                  skill's per-role content); remove the source directory;
+                  rewrite the in-file reference to that path
+        inline    append SOUL.md body as a ## Persona section inside the
+                  flat agent file; remove the source directory
+        keep      only flatten AGENT.md; leave SOUL.md where it is (source
+                  dir kept with SOUL.md only) and rewrite the in-file
+                  reference to \`<name>/SOUL.md\`
+        sibling   move SOUL.md to a sibling flat file <name>.soul.md;
+                  remove the source directory; rewrite the in-file
+                  reference to \`<name>.soul.md\`
+
+    --no-normalize-model    Keep 'model: sonnet' as-is (default: rewrite
+                            to 'model: claude-sonnet-4.6' for Copilot CLI)
+    -h, --help              Show this help
+`);
+}
+
+function runFixCopilot(argv) {
+  const opts = parseFixCopilotArgs(argv);
+  const registry = loadSkillRegistry();
+  const agentsDir = resolve(CWD, opts.dir);
+
+  if (!existsSync(agentsDir)) {
+    console.error(`  ! Agents directory not found: ${agentsDir}`);
+    process.exit(1);
+  }
+
+  const dirs = readdirSync(agentsDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && !e.name.startsWith("."))
+    .map((e) => e.name)
+    .sort();
+
+  if (dirs.length === 0) {
+    console.log(`  Nothing to convert in ${agentsDir} (no subdirectories).`);
+    return;
+  }
+
+  console.log(`\n  sdlc-skills fix-copilot — scanning ${agentsDir}`);
+  console.log(`  Mode: soul=${opts.soul}, normalize-model=${opts.normalizeModel}\n`);
+  if (opts.dryRun) console.log("  DRY RUN — nothing will be written or deleted.\n");
+
+  let converted = 0;
+  let skipped = 0;
+  for (const name of dirs) {
+    const srcDir = join(agentsDir, name);
+    const agentFile = join(srcDir, "AGENT.md");
+    const destAgent = join(agentsDir, `${name}.agent.md`);
+    const destSoulSibling = join(agentsDir, `${name}.soul.md`);
+
+    if (!existsSync(agentFile)) {
+      console.log(`  — ${name} skipped: no AGENT.md inside`);
+      skipped++;
+      continue;
+    }
+    if (existsSync(destAgent)) {
+      console.log(`  — ${name} skipped: ${name}.agent.md already exists`);
+      skipped++;
+      continue;
+    }
+
+    try {
+      const soulFile = join(srcDir, "SOUL.md");
+      const soulText = existsSync(soulFile) ? readFileSync(soulFile, "utf8") : null;
+      const { agent } = transformAgentForCopilot(
+        readFileSync(agentFile, "utf8"),
+        soulText,
+        name,
+        { soulMode: opts.soul, normalizeModel: opts.normalizeModel, registry },
+      );
+
+      // Work out what happens to SOUL.md + the source directory given the mode
+      const willWriteSibling = opts.soul === "sibling" && soulText;
+      const willWriteMemory = opts.soul === "memory" && soulText;
+      const memoryDest = willWriteMemory
+        ? join(CWD, ".agents", "memory", name, "SOUL.md")
+        : null;
+      const removeDir = opts.soul !== "keep"; // keep leaves dir with SOUL.md
+
+      if (opts.dryRun) {
+        console.log(
+          `  → ${name} → ${name}.agent.md (${agent.length} bytes)` +
+            (willWriteSibling ? `, write ${name}.soul.md` : "") +
+            (willWriteMemory ? `, write .agents/memory/${name}/SOUL.md` : "") +
+            (opts.soul === "keep" ? `, keep ${name}/SOUL.md` : "") +
+            (removeDir ? ", remove source dir" : ""),
+        );
+      } else {
+        writeFileSync(destAgent, agent);
+        if (willWriteSibling) writeFileSync(destSoulSibling, soulText);
+        if (willWriteMemory) {
+          mkdirSync(dirname(memoryDest), { recursive: true });
+          writeFileSync(memoryDest, soulText);
+        }
+        if (opts.soul === "keep") {
+          // Delete only AGENT.md, leave the directory with SOUL.md intact.
+          rmSync(agentFile);
+        } else if (removeDir) {
+          rmSync(srcDir, { recursive: true, force: true });
+        }
+        const tail = willWriteSibling
+          ? ` + ${name}.soul.md`
+          : willWriteMemory
+            ? ` + .agents/memory/${name}/SOUL.md`
+            : opts.soul === "keep"
+              ? ` (kept ${name}/SOUL.md)`
+              : "";
+        console.log(`  ✓ ${name} → ${name}.agent.md${tail}`);
+      }
+      converted++;
+    } catch (err) {
+      console.error(`  ! ${name} failed: ${err.message}`);
+      skipped++;
+    }
+  }
+  console.log(
+    `\n  Done: ${converted} ${opts.dryRun ? "would be converted" : "converted"}, ${skipped} skipped.\n`,
+  );
 }
 
 async function main() {
-  const args = parseArgs(process.argv.slice(2));
+  const argv = process.argv.slice(2);
+
+  // Subcommand routing — default is install.
+  if (argv[0] === "fix-copilot") {
+    return runFixCopilot(argv.slice(1));
+  }
+
+  const args = parseArgs(argv);
   const catalog = loadCatalog();
 
   console.log("\n  sdlc-skills — SDLC agents and skills for Claude Code\n");
@@ -442,7 +947,7 @@ async function main() {
   for (const t of targets) {
     console.log(`  → ${t.label} (${t.dir}/)`);
     for (const name of agentsSelection) {
-      const r = copyItem("agents", name, t.dir, args.update);
+      const r = copyItem("agents", name, t, args.update, catalog.registry);
       if (r.status === "installed") {
         console.log(`      ✓ agent  ${name}`);
         installed++;
@@ -454,7 +959,7 @@ async function main() {
       }
     }
     for (const name of skillsSelection) {
-      const r = copyItem("skills", name, t.dir, args.update);
+      const r = copyItem("skills", name, t, args.update, catalog.registry);
       if (r.status === "installed") {
         console.log(`      ✓ skill  ${name}`);
         installed++;


### PR DESCRIPTION
## Summary

Makes the installer a first-class path for **GitHub Copilot CLI** and closes the cross-host gap where declared `skills:` are invisible to the agent at runtime — **only on hosts where that gap actually exists.**

- `--target copilot` flattens `AGENT.md` + `SOUL.md` into a single `.github/agents/<name>.agent.md` and normalizes `model:` for Copilot compatibility.
- **`SOUL.md` now defaults to `memory` mode** — on Copilot targets the file is relocated to `<project>/.agents/memory/<name>/SOUL.md` and the in-agent reference is rewritten as an `@`-prefixed auto-import directive (same convention as the existing `@.agents/memory/<name>/snapshot.md` line). Claude Code auto-loads both at session start; hosts that don't honor `@`-imports still see the path and can read it.
- New `init fix-copilot` subcommand repairs directory-layout installs; modes: `memory` (default) / `inline` / `keep` / `sibling`, plus `--dry-run`, `--no-normalize-model`.
- `--skills` now accepts external ids from `skills.json` (shallow-clone + symlink via shared cache under `~/.cache/sdlc-skills/registry/`).
- **Conditional skills-inventory injection** — installer writes a `SKILLS-INJECTED` section into every installed AGENT.md body **only for non-Claude targets**. Idempotent on `--update`.

## Why conditional skills injection (not universal)

The `skills:` frontmatter field behaves differently per host:

| Host | What `skills:` does | Needs body injection? |
|---|---|---|
| **Claude Code** | Preloads each listed `SKILL.md` into the subagent's context at startup — the agent has the full skill content before reading its AGENT.md | **No** — would duplicate preloaded content |
| **Copilot CLI** | Silently discarded as an unknown frontmatter key | **Yes** — only way the agent knows its skills exist |
| **Cursor / Windsurf** | No documented preload mechanism | **Yes** — treated like Copilot |

## Why `memory` as the SOUL default

`memory` mode matches the existing `@.agents/memory/<name>/snapshot.md` convention already used by every agent — SOUL joins snapshot in the per-role memory dir, and Claude Code's `@`-import treats it exactly like the snapshot (auto-load at session start). For Copilot the flat agent file stays compact (no giant `## Persona` appendage) and the path is predictable across hosts.

Identity section before / after (Copilot target):

```
## Identity                                ## Identity

Read `SOUL.md` in this directory for  →    @.agents/memory/<name>/SOUL.md
your personality, voice, and values.
That's who you are.
```

## What changed

| File | Why |
|---|---|
| `bin/init.mjs` | Copilot transform, fix-copilot subcommand, external-skills resolution, conditional skills-inventory injection, `memory` as the default SOUL mode with `@`-import rewrite (+525 / −16) |
| `README.md` | Copilot CLI install section, fix-copilot reference table (`memory` default), skills-inventory-injection explainer |
| `AGENTS.md` | Copilot CLI row expanded with both install paths |

## Test plan

- [x] `init --target claude/cursor/windsurf` — directory layout preserved, `SOUL.md` stays next to `AGENT.md`, no SKILLS-INJECTED block on Claude
- [x] `init --target copilot` — flat `.agent.md` with `@.agents/memory/<name>/SOUL.md` auto-import and `SOUL.md` written under `.agents/memory/<name>/`; `model: claude-sonnet-4.6` normalized; SKILLS-INJECTED block present
- [x] `init --target copilot/cursor/windsurf` — SKILLS-INJECTED block present (one per agent), idempotent on `--update`
- [x] `init fix-copilot` (no args) — default mode is `memory`; source directory removed; `.agents/memory/<name>/SOUL.md` created
- [x] `init fix-copilot --soul drop` — rejected with list of valid modes (`drop` is no longer a mode)
- [x] External skill resolution: `--skills tdd` → shallow-clones `mattpocock/skills` and symlinks `tdd/`
- [x] Source `agents/**/AGENT.md` / `SOUL.md` files are never modified by the installer

## Scope

Installer-only. Does not add new agents or skills. Sibling PRs ship the consumers.