### PR TITLE
Add atlassian-content skill — Jira ADF + Confluence storage format authoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@ of native plugin formats and a shared npx installer.
   `git-workflow`, `memory`, `playwright-testing`, `browser-verify`,
   `issue-tracking`, `xray-testing`, `goal-verifier`, `context-gatherer`,
   `deep-research`, `obsidian-vault`, `msgraph`, `project-seeder`.
+  `issue-tracking`, `atlassian-content`, `goal-verifier`,
+  `context-gatherer`, `deep-research`, `obsidian-vault`, `msgraph`,
+  `project-seeder`.
 - **`skills.json`** — catalog of all skills, monorepo and external.
   The installer uses it to resolve + fetch external skills (from
   `mattpocock/skills`, `obra/superpowers`, `twostraws/*-Agent-Skill`).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -31,6 +31,7 @@ are capability definitions, not always-on context.
 | `implement-feature` | A plan exists and you're about to write code |
 | `bugfix-workflow` | Reproducing and fixing a reported bug |
 | `xray-testing` | CRUD + results import on Xray entities (Test / Precondition / Set / Plan / Execution / Run) across Cloud (GraphQL) and Server/DC (REST) |
+| `atlassian-content` | Authoring Jira issues/comments (ADF, API v3) and Confluence pages (storage format) with accountId mentions + post-creation verification |
 | `code-review` | Reviewing a PR or diff |
 | `task-completion` | Finishing routed work — commit, push, PR, comment, notify |
 | `git-workflow` | Branching, commits, PRs, rebasing |

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ frameworks, other IDEs) can point directly at `skills/<name>/`.
 | `browser-verify` | Quick visual / smoke verification in a browser |
 | `issue-tracking` | GitHub / Linear / GitLab issue management |
 | `xray-testing` | Xray CRUD + results import — Tests, Preconditions, Test Sets/Plans, Executions, Runs. Xray Cloud (GraphQL) + Server/DC (REST). Stdlib Python CLI fallback |
+| `atlassian-content` | Jira issue/comment authoring (ADF, API v3) + Confluence pages (storage format) with accountId mentions and post-creation verification |
 | `goal-verifier` | Verify a task actually achieved its stated goal |
 | `context-gatherer` | Targeted codebase exploration before changes |
 | `deep-research` | Multi-source research and synthesis |

--- a/skills.json
+++ b/skills.json
@@ -15,6 +15,7 @@
     {"id": "playwright-testing", "monorepo": "sdlc-skills", "name": "playwright-testing", "description": "End-to-end browser testing with Playwright"},
     {"id": "bugfix-workflow",    "monorepo": "sdlc-skills", "name": "bugfix-workflow",    "description": "End-to-end bugfix workflow — reproduce, test, fix, verify, document"},
     {"id": "xray-testing",             "monorepo": "sdlc-skills", "name": "xray-testing",             "description": "CRUD + results import on Xray entities (Test / Precondition / Test Set / Test Plan / Test Execution / Test Run) across Xray Cloud (GraphQL) and Server/DC (REST). JUnit / Cucumber / Xray JSON import formats"},
+    {"id": "atlassian-content",        "monorepo": "sdlc-skills", "name": "atlassian-content",        "description": "Create well-formatted Jira issues/comments (ADF, API v3) and Confluence pages (storage format) with accountId-backed mentions and mandatory post-creation re-fetch + repair"},
     {"id": "implement-feature",  "monorepo": "sdlc-skills", "name": "implement-feature",  "description": "End-to-end feature implementation workflow — plan, test, build, ship"},
     {"id": "plan-feature",       "monorepo": "sdlc-skills", "name": "plan-feature",       "description": "Structured feature planning — requirements, feasibility, acceptance criteria"},
     {"id": "project-seeder",     "monorepo": "sdlc-skills", "name": "project-seeder",     "description": "Generate AGENTS.md, .agents/ content docs, and per-role memory briefings for a new project (used by scout)"},

--- a/skills/atlassian-content/SKILL.md
+++ b/skills/atlassian-content/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: atlassian-content
+description: Create well-formatted Jira issues/comments (ADF, API v3) and Confluence pages (storage format) with accountId-backed mentions and mandatory post-creation re-fetch + repair. Load for "file a bug", "review comment on JIRA-123", "write up a decision page", or any authored Atlassian content.
+license: Apache-2.0
+metadata:
+  author: octobots
+  version: "0.1.0"
+---
+
+# Atlassian content — Jira + Confluence, done right
+
+Atlassian's two content surfaces have **two completely different
+formats**, and markdown is not either of them. Content submitted in
+the wrong format renders as a wall of asterisks, broken tables,
+orphan `@username` strings, and code blocks that display as plain
+paragraphs. This skill is the rulebook for getting it right the
+first time and verifying it after.
+
+**Core principle:** *Format-match the surface, resolve identities
+before you post, and always re-fetch what you wrote.*
+
+## When to load this skill
+
+Load when the task involves authoring content inside Atlassian
+products:
+
+- Filing a Jira issue (story, bug, task, subtask)
+- Leaving a Jira comment (review findings, clarifications, updates)
+- Updating a Jira field that accepts rich text (description, custom
+  text fields)
+- Creating or editing a Confluence page (decisions, runbooks,
+  writeups, reviews)
+- Mentioning a human in either surface
+
+Do NOT load for: read-only Jira/Confluence operations (search,
+field reads, user lookups) — those don't need formatting rules.
+
+## Absolute boundaries
+
+- **Never post markdown into Jira or Confluence.** Jira Cloud API v3
+  expects **ADF** (Atlassian Document Format — a structured JSON
+  document). Confluence REST expects **storage format** (XHTML-ish
+  markup with `<ac:*>` / `<ri:*>` macros). Neither surface
+  interprets markdown natively via the API.
+- **Never mention by `@username`.** Both surfaces mention by
+  **`accountId`** (Cloud). A free-text `@Alexander` string posts as
+  a literal `@Alexander` — no notification, no link, no profile
+  card.
+- **Never declare a post "done" without re-fetching it.** The only
+  ground truth is what the server returns after creation. Run the
+  verification pass (see `references/verification.md`) on every
+  issue, comment, or page you create.
+- **Never update without first fetching the raw current body.**
+  For any edit / append on an existing issue description, comment,
+  or Confluence page, fetch the current content in its **raw
+  structured view** first (ADF doc for Jira, storage format string
+  for Confluence) — not the rendered HTML. Reading the raw body is
+  how you see the existing macros, custom nodes, versioned
+  structure, and formatting conventions the page already uses.
+  Edit *into* that structure; don't overwrite it with a fresh body
+  that discards the author's layout. **Applies regardless of
+  transport** — raw Jira / Confluence REST API, MCP tools
+  (`Elitea_Dev`, `JiraIntegration`, `mcp-atlassian`), or any
+  Atlassian-connected integration the project ships. Pick the read
+  tool that returns the raw ADF / storage string, not a
+  pre-rendered / human-readable summary. See
+  `references/verification.md` § "Before you update: raw-fetch
+  first".
+- **Never paste API tokens into the content.** If a snippet
+  illustrates an API call, redact credentials. This skill writes
+  user-facing content; credentials belong in `.env` / auth_env, not
+  in descriptions.
+
+## Transport — MCP preferred, curl fallback, browser last resort
+
+Priority: **MCP** (Atlassian MCP server like `Elitea_Dev`,
+`JiraIntegration`, `mcp-atlassian` — secrets stay out of agent
+context) → **curl / HTTP** (using `JIRA_BASE_URL` + auth env from
+`.agents/profile.md` § Project systems; if that file isn't present
+yet — project not seeded — ask the operator for the base URL and
+auth env var before falling back to HTTP) → **browser** (last
+resort; note explicitly that verification was visual-only).
+Transport does **not** change the body format — ADF over MCP is the
+same ADF as ADF over curl.
+
+## The authoring loop (every post, every time)
+
+```
+0. If updating an existing resource:
+   Raw-fetch first  → GET the current body in its structured form
+                      (ADF for Jira, storage format for Confluence),
+                      read it, and merge your change into it —
+                      don't regenerate from scratch.
+1. Detect surface      → Jira issue, Jira comment, or Confluence page?
+2. Resolve identities  → mentions by accountId; project/space keys; issue keys
+3. Assemble body       → ADF (Jira) or storage format (Confluence)
+4. Submit              → MCP tool or REST endpoint
+5. Re-fetch            → GET the resource back, don't trust the POST response alone
+6. Validate            → run the checklist in references/verification.md
+7. Repair              → if ugly, PUT/PATCH a fix; don't leave garbage
+```
+
+Each phase is cheap. Skipping any of them is how ugly tickets get
+filed.
+
+### 1. Detect surface
+
+Three surfaces, three format rules:
+
+| Surface | Format | Endpoint (Cloud) |
+|---|---|---|
+| Jira issue create / update | **ADF** under `fields.description` (+ other rich-text custom fields) | `POST /rest/api/3/issue`, `PUT /rest/api/3/issue/{key}` |
+| Jira comment | **ADF** under `body` | `POST /rest/api/3/issue/{key}/comment` |
+| Confluence page create / update | **storage format** (string) under `body.storage.value`, `representation: "storage"` | `POST /wiki/rest/api/content`, `PUT /wiki/rest/api/content/{id}` |
+
+If you're unsure which surface you're targeting: a Jira issue key
+(`PROJ-123`) → Jira. A Confluence space key + page title → Confluence.
+
+### 2. Resolve identities
+
+Before assembling the body, collect every identity you'll reference:
+
+- **Users** → `accountId`. Look up via `GET /rest/api/3/user/search?query=<email-or-name>`
+  (Jira) or `GET /wiki/rest/api/user?username=...` (Confluence) if
+  you only know a name/email. **Cache per session** — the same
+  person has the same `accountId` across both surfaces in a given
+  Atlassian tenant.
+- **Jira project key** → usually known from the task
+  (`.agents/profile.md` § Project systems). If not, `GET /rest/api/3/project`.
+- **Confluence space key** → likewise from profile; otherwise
+  `GET /wiki/rest/api/space`.
+- **Linked issues** → the issue keys themselves; ADF `inlineCard`
+  or `mention`-style cards render them.
+
+If you cannot resolve a user, **do not invent a mention**. Fall
+back to plain text (`"Hi Alexander, "`) or ask the operator.
+
+### 3. Assemble body
+
+- **Jira** → build an ADF document. See `references/jira-adf.md`
+  for the complete node/mark reference and working examples.
+- **Confluence** → build a storage-format XHTML string. See
+  `references/confluence-storage.md`.
+- **Mentions** (both surfaces) → see `references/mentions.md`.
+
+### 4. Submit
+
+MCP call, or `POST` / `PUT` via HTTP. No format-layer logic here —
+the body you assembled in step 3 is the body you send.
+
+### 5. Re-fetch
+
+Read back what you just wrote:
+
+- `GET /rest/api/3/issue/{key}?expand=renderedFields` — compare
+  ADF in `fields.description` and the rendered HTML in
+  `renderedFields.description`. If the rendered HTML is empty,
+  malformed, or missing expected elements, your ADF is wrong.
+- `GET /rest/api/3/issue/{key}/comment/{id}?expand=renderedBody`
+- `GET /wiki/rest/api/content/{id}?expand=body.storage,body.view` —
+  compare `body.storage` (what you submitted) with `body.view` (how
+  Confluence renders it).
+
+### 6. Validate
+
+Run the post-creation checklist in `references/verification.md`.
+Non-negotiable items:
+
+- Every `@mention` became an actual mention node (not a plain text
+  `@name`)
+- Code blocks render as monospace code (not inline backticks in
+  prose)
+- Tables render as tables (not pipe-separated text)
+- Headings render as headings (not bold paragraphs)
+- Links are clickable (not bare URLs in text)
+- No literal `**bold**` / `# heading` markdown artefacts
+
+### 7. Repair
+
+If verification fails, build a corrected body and `PUT` it back.
+Don't file a follow-up ticket "to fix formatting later". The
+content you just filed is evidence of your care; leaving it broken
+is a broken window.
+
+## Quick decision tree
+
+```
+Task: "file a bug for case X"
+  └─ surface = Jira issue
+     └─ format = ADF under fields.description
+        └─ mentions of reporter / assignee → accountId nodes
+           └─ submit → re-fetch → validate → (repair if needed)
+
+Task: "add a review comment on JIRA-123"
+  └─ surface = Jira comment
+     └─ format = ADF under body
+        └─ submit → re-fetch renderedBody → validate
+
+Task: "document the migration plan on the Engineering space"
+  └─ surface = Confluence page
+     └─ format = storage format under body.storage.value
+        └─ submit → re-fetch body.view → validate
+```
+
+## Anti-patterns (things that look fine but aren't)
+
+- **"The markdown renders in the preview"** — Atlassian's *web UI*
+  accepts markdown-like shortcuts and transforms them during
+  editing. The API does not. What you POST is what persists.
+- **"I'll just paste the description as plain text"** — plain text
+  through the API is valid ADF-wrapped plain text, but loses
+  headings, code blocks, lists, and mentions. Acceptable only for
+  one-line comments.
+- **"The POST returned 201, so it worked"** — 201 means the server
+  accepted the JSON structure. It does NOT mean the content
+  renders. Always re-fetch.
+- **"I mentioned the user with `@firstname`"** — Atlassian Cloud
+  does not accept username mentions via API. Only accountId-backed
+  mention nodes. Username strings are literal text.
+- **"I copy-pasted the ADF from the web UI's source"** — the web
+  UI sometimes emits extra fields (`marks: []` vs no `marks`,
+  `version: 1` on nested docs). Use the minimal, documented form
+  in `references/jira-adf.md`.
+- **"I used `<br>` for a line break"** — Confluence storage
+  format tolerates `<br/>` but prefers paragraph boundaries for
+  prose. ADF has no `<br>` — use paragraph splits or `hardBreak`
+  nodes.
+
+## Escalation — when to ask the operator
+
+- The project's `.agents/profile.md` § Project systems doesn't
+  specify an issue tracker or the tracker is on-prem Jira Server
+  (which uses wiki markup, not ADF — different API version).
+- Credentials aren't configured and MCP isn't online.
+- A mention target can't be resolved to an accountId (user left
+  the company, ambiguous name).
+- The space / project requires fields you don't have values for
+  (custom required fields on a specific issue type).
+
+## References
+
+- `references/jira-adf.md` — ADF node/mark catalogue, the JIRA
+  SYNTAX REFERENCE, working examples (story with headings, lists,
+  tables, panels, code blocks, mentions)
+- `references/confluence-storage.md` — storage format primer,
+  common macros (`<ac:structured-macro>`), page creation examples
+- `references/mentions.md` — accountId lookup + mention nodes for
+  both surfaces
+- `references/verification.md` — post-creation checklist and
+  repair recipes
+
+External:
+
+- https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
+- https://developer.atlassian.com/cloud/confluence/rest/v1/intro/
+- https://github.com/sooperset/mcp-atlassian/tree/main/docs/guides
+  (working MCP-server example with ADF + storage-format recipes)

--- a/skills/atlassian-content/references/confluence-storage.md
+++ b/skills/atlassian-content/references/confluence-storage.md
@@ -1,0 +1,332 @@
+# Confluence storage format — the XHTML-ish markup
+
+Confluence REST expects pages in **storage format**: an XHTML
+dialect with custom `<ac:*>` (Atlassian Confluence) and `<ri:*>`
+(resource identifier) elements for macros, links, and rich content.
+
+Markdown does not work. Wiki markup works only through a legacy
+converter endpoint. Storage format is the supported, stable
+surface for automation.
+
+## API version — v1 is used here; v2 is the future
+
+The examples in this reference use the **v1 Cloud REST API**
+(`/wiki/rest/api/content`), which is still fully functional and
+is what most existing Atlassian MCPs wrap. Atlassian's current
+recommendation for new code is the **v2 API**
+(`/wiki/api/v2/pages`) — same storage format, flatter payload:
+
+```
+# v1 (this reference uses this shape everywhere)
+POST /wiki/rest/api/content
+{ "body": { "storage": { "value": "<p>…</p>",
+                          "representation": "storage" } } }
+
+# v2 (same storage content, different wrapping)
+POST /wiki/api/v2/pages
+{ "spaceId": "…", "title": "…",
+  "body": { "representation": "storage",
+            "value": "<p>…</p>" } }
+```
+
+**When to reach for v2:**
+
+- The operator's project or MCP explicitly targets v2.
+- A feature only v2 exposes (e.g. folder-tree navigation,
+  new label APIs).
+- Long-running automation that wants to ride the deprecation
+  glide path rather than be caught mid-migration.
+
+**When v1 is fine:**
+
+- Existing MCPs (`mcp-atlassian`, Elitea's Confluence tools,
+  most vendor MCPs) speak v1 natively.
+- Ad-hoc ops from an agent — v1 is simpler and more widely
+  documented.
+
+The storage-format body itself (every XHTML example below) is
+**identical across v1 and v2**; only the endpoint path and the
+outer JSON wrapper change. Read-back paths differ similarly:
+
+```
+# v1
+GET /wiki/rest/api/content/{id}?expand=body.storage,body.view
+
+# v2
+GET /wiki/api/v2/pages/{id}?body-format=storage
+```
+
+## Page skeleton
+
+Create payload:
+
+```json
+POST /wiki/rest/api/content
+{
+  "type": "page",
+  "title": "Q2 Plan — Review",
+  "space": { "key": "ENG" },
+  "body": {
+    "storage": {
+      "value": "<p>Hello.</p>",
+      "representation": "storage"
+    }
+  }
+}
+```
+
+Update payload (note the required `version.number`):
+
+```json
+PUT /wiki/rest/api/content/{id}
+{
+  "type": "page",
+  "title": "Q2 Plan — Review",
+  "version": { "number": 2 },
+  "body": {
+    "storage": {
+      "value": "<p>Updated.</p>",
+      "representation": "storage"
+    }
+  }
+}
+```
+
+Read back:
+
+```
+GET /wiki/rest/api/content/{id}?expand=body.storage,body.view,version
+```
+
+`body.storage.value` is what you submitted (XHTML). `body.view.value`
+is the rendered HTML the user sees.
+
+## Core structural elements
+
+### Paragraphs, headings, breaks
+
+```html
+<h1>Top heading</h1>
+<h2>Section</h2>
+<p>A paragraph.</p>
+<p>Another paragraph. Use <br/> for a forced line break if you really need one.</p>
+<hr/>
+```
+
+Headings `h1`–`h6` are supported. Prefer `h2` / `h3` for body
+sections — the page title is already the outermost heading.
+
+### Inline marks
+
+```html
+<p>
+  <strong>bold</strong>, <em>italic</em>, <u>underline</u>,
+  <s>strike</s>, and <code>inline code</code>.
+</p>
+```
+
+### Links
+
+Internal links to other Confluence pages use an `<ac:link>`:
+
+```html
+<p>
+  See <ac:link><ri:page ri:content-title="Design Review"
+                        ri:space-key="ENG" /></ac:link>
+  for context.
+</p>
+```
+
+External links are plain `<a href>`:
+
+```html
+<p>See <a href="https://example.com/docs">the docs</a>.</p>
+```
+
+### Lists
+
+```html
+<ul>
+  <li>First</li>
+  <li>Second
+    <ul>
+      <li>Nested</li>
+    </ul>
+  </li>
+</ul>
+
+<ol>
+  <li>Step one</li>
+  <li>Step two</li>
+</ol>
+```
+
+### Tables
+
+```html
+<table>
+  <tbody>
+    <tr>
+      <th>Env</th>
+      <th>Result</th>
+    </tr>
+    <tr>
+      <td>staging</td>
+      <td>fails</td>
+    </tr>
+    <tr>
+      <td>prod</td>
+      <td>not yet deployed</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+Confluence accepts simple `<table>` structures. Avoid `<thead>` /
+`<tfoot>` — the storage format parser sometimes strips them.
+
+### Blockquote
+
+```html
+<blockquote>
+  <p>Quoted paragraph.</p>
+</blockquote>
+```
+
+## Macros — the `<ac:structured-macro>` family
+
+Most rich elements (code blocks, info panels, TOC, attachments)
+are **macros**. General shape:
+
+```html
+<ac:structured-macro ac:name="MACRO_NAME" ac:schema-version="1">
+  <ac:parameter ac:name="PARAM">VALUE</ac:parameter>
+  <ac:rich-text-body>
+    <p>Body content (for macros that accept rich text).</p>
+  </ac:rich-text-body>
+</ac:structured-macro>
+```
+
+### Code block
+
+```html
+<ac:structured-macro ac:name="code" ac:schema-version="1">
+  <ac:parameter ac:name="language">python</ac:parameter>
+  <ac:parameter ac:name="title">Example handler</ac:parameter>
+  <ac:plain-text-body><![CDATA[def handler(event):
+    return {"ok": True}
+]]></ac:plain-text-body>
+</ac:structured-macro>
+```
+
+`<![CDATA[...]]>` protects your code from XML entity escaping.
+Always use it for code blocks.
+
+Common `language` values: `python`, `javascript`, `typescript`,
+`java`, `go`, `bash`, `json`, `yaml`, `sql`, `xml`, `html`, `none`.
+
+### Info / note / warning panels
+
+```html
+<ac:structured-macro ac:name="info" ac:schema-version="1">
+  <ac:rich-text-body>
+    <p>Heads up — this changes next sprint.</p>
+  </ac:rich-text-body>
+</ac:structured-macro>
+```
+
+Panel macro names: `info`, `note`, `tip`, `warning`. Same body
+shape for all.
+
+### Table of contents
+
+```html
+<ac:structured-macro ac:name="toc" ac:schema-version="1">
+  <ac:parameter ac:name="maxLevel">3</ac:parameter>
+</ac:structured-macro>
+```
+
+Place at the top of long pages.
+
+### Status lozenge
+
+```html
+<ac:structured-macro ac:name="status" ac:schema-version="1">
+  <ac:parameter ac:name="colour">Green</ac:parameter>
+  <ac:parameter ac:name="title">DONE</ac:parameter>
+</ac:structured-macro>
+```
+
+`colour` values: `Grey`, `Red`, `Yellow`, `Green`, `Blue`,
+`Purple`. The title is the displayed text.
+
+## Mentions
+
+Mentions in Confluence REST use an `<ac:link>` wrapping a
+`<ri:user>` with `ri:account-id`:
+
+```html
+<p>
+  Hi
+  <ac:link>
+    <ri:user ri:account-id="61e1a042e67ea2006b5b2157" />
+  </ac:link>,
+  please review.
+</p>
+```
+
+See `mentions.md` for accountId lookup. The same `accountId` works
+across Jira and Confluence in the same tenant.
+
+## Worked example — a decision page with mention, code block, panel, table
+
+```json
+POST /wiki/rest/api/content
+{
+  "type": "page",
+  "title": "Decision — switch TMS to Zephyr Scale",
+  "space": { "key": "ENG" },
+  "body": {
+    "storage": {
+      "value": "<h2>Context</h2><p>We currently use TestRail but the team wants native Jira integration. Raised by <ac:link><ri:user ri:account-id=\"61e1a042e67ea2006b5b2157\" /></ac:link>.</p><h2>Options considered</h2><table><tbody><tr><th>Option</th><th>Pros</th><th>Cons</th></tr><tr><td>Keep TestRail</td><td>Current tooling works</td><td>Separate login, poor Jira linking</td></tr><tr><td>Move to Zephyr Scale</td><td>Native Jira, no extra login</td><td>Migration effort, ~400 cases</td></tr></tbody></table><h2>Decision</h2><ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\"><ac:rich-text-body><p>We move to Zephyr Scale by end of Q2.</p></ac:rich-text-body></ac:structured-macro><h2>Migration script sketch</h2><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\"><ac:parameter ac:name=\"language\">python</ac:parameter><ac:plain-text-body><![CDATA[for case in testrail.cases(project_id=7):\n    zephyr.create_case(\n        name=case.title,\n        steps=case.custom_steps_separated,\n    )\n]]></ac:plain-text-body></ac:structured-macro>",
+      "representation": "storage"
+    }
+  }
+}
+```
+
+Note the `\"` escapes — the whole storage string is JSON-encoded
+when submitted via REST. If your agent tool assembles the JSON for
+you, you may write the XHTML directly.
+
+## Common pitfalls
+
+- **Unescaped `&`, `<`, `>`** — storage format is XHTML. A literal
+  ampersand in prose must be `&amp;`. A literal `<` outside a tag
+  must be `&lt;`. Code blocks inside `<![CDATA[...]]>` are exempt.
+- **Self-closing an element that isn't void** — `<p />` is invalid
+  for paragraphs (which expect content). Use `<p></p>` or include
+  content. `<hr/>`, `<br/>`, and the empty `<ri:user ... />` are
+  fine self-closed.
+- **Missing `version.number` on update** — a `PUT` without the
+  incremented version number returns 409. Always read the current
+  page, increment by 1, include in the update payload.
+- **Submitting markdown** — `**bold**` displays as literal
+  asterisks. `- item` displays as literal hyphen. Always use
+  XHTML.
+- **Namespace prefixes not declared** — `<ac:*>` and `<ri:*>` are
+  known to Confluence's parser and don't require xmlns
+  declarations inside the storage value. Don't add them — some
+  library helpers add them redundantly and Confluence rejects the
+  page.
+- **Pasting rendered HTML from the web UI** — the rendered view
+  (`body.view`) contains output-only classes (`<span class="…">`)
+  and is NOT round-trippable. Always author in storage format, not
+  rendered HTML.
+
+## References
+
+- https://developer.atlassian.com/cloud/confluence/rest/v1/intro/
+- https://developer.atlassian.com/cloud/confluence/advanced-searching-using-cql/
+- https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html
+- https://github.com/sooperset/mcp-atlassian/tree/main/docs/guides

--- a/skills/atlassian-content/references/jira-adf.md
+++ b/skills/atlassian-content/references/jira-adf.md
@@ -1,0 +1,370 @@
+# Jira ADF (Atlassian Document Format) — API v3
+
+**JIRA SYNTAX REFERENCE:**
+
+- Use **ADF** (Atlassian Document Format) — a structured JSON document.
+- Use **API v3** — `/rest/api/3/*`. API v2 accepts wiki markup, not
+  ADF, and is legacy for Cloud.
+- Recommended: create professional, well-formatted Jira issues /
+  comments with user mentions, code blocks, panels, tables, and
+  links by assembling ADF documents and POSTing them.
+
+## Document skeleton
+
+Every ADF document has this outer shape:
+
+```json
+{
+  "type": "doc",
+  "version": 1,
+  "content": [ /* block nodes */ ]
+}
+```
+
+`content` is an array of **block nodes** (paragraphs, headings,
+lists, tables, panels, code blocks, rules). Block nodes usually
+contain **inline nodes** (text, mention, link, emoji, inlineCard,
+hardBreak).
+
+### Where the doc goes
+
+| Operation | Field |
+|---|---|
+| Create issue description | `fields.description` (the ADF document object itself) |
+| Update issue description | same, in `fields` of `PUT /rest/api/3/issue/{key}` |
+| Post a comment | `body` (the ADF document object itself) |
+| Custom rich-text field | `fields.customfield_XXXXX` (same structure) |
+
+Example issue-create payload:
+
+> **`issuetype`: prefer `id` for programmatic filing.** Project
+> admins rename issue types (`Defect`, `Production Incident`, …)
+> and multiple types can share a display name across projects.
+> Look up the valid set for a project with
+> `GET /rest/api/3/issue/createmeta?projectKeys=PROJ&expand=projects.issuetypes`
+> and submit `"issuetype": { "id": "10004" }`. Use `{ "name": "Bug" }`
+> only when you're filing into a known project you control.
+
+```json
+{
+  "fields": {
+    "project": { "key": "PROJ" },
+    "summary": "Login returns 500 on plus-sign emails",
+    "issuetype": { "name": "Bug" },
+    "description": {
+      "type": "doc",
+      "version": 1,
+      "content": [
+        { "type": "paragraph",
+          "content": [{ "type": "text",
+                        "text": "Reproduced on staging 2026-04-20." }] }
+      ]
+    }
+  }
+}
+```
+
+Example comment payload:
+
+```json
+POST /rest/api/3/issue/PROJ-123/comment
+{
+  "body": {
+    "type": "doc",
+    "version": 1,
+    "content": [
+      { "type": "paragraph",
+        "content": [{ "type": "text", "text": "Verified the fix." }] }
+    ]
+  }
+}
+```
+
+## Block nodes — the ones you'll actually use
+
+### paragraph
+
+```json
+{ "type": "paragraph",
+  "content": [ /* inline nodes */ ] }
+```
+
+An empty paragraph (`"content": []` or omitted) is a blank line.
+
+### heading
+
+```json
+{ "type": "heading",
+  "attrs": { "level": 2 },
+  "content": [{ "type": "text", "text": "Section title" }] }
+```
+
+`level`: 1–6. Prefer 2–3 for section headers inside a ticket;
+level 1 is rarely needed (the summary is already the title).
+
+### bulletList / orderedList + listItem
+
+```json
+{ "type": "bulletList",
+  "content": [
+    { "type": "listItem",
+      "content": [
+        { "type": "paragraph",
+          "content": [{ "type": "text", "text": "First item" }] }
+      ] },
+    { "type": "listItem",
+      "content": [
+        { "type": "paragraph",
+          "content": [{ "type": "text", "text": "Second item" }] }
+      ] }
+  ] }
+```
+
+`orderedList` is identical but accepts `"attrs": { "order": 1 }` to
+start numbering at a non-1 value.
+
+**Gotcha:** list items wrap their content in paragraph nodes. Text
+directly inside a `listItem` without a paragraph wrapper is invalid.
+
+### codeBlock
+
+```json
+{ "type": "codeBlock",
+  "attrs": { "language": "python" },
+  "content": [{ "type": "text",
+                "text": "def handler(event):\n    return {'ok': True}\n" }] }
+```
+
+Common languages: `python`, `javascript`, `typescript`, `java`,
+`go`, `rust`, `bash`, `sh`, `json`, `yaml`, `sql`, `html`, `css`,
+`text` (plain / unhighlighted).
+
+Newlines inside `text` are literal `\n` characters. Do NOT put
+paragraph nodes inside a code block.
+
+### panel
+
+```json
+{ "type": "panel",
+  "attrs": { "panelType": "info" },
+  "content": [
+    { "type": "paragraph",
+      "content": [{ "type": "text",
+                    "text": "Context: this is a staging regression." }] }
+  ] }
+```
+
+`panelType`: `info` (blue), `note` (purple), `tip` (green),
+`warning` (yellow), `error` (red). Use sparingly — one or two per
+ticket; overusing panels makes the ticket look noisy.
+
+### table
+
+```json
+{ "type": "table",
+  "attrs": { "isNumberColumnEnabled": false, "layout": "default" },
+  "content": [
+    { "type": "tableRow",
+      "content": [
+        { "type": "tableHeader",
+          "content": [{ "type": "paragraph",
+                        "content": [{ "type": "text", "text": "Env" }] }] },
+        { "type": "tableHeader",
+          "content": [{ "type": "paragraph",
+                        "content": [{ "type": "text", "text": "Result" }] }] }
+      ] },
+    { "type": "tableRow",
+      "content": [
+        { "type": "tableCell",
+          "content": [{ "type": "paragraph",
+                        "content": [{ "type": "text", "text": "staging" }] }] },
+        { "type": "tableCell",
+          "content": [{ "type": "paragraph",
+                        "content": [{ "type": "text", "text": "fails" }] }] }
+      ] }
+  ] }
+```
+
+Every cell (header or body) wraps its content in a paragraph. A
+cell with only plain text directly inside is invalid.
+
+### blockquote
+
+```json
+{ "type": "blockquote",
+  "content": [
+    { "type": "paragraph",
+      "content": [{ "type": "text", "text": "Quoted line." }] }
+  ] }
+```
+
+### rule
+
+```json
+{ "type": "rule" }
+```
+
+Horizontal divider. No content, no attrs.
+
+## Inline nodes
+
+### text + marks
+
+```json
+{ "type": "text", "text": "Hello world" }
+```
+
+Apply **marks** via the `marks` array:
+
+```json
+{ "type": "text", "text": "bold", "marks": [{ "type": "strong" }] }
+{ "type": "text", "text": "italic", "marks": [{ "type": "em" }] }
+{ "type": "text", "text": "code", "marks": [{ "type": "code" }] }
+{ "type": "text", "text": "strike", "marks": [{ "type": "strike" }] }
+{ "type": "text", "text": "underline", "marks": [{ "type": "underline" }] }
+```
+
+Combine by listing multiple marks:
+
+```json
+{ "type": "text", "text": "bold italic",
+  "marks": [{ "type": "strong" }, { "type": "em" }] }
+```
+
+### link (as a text mark)
+
+```json
+{ "type": "text", "text": "our docs",
+  "marks": [{ "type": "link",
+              "attrs": { "href": "https://example.com/docs" } }] }
+```
+
+Bare URLs without a link mark render as plain text — always wrap.
+
+### mention
+
+```json
+{ "type": "mention",
+  "attrs": { "id": "61e1a042e67ea2006b5b2157",
+             "text": "@Alexander Bychinskiy" } }
+```
+
+`id` is the Atlassian **accountId**. `text` is the display fallback
+shown if the mention fails to render — match the user's display
+name with a leading `@`. See `mentions.md` for accountId lookup.
+
+### inlineCard (linked issue / URL preview)
+
+```json
+{ "type": "inlineCard",
+  "attrs": { "url": "https://your-site.atlassian.net/browse/PROJ-123" } }
+```
+
+Use for linking another Jira issue — renders as a live card with
+summary, status, and assignee.
+
+### hardBreak
+
+```json
+{ "type": "hardBreak" }
+```
+
+A forced line break inside a paragraph. Prefer paragraph splits
+for prose; use `hardBreak` only when you need a visual break
+without a paragraph gap.
+
+## Worked example — a well-formatted bug report
+
+```json
+{
+  "fields": {
+    "project": { "key": "PROJ" },
+    "summary": "Login returns 500 when email contains '+' character",
+    "issuetype": { "name": "Bug" },
+    "priority": { "name": "High" },
+    "description": {
+      "type": "doc",
+      "version": 1,
+      "content": [
+        { "type": "heading",
+          "attrs": { "level": 2 },
+          "content": [{ "type": "text", "text": "Summary" }] },
+        { "type": "paragraph",
+          "content": [
+            { "type": "text", "text": "The " },
+            { "type": "text", "text": "/api/login",
+              "marks": [{ "type": "code" }] },
+            { "type": "text", "text": " endpoint returns 500 when the email address contains a " },
+            { "type": "text", "text": "+",
+              "marks": [{ "type": "code" }] },
+            { "type": "text", "text": " character. Reproduced on staging 2026-04-20." }
+          ] },
+
+        { "type": "heading",
+          "attrs": { "level": 2 },
+          "content": [{ "type": "text", "text": "Steps to reproduce" }] },
+        { "type": "orderedList",
+          "content": [
+            { "type": "listItem",
+              "content": [{ "type": "paragraph",
+                            "content": [{ "type": "text",
+                                          "text": "POST /api/login with email user+tag@example.com" }] }] },
+            { "type": "listItem",
+              "content": [{ "type": "paragraph",
+                            "content": [{ "type": "text",
+                                          "text": "Observe 500 response" }] }] }
+          ] },
+
+        { "type": "heading",
+          "attrs": { "level": 2 },
+          "content": [{ "type": "text", "text": "Expected" }] },
+        { "type": "paragraph",
+          "content": [{ "type": "text",
+                        "text": "200 OK with session cookie, per RFC 5322 which permits '+' in local-part." }] },
+
+        { "type": "heading",
+          "attrs": { "level": 2 },
+          "content": [{ "type": "text", "text": "Stack trace" }] },
+        { "type": "codeBlock",
+          "attrs": { "language": "text" },
+          "content": [{ "type": "text",
+                        "text": "TypeError: can't escape '+' in email.split('@')[0]\n  at normalize_email (auth/normalize.py:42)\n  at login (auth/views.py:117)\n" }] },
+
+        { "type": "panel",
+          "attrs": { "panelType": "info" },
+          "content": [
+            { "type": "paragraph",
+              "content": [
+                { "type": "text", "text": "Raising this to " },
+                { "type": "mention",
+                  "attrs": { "id": "61e1a042e67ea2006b5b2157",
+                             "text": "@Alexander Bychinskiy" } },
+                { "type": "text", "text": " — can you triage by EOD?" }
+              ] }
+          ] }
+      ]
+    }
+  }
+}
+```
+
+## Common pitfalls
+
+- **Missing paragraph wrapper inside listItem / tableCell** — the
+  node is rejected with a vague "unknown child" error. Always
+  wrap list-item and cell text in a `paragraph` node.
+- **Newlines as `\n` in a text node** — that's literal `\n` in the
+  rendered output. For a line break: end the paragraph (close the
+  paragraph node) and start a new one, or insert a `hardBreak`
+  node.
+- **Using `code` as a block** — `code` is a mark (inline code).
+  `codeBlock` is the block node. They're not interchangeable.
+- **Nested paragraphs** — paragraphs can't contain paragraphs.
+  Most block nodes (panel, blockquote, tableCell) accept
+  paragraphs as children; a paragraph's children are inline nodes.
+- **`version` on the inner doc vs outer** — the outer `doc` needs
+  `version: 1`. Nested docs (e.g., inside a tableCell) should not
+  repeat `version`.
+- **Mixing ADF with wiki markup** — `*bold*` or `{code}...{code}`
+  inside a text node is literal text, not formatting. Use marks
+  and block nodes.

--- a/skills/atlassian-content/references/mentions.md
+++ b/skills/atlassian-content/references/mentions.md
@@ -1,0 +1,154 @@
+# Mentions — the correct way, on both surfaces
+
+Atlassian Cloud mentions are backed by an **accountId** — an
+opaque string per user within a tenant (e.g.
+`61e1a042e67ea2006b5b2157`). `@username` / `@email` strings are
+**not mentions** when posted through the API — they render as
+literal text, no notification, no profile card, no link.
+
+The same `accountId` works across Jira and Confluence in the same
+tenant.
+
+## 1. Look up the accountId
+
+### From an email
+
+```
+GET /rest/api/3/user/search?query=alexander@example.com
+→ [ { "accountId": "61e1a042e67ea2006b5b2157",
+      "displayName": "Alexander Bychinskiy",
+      "emailAddress": "alexander@example.com", ... } ]
+```
+
+### From a display name (fuzzier — may return multiples)
+
+```
+GET /rest/api/3/user/search?query=Alexander Bychinskiy
+```
+
+Verify: the `displayName` you get back matches what you searched
+for. If multiple users match, don't guess — ask the operator or
+fall back to plain text.
+
+### From the current authenticated user (myself)
+
+```
+GET /rest/api/3/myself
+→ { "accountId": "...", "displayName": "...", ... }
+```
+
+### Caching
+
+Cache accountIds per session, keyed by email or normalized
+display-name. Resolving the same user twice in one run is wasted
+calls; resolving them five times is a bug.
+
+Caching across sessions belongs in `.agents/memory/` or the
+project's profile, not in this skill.
+
+## 2. Use it in a Jira mention (ADF)
+
+Inside any inline-node context (paragraph, table cell, list item):
+
+```json
+{ "type": "mention",
+  "attrs": { "id": "61e1a042e67ea2006b5b2157",
+             "text": "@Alexander Bychinskiy" } }
+```
+
+- `id` → the accountId.
+- `text` → the **display fallback**, shown only when the mention
+  fails to render. Match the user's display name verbatim with a
+  leading `@` (e.g. `"@Alexander Bychinskiy"`); modern Atlassian
+  UIs render spaces fine.
+
+Full paragraph example:
+
+```json
+{ "type": "paragraph",
+  "content": [
+    { "type": "text", "text": "Hi " },
+    { "type": "mention",
+      "attrs": { "id": "61e1a042e67ea2006b5b2157",
+                 "text": "@Alexander Bychinskiy" } },
+    { "type": "text", "text": ", can you review this?" }
+  ] }
+```
+
+## 3. Use it in a Confluence mention (storage format)
+
+Inside any body content (paragraph, table cell, list item):
+
+```html
+<ac:link>
+  <ri:user ri:account-id="61e1a042e67ea2006b5b2157" />
+</ac:link>
+```
+
+Full paragraph example:
+
+```html
+<p>
+  Hi
+  <ac:link>
+    <ri:user ri:account-id="61e1a042e67ea2006b5b2157" />
+  </ac:link>,
+  please review.
+</p>
+```
+
+Confluence's renderer substitutes the user's current display name
+inside the anchor — you don't provide a fallback text node.
+
+## 4. Mentioning multiple users
+
+Fine — concatenate inline nodes separated by text:
+
+```json
+{ "type": "paragraph",
+  "content": [
+    { "type": "text", "text": "FYI " },
+    { "type": "mention",
+      "attrs": { "id": "ACCOUNTID-A", "text": "@Anna" } },
+    { "type": "text", "text": " and " },
+    { "type": "mention",
+      "attrs": { "id": "ACCOUNTID-B", "text": "@Bob" } },
+    { "type": "text", "text": ": please review." }
+  ] }
+```
+
+Confluence:
+
+```html
+<p>
+  FYI
+  <ac:link><ri:user ri:account-id="ACCOUNTID-A" /></ac:link>
+  and
+  <ac:link><ri:user ri:account-id="ACCOUNTID-B" /></ac:link>:
+  please review.
+</p>
+```
+
+## 5. Failure modes
+
+- **User search returns empty** → the user doesn't exist in this
+  tenant (may have left the company, may be a different tenant, or
+  the search term is too broad/narrow). Do not invent a mention;
+  fall back to plain text (`"Hi Alexander, "`).
+- **Multiple matches** → if you can't narrow down via email, ask
+  the operator which accountId to use.
+- **Deactivated user** → mention still posts, but shows as greyed
+  out. Decide whether that's useful (historical record) or
+  misleading (expecting a response) — often better to use plain
+  text with the name.
+- **Group mentions** → Jira supports `groupId`-based mention-like
+  behavior via **team mentions** (not covered here). Confluence
+  does not have built-in group mention in storage format. For
+  "the platform team", mention the team lead individually or add
+  a `@label` convention agreed with the team.
+
+## 6. Privacy note
+
+`accountId` is safe to log / persist internally — it's not PII by
+itself. Email addresses ARE PII — if you cache an email → accountId
+lookup, respect the project's data-handling policy.

--- a/skills/atlassian-content/references/verification.md
+++ b/skills/atlassian-content/references/verification.md
@@ -1,0 +1,306 @@
+# Post-creation verification — re-fetch, validate, repair
+
+The POST returned 201. That proves the server accepted your JSON.
+It does NOT prove the content renders correctly. This page is the
+checklist for turning "accepted" into "good".
+
+Run this every time. No exceptions. Ugly tickets are evidence of
+skipped verification.
+
+> **If `.agents/profile.md` isn't populated yet** (project not
+> seeded, or seeded without the `Project systems` block), ask the
+> operator for the Jira base URL, auth env var, and — for
+> Confluence — the space key before running the curl-fallback
+> verification steps below. MCP transport sidesteps this since the
+> server carries its own config.
+
+## Before you update: raw-fetch first
+
+Verification covers the **after**. This section covers the
+**before**: when you're editing (not creating) a Jira issue,
+comment, or Confluence page, always fetch the current body in its
+**raw structured view** before writing the update.
+
+"Raw" means the body as the API stores it — the ADF JSON for Jira,
+the storage-format XHTML string for Confluence. NOT the rendered
+HTML (`renderedFields.description` / `body.view.value`) which is
+output-only and loses macros, custom nodes, and structural hints.
+
+### Why
+
+- The existing body has structure (sections, macros, panels,
+  custom fields) authored by a human or a prior agent pass. An
+  update built from scratch usually erases that structure.
+- Confluence pages embed macros (`<ac:structured-macro>`) that
+  only appear verbatim in the storage view. Regenerating a page
+  from the rendered HTML drops them silently.
+- Jira ADF documents may contain nodes newer than this skill
+  knows about. Reading them raw lets you preserve what you don't
+  recognize, instead of discarding it.
+- For Confluence specifically, you also need the current
+  `version.number` for the update payload — which only comes on
+  a raw fetch.
+
+### Fetch endpoints (raw)
+
+The same rule applies on **every transport** — raw REST, MCP
+tools, or any Atlassian-connected integration wired into the
+project. Pick the variant that returns the raw ADF / storage
+string, not a pre-rendered / human-readable summary.
+
+```
+# --- Raw REST API ---
+
+# Jira issue description (and other rich-text fields)
+GET /rest/api/3/issue/{key}?fields=description,comment
+→ fields.description is the ADF document you'll edit
+
+# Jira comment
+GET /rest/api/3/issue/{key}/comment/{id}
+→ body is the ADF document
+
+# Confluence page
+GET /wiki/rest/api/content/{id}?expand=body.storage,version
+→ body.storage.value is the XHTML you'll edit;
+  version.number is the number you must increment in the PUT
+```
+
+```
+# --- MCP / Atlassian connectors ---
+
+# Most MCP servers expose both a "rich" read and a "raw" read.
+# Pick the raw variant. Examples (exact names vary by server):
+
+#   mcp-atlassian:
+#     jira_get_issue         → includes fields.description (ADF)
+#     confluence_get_page    → pass include_raw=true / body_format=storage
+#                              to get body.storage.value rather than body.view
+
+#   Elitea_Dev / JiraIntegration:
+#     JiraIntegration.get_issue_details   → returns ADF under description
+#     JiraIntegration.get_comments        → returns ADF bodies
+#     ConfluenceIntegration.get_page_raw  → storage-format XHTML
+
+# If a tool only returns rendered HTML / markdown-ified text,
+# that's the wrong tool for a pre-update fetch. Find the raw
+# equivalent, add one, or fall back to REST with the project's
+# configured auth_env.
+```
+
+Do NOT pass `expand=renderedFields` / `body.view` for this step —
+those are for the post-update verification pass, not for reading
+the source of truth before an edit.
+
+### Merge strategy
+
+- **Append** (add a new section, new comment paragraph, new table
+  row) → parse the raw body, add your block nodes at the end (or
+  at the right anchor), serialize back, PUT.
+- **Replace a section** → find the heading node that anchors the
+  section, replace the following block nodes up to the next
+  heading of equal/greater level, keep the rest.
+- **Fix a typo** → find the specific text node, edit the `text`
+  value, leave everything else untouched.
+- **Full rewrite** (rare, and only when the operator asks) → even
+  then, screenshot / archive the raw body first so the old
+  structure isn't lost.
+
+If the raw body contains nodes / elements you don't recognize
+(new ADF node types, custom macros), **preserve them byte-for-byte
+in your output**. Dropping an unknown node silently is the
+same class of bug as dropping a known one.
+
+### When skipping is OK
+
+Only when you're writing a **net-new** resource — first-time
+issue-create, first comment, brand-new page. There's no existing
+body to preserve. This is the only exception.
+
+## Why re-fetch
+
+Three classes of issue only surface on read-back:
+
+1. **Structural errors the server tolerated** — e.g. unsupported
+   ADF node silently dropped; storage-format element parsed to
+   empty. Server returns 201; content is partially missing.
+2. **Semantic errors that serialize fine** — mention `id` that
+   doesn't exist in the tenant renders as a grey "unknown user"
+   badge; link `href` with a typo becomes a dead link.
+3. **Renderer quirks** — paragraph without content renders as a
+   weird vertical gap; table without a `<tbody>` renders with
+   broken borders in some themes.
+
+The only reliable check is: fetch the resource, look at both the
+source you submitted and the rendered output, compare.
+
+## Re-fetch endpoints
+
+### Jira issue
+
+```
+GET /rest/api/3/issue/{key}?expand=renderedFields
+```
+
+- `fields.description` → the ADF you posted.
+- `renderedFields.description` → the HTML Jira renders.
+
+Sanity check: rendered HTML is non-empty and contains the expected
+shape (headings, lists, code blocks, mentions as `<a class="user-hover">`).
+
+### Jira comment
+
+```
+GET /rest/api/3/issue/{key}/comment/{id}?expand=renderedBody
+```
+
+- `body` → the ADF you posted.
+- `renderedBody` → the HTML Jira renders.
+
+### Confluence page
+
+```
+GET /wiki/rest/api/content/{id}?expand=body.storage,body.view,version
+```
+
+- `body.storage.value` → the storage format you submitted.
+- `body.view.value` → the rendered HTML users see.
+- `version.number` → needed if you're about to submit a PUT repair.
+
+## Validation checklist
+
+For each created resource, confirm ALL of these:
+
+### Mentions
+- [ ] Every `@mention` you intended appears as a mention node /
+      linked user in the rendered HTML.
+- [ ] No literal `@username` strings anywhere you meant to mention.
+- [ ] `accountId` resolved to a real display name (not "Unknown
+      user" / greyed-out badge).
+
+### Headings
+- [ ] Headings render as headings (`<h1>`–`<h6>` in rendered HTML),
+      not as bold paragraphs or literal `# heading` text.
+- [ ] Heading hierarchy makes sense — no skipping from h1 to h4.
+
+### Lists
+- [ ] Bullet lists render as `<ul><li>`, ordered as `<ol><li>`.
+- [ ] No literal `- item` / `1. item` hyphen-prefixed text.
+- [ ] Nested list items actually nest.
+
+### Code blocks
+- [ ] Code blocks render monospaced with (optionally) syntax
+      highlighting. No lines of literal backticks.
+- [ ] Newlines preserved.
+- [ ] No stray HTML entities inside code (`&amp;` where you meant
+      `&`).
+
+### Tables
+- [ ] Table renders with borders and cells. No pipe-separated
+      `col1 | col2 | col3` text.
+- [ ] Every cell populated (no "missing content" empty renders
+      from a skipped paragraph wrapper).
+
+### Links
+- [ ] Links are clickable. No bare URLs in prose.
+- [ ] External URLs point where they should (not typo'd).
+- [ ] Internal Confluence page links resolve to the intended page
+      (check the hover card / href).
+
+### Panels / macros
+- [ ] Info / note / warning panels render with the right colour.
+- [ ] Code macro language matches the code (no `python` on JSON).
+
+### Typography
+- [ ] No literal `**bold**` / `*italic*` / `_italic_` markdown
+      artefacts.
+- [ ] No half-rendered HTML tags (e.g. `<br>` visible in body).
+
+### Hygiene
+- [ ] No API tokens / secrets leaked into body text.
+- [ ] No placeholder text left in (`TODO:`, `XXX`, `FIXME` unless
+      intentional).
+- [ ] Ticket summary / page title isn't empty or placeholder.
+
+## Repair recipes
+
+When the checklist fails, fix it — do not file a "fix formatting
+later" ticket. The repair is cheap.
+
+### Jira issue description
+
+```
+PUT /rest/api/3/issue/{key}
+{
+  "fields": {
+    "description": { /* corrected ADF doc */ }
+  }
+}
+```
+
+### Jira comment
+
+Jira comments update via:
+
+```
+PUT /rest/api/3/issue/{key}/comment/{id}
+{
+  "body": { /* corrected ADF doc */ }
+}
+```
+
+If the comment is wrong in a minor way (typo), editing is fine.
+If the original is deeply broken and misleading, consider deleting
+(`DELETE /.../comment/{id}`) and re-posting, with a short note on
+the thread about the repost.
+
+### Confluence page
+
+Page updates require the next version number:
+
+```
+PUT /wiki/rest/api/content/{id}
+{
+  "type": "page",
+  "title": "<same or updated>",
+  "version": { "number": <current_version_number + 1> },
+  "body": {
+    "storage": {
+      "value": "<corrected storage xhtml>",
+      "representation": "storage"
+    }
+  }
+}
+```
+
+Read the current `version.number` first, increment by one. A
+mismatched version number returns 409 Conflict.
+
+## Visual spot-check — when API-only isn't enough
+
+The rendered HTML from `?expand=renderedFields` / `body.view` is
+usually enough. But for pages that rely on spatial layout
+(complex tables, side-by-side panels, embedded diagrams), a
+visual check catches what HTML comparison misses.
+
+When to open the browser:
+
+- Content with >1 nested macro or custom layout.
+- First time filing in a new project / space (template quirks).
+- Operator explicitly asked for a "pretty" ticket / page.
+- Previous repair attempt was still off.
+
+Skip the visual check for routine comments and simple issue
+descriptions — the API validation is sufficient there.
+
+## Logging what you did
+
+For audit / handoff, record (in the agent's reply or memory):
+
+- The created resource URL (`https://site.atlassian.net/browse/{key}`,
+  or `https://site.atlassian.net/wiki/spaces/{space}/pages/{id}`)
+- Whether verification passed on first post or required repair
+- Any accountId lookups that failed (useful for updating the
+  project's team roster)
+
+Do not log the full body — that's noise and potentially PII-laden.
+The URL is the audit trail.


### PR DESCRIPTION
Focused authoring skill for Atlassian's two content surfaces: Jira issues/comments via ADF, Confluence pages via storage format. Enforces: no markdown (Jira expects ADF, Confluence expects storage format); accountId-backed mentions (not @username); mandatory post-creation re-fetch; raw-fetch before update. Transport-agnostic (MCP → curl → browser). Self-contained — no agent changes in this PR.

**Files:** `skills/atlassian-content/SKILL.md` (255L) + 4 references (jira-adf, confluence-storage, mentions, verification). `skills.json`, `AGENTS.md`, `GEMINI.md`, `README.md` catalog entries.

**Dependencies:** none. Works on every supported host. Benefits from #2 (installer skills-inventory injection) when present but functions without it.