### PR TITLE
Add xray-testing skill — Cloud GraphQL + Server REST + stdlib Python CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,8 @@ of native plugin formats and a shared npx installer.
   spec-compliant workflow skills: `plan-feature`, `implement-feature`,
   `bugfix-workflow`, `code-review`, `tdd`, `task-completion`,
   `git-workflow`, `memory`, `playwright-testing`, `browser-verify`,
-  `issue-tracking`, `goal-verifier`, `context-gatherer`, `deep-research`,
-  `obsidian-vault`, `msgraph`, `project-seeder`.
+  `issue-tracking`, `xray-testing`, `goal-verifier`, `context-gatherer`,
+  `deep-research`, `obsidian-vault`, `msgraph`, `project-seeder`.
 - **`skills.json`** — catalog of all skills, monorepo and external.
   The installer uses it to resolve + fetch external skills (from
   `mattpocock/skills`, `obra/superpowers`, `twostraws/*-Agent-Skill`).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -30,6 +30,7 @@ are capability definitions, not always-on context.
 | `plan-feature` | A spec/requirement exists and implementation hasn't started |
 | `implement-feature` | A plan exists and you're about to write code |
 | `bugfix-workflow` | Reproducing and fixing a reported bug |
+| `xray-testing` | CRUD + results import on Xray entities (Test / Precondition / Set / Plan / Execution / Run) across Cloud (GraphQL) and Server/DC (REST) |
 | `code-review` | Reviewing a PR or diff |
 | `task-completion` | Finishing routed work — commit, push, PR, comment, notify |
 | `git-workflow` | Branching, commits, PRs, rebasing |

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ frameworks, other IDEs) can point directly at `skills/<name>/`.
 | `playwright-testing` | E2E browser testing with Playwright |
 | `browser-verify` | Quick visual / smoke verification in a browser |
 | `issue-tracking` | GitHub / Linear / GitLab issue management |
+| `xray-testing` | Xray CRUD + results import — Tests, Preconditions, Test Sets/Plans, Executions, Runs. Xray Cloud (GraphQL) + Server/DC (REST). Stdlib Python CLI fallback |
 | `goal-verifier` | Verify a task actually achieved its stated goal |
 | `context-gatherer` | Targeted codebase exploration before changes |
 | `deep-research` | Multi-source research and synthesis |

--- a/skills.json
+++ b/skills.json
@@ -14,6 +14,7 @@
     {"id": "issue-tracking",     "monorepo": "sdlc-skills", "name": "issue-tracking",     "description": "GitHub issue lifecycle — labelling, commenting, closing"},
     {"id": "playwright-testing", "monorepo": "sdlc-skills", "name": "playwright-testing", "description": "End-to-end browser testing with Playwright"},
     {"id": "bugfix-workflow",    "monorepo": "sdlc-skills", "name": "bugfix-workflow",    "description": "End-to-end bugfix workflow — reproduce, test, fix, verify, document"},
+    {"id": "xray-testing",             "monorepo": "sdlc-skills", "name": "xray-testing",             "description": "CRUD + results import on Xray entities (Test / Precondition / Test Set / Test Plan / Test Execution / Test Run) across Xray Cloud (GraphQL) and Server/DC (REST). JUnit / Cucumber / Xray JSON import formats"},
     {"id": "implement-feature",  "monorepo": "sdlc-skills", "name": "implement-feature",  "description": "End-to-end feature implementation workflow — plan, test, build, ship"},
     {"id": "plan-feature",       "monorepo": "sdlc-skills", "name": "plan-feature",       "description": "Structured feature planning — requirements, feasibility, acceptance criteria"},
     {"id": "project-seeder",     "monorepo": "sdlc-skills", "name": "project-seeder",     "description": "Generate AGENTS.md, .agents/ content docs, and per-role memory briefings for a new project (used by scout)"},

--- a/skills/xray-testing/SKILL.md
+++ b/skills/xray-testing/SKILL.md
@@ -1,0 +1,423 @@
+---
+name: xray-testing
+description: CRUD + results import on Xray entities (Test / Precondition / Test Set / Test Plan / Test Execution / Test Run) across Cloud (GraphQL) and Server/DC (REST). Load for "pull test PROJ-T42", "create Xray test from this AFS", "link test to story", "upload JUnit to test plan", or any Xray CRUD. Complements test-case-analysis and atlassian-content.
+license: Apache-2.0
+metadata:
+  author: octobots
+  version: "0.1.0"
+---
+
+# Xray — the TMS that lives inside Jira
+
+Xray stores test cases and execution records as Jira issues of
+specific issue types (`Test`, `Precondition`, `Test Set`,
+`Test Plan`, `Test Execution`). That design is why this skill is
+separate from `atlassian-content`: the **Jira issue layer** (ADF,
+comments, mentions) is covered there; **everything Xray-specific**
+(test steps, preconditions, test run statuses, results import,
+coverage links) lives here and talks to Xray's own API.
+
+This skill is **transport-agnostic** (GraphQL / REST / MCP /
+connector) and **deployment-agnostic** (Cloud or Server / DC).
+
+## When to load this skill
+
+Load when the task involves reading, authoring, linking, or
+recording results against Xray entities:
+
+- Fetching a Test's steps (structured, not the Jira description)
+- Creating a Test / Precondition / Test Set / Test Plan
+- Adding or editing steps on a Test
+- Adding Tests to a Test Set / Test Plan
+- Creating a Test Execution and reporting Test Run results
+- Importing results from JUnit / Cucumber / NUnit / TestNG /
+  generic Xray JSON
+- Linking a Test to a story / requirement / bug for coverage
+- Querying coverage ("which tests cover PROJ-42?" /
+  "which requirements have no tests?")
+
+Do NOT load for: pure Jira field reads / comment authoring on
+Xray issue keys — those don't need Xray-specific endpoints.
+Use `atlassian-content` for that.
+
+## Transport priority — check in this order on every call
+
+**MCP is first. The CLI is a fallback. Raw REST / GraphQL is a
+last resort.** Never default to `scripts/xray.py` when an MCP
+tool already covers the operation — secrets stay out of agent
+context when you go through MCP, and an MCP-wired project has
+already invested in permissions / audit / reliability the CLI
+can't match.
+
+1. **MCP tools** — `mcp__<server>__<toolset>_*`
+   (e.g. `mcp__Elitea_Dev__JiraIntegration_get_issue_details`,
+   `mcp__dmtools-cli__xray_get_test`, `mcp__mcp-xray__*`). Discover
+   with the host's MCP-listing command (`copilot --list-mcp`,
+   `claude mcp list`, Cursor / Windsurf settings panel) and match
+   the tool to the operation. Use the MCP if a matching tool
+   exists, even if the skill's examples show CLI commands.
+2. **Bundled CLI** — `scripts/xray.py` (stdlib Python, zero deps).
+   Only when no MCP tool covers the operation, or when the MCP
+   server is offline. The CLI auto-detects Cloud vs Server,
+   caches JWTs, and bakes in the re-fetch + validate discipline
+   (exit 3 on mismatch). See `scripts/README.md` for the surface.
+3. **Raw REST / GraphQL** — assemble your own HTTP call. Reserve
+   for debugging or when both MCP and the CLI are unavailable.
+
+If you start an operation on MCP and hit a gap (missing tool,
+auth error, stale cache), log the gap clearly in your reply,
+drop down to the CLI, and surface the gap in your summary so the
+operator can fix the MCP config.
+
+Agents are allowed (and encouraged) to fix / extend `scripts/xray.py`
+when they hit a bug or missing capability. Rules of the road —
+preserve exit codes and env-var names, stdlib-only, re-fetch-and-verify
+on every new write, syntax-check before commit — live in
+[`scripts/README.md` § Extending this script](scripts/README.md).
+
+## Absolute boundaries
+
+- **Don't fake a Test by POSTing a plain Jira issue with
+  `issuetype=Test`.** Xray requires its own REST / GraphQL calls
+  to populate `Test Type`, step list, preconditions, and scenario
+  body. Creating the Jira issue alone leaves an empty Xray Test.
+- **Don't put test steps into the issue description.** Xray's
+  steps live in a separate structured store. The Jira
+  `description` field is a free-text sibling, not the spec.
+- **Don't invent a test `Status` value.** Xray statuses are
+  project-configurable (defaults: `PASSED`, `FAILED`,
+  `EXECUTING`, `TODO`, `ABORTED`, `BLOCKED`). If you don't know
+  which statuses this project uses, query them first; do not
+  guess.
+- **Don't upload result files you haven't verified.** JUnit and
+  Cucumber XML/JSON shapes vary between runners — a mis-shaped
+  report uploads silently as zero results. Always confirm the
+  created Test Execution has the expected Test Run count after
+  import.
+- **Don't rewrite step IDs.** Steps have opaque IDs. When
+  updating, fetch, modify in place, and submit — don't
+  regenerate the step list from scratch (you'll orphan execution
+  history).
+- **Don't leave a new Test orphaned from its story.** When you
+  create a Test that covers a user story / requirement / bug,
+  you MUST link it via Xray's **coverage link** —
+  `addTestsToRequirement` (Cloud GraphQL) /
+  `POST /api/test/<key>/requirement` (Server REST) — or
+  `xray test link-requirement <TEST> <STORY>` from the CLI. The
+  plain Jira `issuelinks` field (`Tests` / `Is tested by`) does
+  NOT register coverage in Xray's reports on modern Cloud
+  installs. If you skip this step, coverage rollups show the
+  story as "uncovered" even though the Test exists — a silent
+  bug in triage. See § "Link Tests to stories" below for the
+  full rule.
+
+## Deployment — Cloud vs Server / DC
+
+| Trait | **Xray Cloud** | **Xray Server / DC** |
+|---|---|---|
+| Primary API | GraphQL (`/api/v2/graphql`) | REST (`<jira>/rest/raven/2.0`, `/1.0`) |
+| Auth | JWT from `/api/v2/authenticate` (client_id + client_secret) | Basic auth or PAT against Jira |
+| Typical base URL | `https://xray.cloud.getxray.app/api/v2` | `https://<your-jira>/rest/raven/2.0` |
+| Entity keys | Jira keys (`PROJ-T42`) | Jira keys (`PROJ-T42`) |
+| Project scope | Xray app per Atlassian tenant | Xray app per Jira instance |
+
+The **entity model is identical** across both. Only the transport
+differs. Detect which one you're on from the project's
+`.agents/profile.md` § Project systems and the adapter declared
+in `.agents/test-automation.yaml`:
+
+```yaml
+# .agents/test-automation.yaml
+tms:
+  adapter: xray
+  deployment: cloud        # or: server
+  base_url: https://xray.cloud.getxray.app/api/v2
+  auth_env: XRAY_CLIENT_ID, XRAY_CLIENT_SECRET   # cloud
+  # auth_env: JIRA_TOKEN                         # server
+  jira_base_url: https://your-site.atlassian.net
+```
+
+If `.agents/test-automation.yaml` doesn't exist yet (project not
+seeded, or the test-automation pipeline skill isn't installed),
+the bundled CLI falls back to reading env vars directly —
+`XRAY_DEPLOYMENT`, `XRAY_CLIENT_ID`/`XRAY_CLIENT_SECRET` +
+`JIRA_BASE_URL` for Cloud, or `JIRA_TOKEN` + `JIRA_BASE_URL` for
+Server. Ask the operator for those values before running against
+an unseeded repo; see `scripts/README.md` § Configure via
+environment.
+
+If MCP is wired in (`Elitea_Dev`, `dmtools-cli`, `mcp-xray`, …),
+prefer the MCP tool — it usually normalizes Cloud vs Server
+under one interface.
+
+If no MCP is available, use the bundled CLI at
+[`scripts/xray.py`](scripts/xray.py) (stdlib-only Python,
+`scripts/README.md` for the full surface). The CLI auto-detects
+Cloud vs Server from env, caches JWTs, and bakes in the
+post-write re-fetch discipline (exit 3 on mismatch). Common ops:
+
+```bash
+xray auth-verify                          # reachability + status set check
+xray test get PROJ-T42                    # summary + step list
+xray test create --project PROJ --summary "..." --type Manual --steps steps.txt
+xray exec create --project PROJ --summary "Smoke 04-22" \
+  --tests PROJ-T42,PROJ-T43 --plan PROJ-P7
+xray import junit target/junit.xml --project PROJ --plan PROJ-P7
+```
+
+## Entity model + coverage linking
+
+### The six entities Xray tracks
+
+| Entity | Jira issue type | Purpose |
+|---|---|---|
+| **Test** | `Test` | Single test case. Test Type: Manual / Cucumber / Generic. |
+| **Precondition** | `Precondition` | Shared setup steps referenced by multiple Tests. |
+| **Test Set** | `Test Set` | Named grouping — "smoke", "regression-P1". No execution semantics. |
+| **Test Plan** | `Test Plan` | Planning container — "Release 2.7 QA sign-off". Aggregates latest Test Run status. |
+| **Test Execution** | `Test Execution` | Single run event. Contains one **Test Run** per Test executed. |
+| **Test Run** | (inside a Test Execution) | Status + evidence + comments for one Test in one Execution. Run ID, not Jira key. |
+
+```
+Requirement (Story / Bug) ──covered by── Test
+                                          ├── Precondition(s)
+                                          ├── in Test Set(s)
+                                          └── in Test Plan(s)
+                                                           │
+                                                           └─ executed via
+                                                              Test Execution → Test Run
+```
+
+A Test Run is never standalone — it only exists as a row inside a
+Test Execution. "Reporting a result" means posting to the Test Run
+that belongs to (Test Execution × Test).
+
+Full field list per entity + Test Type specifics:
+[`references/entities.md`](references/entities.md).
+
+### Coverage linking — the non-negotiable rule
+
+Creating a Test for a story and stopping there is half-finished.
+The story will show "no tests" in Xray's coverage reports until
+you link them — and the link is **not** a standard Jira
+`issuelinks` entry.
+
+> **Rule:** every Test created to validate a story / requirement /
+> bug MUST be linked via Xray's coverage link, *in the same unit
+> of work* as the Test creation. If the Test covers nothing (pure
+> infra / CI-smoke), document that explicitly in the Test
+> description.
+
+| Deployment | Call |
+|---|---|
+| Cloud (GraphQL) | `addTestsToRequirement(issueId: <STORY>, testIssueIds: [<TEST>])` |
+| Server / DC (REST) | `POST /rest/raven/2.0/api/test/<TEST>/requirement` body `{ "add": ["<STORY>"] }` |
+| CLI (either) | `xray test link-requirement <TEST-KEY> <STORY-KEY>` |
+| MCP (if available) | typically `*.add_tests_to_requirement` — prefer MCP when present |
+
+The plain Jira "Tests" / "Is tested by" `issuelinks` does **not**
+register coverage in modern Xray Cloud reports — it's free-text
+traceability, not a coverage edge. Use the native call above.
+
+**Verify after linking** (cloud GraphQL):
+`getCoverableIssue(issueId: <STORY>) { tests { results { jira(fields:["key"]) } } }`
+— expect the new Test key. CLI equivalent:
+`xray coverage <STORY>`. If the list is empty, inspect
+`addedTests` / `warning` in the link response and re-link.
+
+Skip coverage only when the Test genuinely covers nothing (infra /
+CI-smoke) — and document that in the Test body.
+
+## The CRUD loop (every call, every time)
+
+Mirrors the discipline of `atlassian-content`:
+
+```
+0. If updating: raw-fetch the current entity (Cloud GraphQL
+   returns structured fields; Server REST returns JSON). Merge
+   your change; don't regenerate.
+1. Detect deployment   → Cloud (GraphQL) or Server (REST)?
+2. Detect entity       → Test, Precondition, Set, Plan, Execution, Run?
+3. Resolve identities  → Jira keys, accountIds (for assignee/executedBy),
+                         test run IDs (inside an Execution)
+4. Assemble body       → GraphQL variables or REST JSON per
+                         references/cloud-graphql.md / server-rest.md
+5. Submit              → MCP tool or HTTP call
+6. Re-fetch            → GET the updated entity back
+7. Validate            → counts match (steps, tests in set, runs in
+                         execution); statuses are permitted values;
+                         no orphaned links
+8. Repair              → fix in place; don't leave a half-written
+                         execution
+```
+
+### 0. Raw-fetch first (for any update)
+
+Same rule as atlassian-content: fetch the current entity body in
+its **structured form** before editing. For Xray this is:
+
+- Cloud GraphQL: query the fields you're about to modify
+  (`steps { id action data result }`, `preconditions { issueId }`,
+  `tests { issueId }`, …).
+- Server REST: `GET /rest/raven/2.0/api/test/<key>` etc.
+
+**Applies regardless of transport** — raw GraphQL / REST, MCP
+server (`Elitea_Dev`, `dmtools-cli`, `mcp-xray`), or any
+Atlassian-connected integration. Choose the variant that returns
+structured fields, not a human-readable summary.
+
+Reason: step IDs, run IDs, and evidence attachments are opaque
+values — regenerating them from scratch loses history and breaks
+references from Test Plans / Test Executions that already
+reference them.
+
+### 1–2. Detect deployment + entity
+
+Branch once here. Every subsequent call uses one family of
+endpoints for the rest of the loop.
+
+### 3. Resolve identities
+
+- **Jira keys** — you usually already have these
+  (`PROJ-T42` / `PROJ-123`).
+- **accountId** (Cloud) — for `assignee`, `executedBy`, comment
+  authorship. Use the lookup in `atlassian-content/mentions.md`.
+- **issueId** — Xray's GraphQL often expects internal Jira
+  `issueId` (numeric) rather than the `issueKey`. Resolve with
+  `GET /rest/api/3/issue/<key>?fields=summary` — the `id` field
+  in the response is the numeric id.
+- **testRunId** — obtain from the Test Execution:
+  `getTestExecution(issueId: ...) { testRuns { results { id test { jira { key } } } } }`
+  (Cloud) or `GET /rest/raven/2.0/api/testexec/<key>/test` (Server).
+
+### 4. Assemble body
+
+- Cloud → GraphQL — see `references/cloud-graphql.md` for
+  queries, mutations, and authentication flow.
+- Server → REST — see `references/server-rest.md` for endpoints
+  and JSON shapes.
+- Results import → see `references/results-import.md` for
+  JUnit / Cucumber / Xray JSON formats.
+
+### 5–8. Submit, re-fetch, validate, repair
+
+The re-fetch step proves what you intended actually landed:
+
+- **Test creation** → re-fetch the Test; confirm `testType`,
+  step count, any precondition links.
+- **Results import** → re-fetch the Test Execution; confirm the
+  Test Run count matches the number of cases in the report, and
+  statuses are the expected values.
+- **Linking** → re-fetch the Test (or the requirement); confirm
+  the link appears on both sides.
+
+If counts don't match or statuses are wrong, the report shape
+was off — fix the report and re-import.
+
+## Common task shapes
+
+The CRUD loop above applies to every task. Three common flows, as
+checklists:
+
+**Create Manual Test from AFS covering PROJ-123** — detect deployment
+→ resolve project key + assignee accountId + preconditions + story
+key → POST new Test (GraphQL `createTest` or REST
+`POST /api/test`) → link coverage
+(`addTestsToRequirement(PROJ-123, [<new>])`) → re-fetch Test for step
+count AND re-fetch PROJ-123 coverage for the new Test key.
+
+**Import JUnit results against Test Plan PROJ-P7** — build
+Xray-recognized JUnit XML (classname / name mapped to Jira keys per
+the adapter config) → `POST /import/execution/junit?testPlanKey=PROJ-P7`
+→ re-fetch the returned Test Execution → run count must equal
+`<testcase>` count. Zero = broken mapping (silent-fail signature).
+
+**Add Test PROJ-T42 to Test Set PROJ-TS10** — raw-fetch PROJ-TS10 →
+skip if already present → `addTestsToTestSet` (Cloud) or
+`POST /api/testset/<TS10>/test` (Server) → re-fetch to confirm.
+
+Full request/response shapes: `references/cloud-graphql.md` (Cloud),
+`references/server-rest.md` (Server), `references/results-import.md`
+(imports).
+
+## Anti-patterns
+
+- **"I created the Test issue in Jira, why is Xray empty?"** —
+  Xray tracks Test Type, steps, scenarios in its own store.
+  Creating the Jira issue alone leaves an empty Test. Use the
+  Xray mutation / REST.
+- **"I imported the JUnit report and the response was 200, but
+  the Test Execution is empty."** — 200 often means "accepted
+  the upload". Zero runs = bad mapping between your
+  `classname`/`name` and Jira Test keys. See the import
+  reference.
+- **"I updated the step list but the execution history
+  disappeared."** — You regenerated step IDs. Never reassign
+  step IDs; fetch, edit in place, submit.
+- **"I assigned a Test Run status that Xray rejected."** —
+  Statuses are project-configurable. Query allowed values
+  (`getStatuses` GraphQL query) first.
+- **"I link the Test to the story via Jira's `links` field."**
+  — That works for free-text traceability but doesn't register
+  coverage in Xray's reports on modern Cloud installs. Use
+  Xray's `addTestsToRequirement` (Cloud GraphQL) or
+  `/api/test/<key>/requirement` (Server) so coverage rolls up.
+  See § "Link Tests to stories" above.
+- **"I created a Test for the story and moved on without
+  linking it."** — Coverage reports will show the story as
+  uncovered even though the Test exists. Linking is part of
+  "creating a Test for X", not a follow-up task.
+- **"I POSTed a JSON body with `markdown` formatting."** — Xray
+  fields that accept rich text follow the same rule as
+  `atlassian-content`: Cloud uses ADF, Server uses wiki markup.
+  Test step text is typically plain text; check the field docs.
+
+## Escalation
+
+Ask the operator when:
+
+- The project uses a non-default set of Test Run statuses and
+  none are declared in `.agents/profile.md`.
+- A Test requires custom fields (defined per-project) that
+  aren't documented.
+- The results-file format doesn't match any supported importer
+  (e.g. Robot Framework when no Xray Robot plugin is installed).
+- Coverage links are expected to a custom issue type (some teams
+  cover Epics, others cover Stories only — ask which).
+
+## References
+
+- `references/cloud-graphql.md` — Xray Cloud API v2: auth flow,
+  core queries (`getTests`, `getTestExecution`, `getStatuses`,
+  `getCoverableIssue`), core mutations (`createTest`,
+  `updateTestSteps`, `addTestsToTestSet`, `addTestRuns`),
+  fragments, pagination.
+- `references/server-rest.md` — Xray Server / DC REST endpoints
+  for Test / Precondition / Test Set / Test Plan / Test Execution
+  / Test Run, including JSON examples and the `import/execution/*`
+  endpoints.
+- `references/entities.md` — Test Types (Manual / Cucumber /
+  Generic), field-by-field reference per entity, coverage model.
+- `references/results-import.md` — JUnit, Cucumber JSON, TestNG,
+  NUnit, and generic Xray JSON result formats; classname/name
+  mapping; validation after import.
+- `scripts/xray.py` + `scripts/README.md` — stdlib-only Python
+  CLI covering every operation above; the HTTP fallback to use
+  when an MCP tool isn't wired. Agents are explicitly allowed to
+  fix / extend the script when they hit bugs or missing
+  capabilities — see § Evolving the CLI above.
+- `references/jira-rest-fallback.md` — what's still reachable
+  when the Xray API itself is unreachable (credentials rejected,
+  regional mismatch, outage). Jira REST alone lets you list /
+  filter Tests by type, read issue shells, and file defects; it
+  does NOT expose structured Test bodies or Test Runs.
+
+External — primary sources:
+
+- Xray Cloud GraphQL: https://xray.cloud.getxray.app/doc/graphql/
+- Xray Cloud REST (v2): https://docs.getxray.app/display/XRAYCLOUD/REST+API
+- Xray Server / DC REST: https://docs.getxray.app/display/XRAY/REST+API
+- dmtools-cli Xray module (for patterns / examples):
+  https://github.com/IstiN/dmtools-cli/tree/main/dmtools-core/src
+- Elitea SDK Xray tools:
+  https://github.com/EliteaAI/elitea-sdk/tree/main/elitea_sdk/tools/xray

--- a/skills/xray-testing/references/cloud-graphql.md
+++ b/skills/xray-testing/references/cloud-graphql.md
@@ -1,0 +1,381 @@
+# Xray Cloud — GraphQL API v2
+
+Xray Cloud exposes its primary API at
+**`https://xray.cloud.getxray.app/api/v2/graphql`**. A small set
+of REST endpoints exist for auth and results import; everything
+else is GraphQL.
+
+## 1. Authentication
+
+Xray Cloud uses a short-lived **JWT** obtained from client
+credentials.
+
+```
+POST https://xray.cloud.getxray.app/api/v2/authenticate
+Content-Type: application/json
+
+{
+  "client_id":     "<XRAY_CLIENT_ID>",
+  "client_secret": "<XRAY_CLIENT_SECRET>"
+}
+```
+
+The response body **is** the JWT string (plain text in quotes).
+Use it as a bearer token:
+
+```
+Authorization: Bearer <JWT>
+```
+
+Tokens are valid for ~24h. Cache per session; re-auth on 401.
+
+Client credentials come from Jira → Apps → Xray → API Keys.
+Store in env (`XRAY_CLIENT_ID`, `XRAY_CLIENT_SECRET`) — never in
+the repo.
+
+## 2. Everything uses `issueId`, not `issueKey` — usually
+
+Xray's GraphQL schema keys entities by **internal Jira issueId**
+(numeric string). You'll usually have a Jira key (`PROJ-T42`);
+resolve to issueId via the Jira REST API:
+
+```
+GET /rest/api/3/issue/PROJ-T42?fields=summary
+→ { "id": "123456", "key": "PROJ-T42", ... }
+```
+
+Cache `key → issueId` per session.
+
+Many queries accept a `jql` string as an alternative to
+`issueIds`; for ad-hoc filters, JQL is often simpler:
+
+```graphql
+query { getTests(jql: "project = PROJ AND issuetype = Test AND labels = smoke",
+                limit: 100) {
+  total results { issueId jira(fields: ["key","summary"]) } } }
+```
+
+## 3. Core queries
+
+### Get a single Test (with steps)
+
+```graphql
+query GetTest($issueId: String!) {
+  getTest(issueId: $issueId) {
+    issueId
+    projectId
+    testType { name kind }
+    jira(fields: ["key", "summary", "status"])
+    steps {
+      id
+      action
+      data
+      result
+      attachments { id filename }
+    }
+    preconditions(limit: 50) {
+      total
+      results { issueId jira(fields: ["key", "summary"]) }
+    }
+  }
+}
+```
+
+`testType.kind` is `"Manual"` / `"Cucumber"` / `"Generic"`.
+
+- Manual → `steps` list is authoritative.
+- Cucumber → `gherkin` field holds the scenario body (query it
+  separately: `... on Test { gherkin }` — depending on schema
+  version).
+- Generic → `unstructured` field holds the free-text definition.
+
+### Get a Test Execution with its Test Runs
+
+```graphql
+query GetTestExecution($issueId: String!) {
+  getTestExecution(issueId: $issueId) {
+    issueId
+    jira(fields: ["key", "summary"])
+    testRuns(limit: 100) {
+      total
+      results {
+        id
+        status { name color }
+        test { issueId jira(fields: ["key"]) }
+        startedOn
+        finishedOn
+        executedBy
+        comment
+        defects { issueId jira(fields: ["key"]) }
+      }
+    }
+  }
+}
+```
+
+The `results[].id` is the **Test Run ID** — the handle you use
+to update status, attach evidence, or comment.
+
+### Get allowed statuses
+
+```graphql
+query { getStatuses { name description color final } }
+```
+
+Always query this before posting a Test Run status — the
+default set (`PASSED`, `FAILED`, `EXECUTING`, `TODO`,
+`ABORTED`, `BLOCKED`) may be extended or replaced per project.
+
+### Get coverage for a requirement
+
+```graphql
+query GetCoverage($issueId: String!) {
+  getCoverableIssue(issueId: $issueId) {
+    issueId
+    jira(fields: ["key", "summary"])
+    status { name color }
+    tests(limit: 100) {
+      total
+      results { issueId jira(fields: ["key", "summary"]) }
+    }
+  }
+}
+```
+
+### Paginate
+
+`limit` is capped at 100 per query. For longer lists, use `start`
++ `limit`:
+
+```graphql
+query { getTests(jql: "...", limit: 100, start: 0) { total results { issueId } } }
+```
+
+Iterate `start` in steps of 100 while `start < total`.
+
+## 4. Core mutations
+
+### Create a Manual Test
+
+```graphql
+mutation CreateTest(
+  $projectKey: String!,
+  $summary: String!,
+  $steps: [CreateStepInput],
+  $assigneeAccountId: String
+) {
+  createTest(
+    testType: { name: "Manual" },
+    steps: $steps,
+    jira: {
+      fields: {
+        project:  { key: $projectKey },
+        summary:  $summary,
+        assignee: { accountId: $assigneeAccountId }
+      }
+    }
+  ) {
+    test { issueId jira(fields: ["key"]) }
+    warnings
+  }
+}
+```
+
+Variables:
+
+```json
+{
+  "projectKey": "PROJ",
+  "summary": "User can log in with a plus-sign email",
+  "assigneeAccountId": "61e1a042e67ea2006b5b2157",
+  "steps": [
+    { "action": "Open the login page", "data": "", "result": "Form is visible" },
+    { "action": "Enter email 'user+tag@example.com' and password",
+      "data": "", "result": "Fields accept input" },
+    { "action": "Click Log in", "data": "",
+      "result": "Dashboard renders within 2s" }
+  ]
+}
+```
+
+`warnings` in the response is non-fatal but worth surfacing.
+
+### Create a Cucumber Test
+
+```graphql
+mutation {
+  createTest(
+    testType: { name: "Cucumber" },
+    gherkin: "Scenario: Plus-sign email login\n  Given ...\n",
+    jira: { fields: { project: { key: "PROJ" }, summary: "..." } }
+  ) { test { issueId } }
+}
+```
+
+### Update Test steps (in place)
+
+```graphql
+mutation UpdateTestStep(
+  $issueId: String!,
+  $stepId: String!,
+  $step: UpdateStepInput!
+) {
+  updateTestStep(issueId: $issueId, stepId: $stepId, step: $step) {
+    warnings
+  }
+}
+```
+
+For reordering / adding / removing: `addTestStep`, `removeTestStep`.
+Fetch current step IDs first — do not reassign them.
+
+### Add Tests to a Test Set / Test Plan
+
+```graphql
+mutation {
+  addTestsToTestSet(
+    issueId: "<TS issueId>",
+    testIssueIds: ["<T1 issueId>", "<T2 issueId>"]
+  ) { addedTests warning }
+}
+
+mutation {
+  addTestsToTestPlan(
+    issueId: "<TP issueId>",
+    testIssueIds: ["<T1 issueId>", "<T2 issueId>"]
+  ) { addedTests warning }
+}
+```
+
+Removal: `removeTestsFromTestSet` / `removeTestsFromTestPlan`.
+
+### Create a Test Execution
+
+```graphql
+mutation {
+  createTestExecution(
+    testIssueIds: ["<T1 issueId>", "<T2 issueId>"],
+    jira: {
+      fields: {
+        project: { key: "PROJ" },
+        summary: "Regression run 2026-04-22 / staging"
+      }
+    }
+  ) {
+    testExecution { issueId jira(fields: ["key"]) }
+    warnings
+  }
+}
+```
+
+For a Test Execution tied to a Test Plan:
+
+```graphql
+... createTestExecution(
+  testPlanIssueId: "<TP issueId>",
+  testIssueIds: [ ... ], ...
+) ...
+```
+
+### Report a single Test Run result
+
+Given a Test Run ID from `getTestExecution().testRuns.results[].id`:
+
+```graphql
+mutation UpdateTestRun(
+  $id: String!,
+  $status: String!,   # e.g. "PASSED", "FAILED"
+  $comment: String,
+  $evidence: [AttachmentDataInput]
+) {
+  updateTestRunStatus(id: $id, status: $status) { warnings }
+  updateTestRunComment(id: $id, comment: $comment) { warnings }
+  addEvidenceToTestRun(id: $id, evidence: $evidence) { warnings }
+}
+```
+
+Evidence is uploaded as base64:
+
+```json
+[
+  { "filename": "login-failure.png",
+    "mimeType": "image/png",
+    "data":     "<base64>" }
+]
+```
+
+For bulk results from a file, prefer the REST import endpoints
+(see `results-import.md`) — far cheaper than N single-Run
+mutations.
+
+### Link a Test to a requirement (coverage)
+
+```graphql
+mutation {
+  addTestsToRequirement(
+    issueId: "<Story issueId>",
+    testIssueIds: ["<Test issueId>"]
+  ) { addedTests warning }
+}
+```
+
+Mirror: `removeTestsFromRequirement`.
+
+## 5. Fragments — reusable shapes
+
+```graphql
+fragment JiraBasics on Issue {
+  key
+  summary
+  status
+}
+
+fragment TestBasics on Test {
+  issueId
+  testType { name kind }
+  jira(fields: ["key", "summary", "status"])
+}
+```
+
+Use in queries:
+
+```graphql
+query { getTests(jql: "...", limit: 50) {
+  total results { ...TestBasics } } }
+```
+
+## 6. Error handling
+
+- **401** → JWT expired. Re-authenticate.
+- **422 / `errors[]` in response** → malformed mutation input.
+  GraphQL errors come back in the `errors` array — always check
+  even on 200.
+- **`warnings[]` in a success response** → not fatal, but surface
+  it (unexpected downgrades, conflicting links, etc.).
+- **Empty response body on a successful POST** → some proxies
+  strip bodies on 204 responses; follow with a re-fetch.
+
+## 7. Worked example — end-to-end
+
+**Goal**: "Create a new Manual Test for PROJ, link it to story
+PROJ-123, add it to the 'smoke' Test Set, create a Test
+Execution, and report PASSED."
+
+```
+1. Auth:        POST /authenticate → JWT
+2. Resolve:     GET /rest/api/3/issue/PROJ-123 → issueId "55501"
+                GET /rest/api/3/issue/PROJ-TS10 → issueId "44401"
+3. createTest:  mutation → new Test issueId "99901" (PROJ-T42)
+4. addTestsToRequirement(issueId: "55501",
+                         testIssueIds: ["99901"])
+5. addTestsToTestSet(issueId: "44401",
+                     testIssueIds: ["99901"])
+6. createTestExecution(testIssueIds: ["99901"],
+                       jira: { ... "summary": "Smoke 04-22" })
+   → Execution issueId "99902" (PROJ-TE7)
+7. getTestExecution(issueId: "99902") {
+     testRuns { results { id test { jira(fields:["key"]) } } } }
+   → run.id "abcd-run-id"
+8. updateTestRunStatus(id: "abcd-run-id", status: "PASSED")
+9. Re-fetch PROJ-TE7; confirm 1 run, PASSED.
+```

--- a/skills/xray-testing/references/entities.md
+++ b/skills/xray-testing/references/entities.md
@@ -1,0 +1,243 @@
+# Xray entity model — field reference
+
+All six entities are **Jira issues** (except Test Run). They share
+standard Jira fields (project, summary, description, assignee,
+priority, labels, components, fixVersions) plus Xray-specific
+fields.
+
+This reference is the "what fields matter, what values are
+allowed, what you can and can't change" view. Call-shape details
+are in `cloud-graphql.md` / `server-rest.md`.
+
+## Test — the test case
+
+### Test Type
+
+A Test has **exactly one** Test Type, set at creation and rarely
+changed:
+
+| Test Type | Content shape | Used for |
+|---|---|---|
+| **Manual** | Ordered list of steps (`action` / `data` / `result`) | Human / step-by-step execution — the most common shape |
+| **Cucumber** | A single Gherkin scenario body | BDD-style tests, directly runnable by Cucumber / SpecFlow |
+| **Generic** | Free-text `definition` field | Any other kind — programmatic tests, checklists, exploratory templates |
+
+Additional custom Test Types (e.g. "Automated", "Exploratory") can
+be defined per project — query `/rest/api/2/field` (Server) or
+`getTestTypes` (Cloud GraphQL) to see what's configured.
+
+### Steps (Manual Test)
+
+Each step has:
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | auto | Opaque string — never reassign |
+| `action` | yes | What the tester does ("Click Submit") |
+| `data` | no | Input data ("user+tag@x.com / s3cret") |
+| `result` | yes | Expected outcome ("Dashboard loads") |
+| `attachments` | no | Step-level evidence (screenshots, CSVs) |
+| `customFields` | no | Project-configured fields per step |
+
+Steps are **ordered** — the order in the array is the execution
+order. Rearrange via dedicated reorder mutations / endpoints, not
+by swapping array positions wholesale (preserves history).
+
+### Scenario (Cucumber Test)
+
+A single Gherkin block:
+
+```gherkin
+Scenario: Plus-sign email login
+  Given I am on the login page
+  When I submit user+tag@example.com / s3cret
+  Then I see the dashboard within 2 seconds
+```
+
+Variants:
+- **Scenario** (default) — one concrete path
+- **Scenario Outline** — parameterized; includes an `Examples:` table
+- **Background** — applied via Preconditions (see below)
+
+Xray stores the Cucumber body in a `gherkin` field (Cloud) or the
+`Cucumber Test Content` custom field (Server).
+
+### Definition (Generic Test)
+
+Free text / code / pseudo-code. Stored in `unstructured` (Cloud) /
+`Generic Test Definition` custom field (Server). No enforced shape.
+
+### Links
+
+A Test links to:
+
+- **Preconditions** — shared setup, many-to-many
+- **Test Sets** — grouping, many-to-many
+- **Test Plans** — planning containers, many-to-many
+- **Requirement** — Stories / Bugs / Epics covered by the Test
+  (Xray's coverage link, NOT the standard Jira "links" field)
+- **Test Executions** — automatic, as the Test gets run
+
+## Precondition — shared setup steps
+
+A Precondition is a Jira issue of type `Precondition` holding
+setup steps that multiple Tests share ("A logged-in admin user
+exists with `seed_admin` fixture"). It is **not** a Test —
+it's not executed on its own, it doesn't appear in Test
+Executions as a separate row. It contributes steps to each Test
+that references it.
+
+Type variants parallel Manual / Cucumber / Generic Tests —
+usually **Manual** with a step list, occasionally **Cucumber**
+(for a `Background:` block).
+
+Link from a Test → Precondition via the Test's
+`preconditions` field. Link is many-to-many.
+
+## Test Set — pure organizational grouping
+
+A Jira issue of type `Test Set` that holds a list of Tests.
+Analogous to a tag or folder. No execution semantics — a Test Set
+does not track latest status or roll up results.
+
+Use for:
+- Smoke / regression / onboarding suites
+- Feature-scoped groupings ("checkout flow", "admin panel")
+- Temporary investigation buckets
+
+A Test can belong to any number of Test Sets.
+
+## Test Plan — planning container with rolled-up status
+
+A Jira issue of type `Test Plan` that holds a list of Tests **and
+rolls up their latest run status** across all Test Executions
+linked to the Plan.
+
+Typical usage: one Test Plan per release or sprint
+("Release 2.7 QA sign-off"). The plan shows, for each Test, the
+latest PASSED / FAILED / etc. across every Test Execution
+associated with it.
+
+Key differences vs Test Set:
+
+| Trait | Test Set | Test Plan |
+|---|---|---|
+| Purpose | Grouping | Execution rollup |
+| Status aggregation | No | Yes |
+| Test Executions link here | No | Yes |
+| Typical lifetime | Persistent | Per release / sprint |
+
+A Test Execution can be linked to a Test Plan at creation or
+later; all its Test Runs then contribute to the Plan's rollup.
+
+## Test Execution — one run event
+
+A Jira issue of type `Test Execution` representing a specific
+run: "Regression run 2026-04-22 / staging" or "Nightly CI 1087".
+
+Contains a **Test Run per Test** in its scope. Test Runs are
+**not** separate Jira issues — they live inside the Test
+Execution.
+
+Common fields:
+
+| Field | Notes |
+|---|---|
+| `summary` | Name of the run |
+| `testEnvironments` | e.g. `["staging"]` — used for filtering and rollups |
+| `fixVersion`, `revision` | Optional — release / commit identifiers |
+| `testPlan` | Optional — linked Test Plan for rollup |
+| `testRuns` | Auto-populated as Tests are added |
+
+## Test Run — status + evidence for one Test inside one Execution
+
+The running record. **Not a Jira issue.** Identified by a run ID
+(opaque) or numeric id (Server REST).
+
+Fields:
+
+| Field | Notes |
+|---|---|
+| `id` | Opaque / numeric identifier |
+| `test` | Reference to the Test issue |
+| `status` | PASSED / FAILED / EXECUTING / TODO / ABORTED / BLOCKED (project-configurable) |
+| `startedOn`, `finishedOn` | Timestamps |
+| `executedBy` | accountId (Cloud) / username (Server) |
+| `comment` | Free text — rationale, link to CI build, etc. |
+| `defects` | Linked Bug issues |
+| `evidence` | Attached files (screenshots, logs) |
+| `steps` | Per-step result list for Manual Tests |
+
+A Test Run is created automatically when a Test is added to a
+Test Execution, and updated repeatedly — not deleted. Re-running
+the Test against the same Execution updates the same Run; a new
+Execution creates a new Run.
+
+## Coverage model
+
+Xray's "coverage" answers: *which requirements have tests, and
+what's their latest status?*
+
+Coverage is **derived**, not stored:
+
+1. A Test is linked to a requirement (Story / Bug / Epic / custom)
+   via Xray's requirement link.
+2. Each Test Run on that Test contributes a latest status.
+3. Reports aggregate latest status per requirement.
+
+Implications:
+
+- Linking a Test via the **standard Jira `links` field** does NOT
+  count as coverage — it's a free-text relation. Use Xray's
+  `addTestsToRequirement` (Cloud) / `/api/test/<key>/requirement`
+  (Server) instead.
+- "No test coverage" = the requirement has no Test links.
+- "Tests passing coverage" = all linked Tests have a final-status
+  Test Run of PASSED within the configured scope (Test Plan / Test
+  Environment / Version).
+
+## Status catalogue
+
+Xray ships six default statuses; projects can extend or replace:
+
+| Status | `final` | Typical meaning |
+|---|---|---|
+| `TODO` | no | Scheduled but not yet run |
+| `EXECUTING` | no | Currently running |
+| `PASSED` | yes | Ran and met expectations |
+| `FAILED` | yes | Ran and missed expectations |
+| `ABORTED` | yes | Run was interrupted |
+| `BLOCKED` | no | Can't run (env / data / dependency) |
+
+Don't hard-code. Always query:
+
+```
+# Server
+GET /rest/raven/2.0/api/settings/teststatuses
+
+# Cloud
+query { getStatuses { name final color description } }
+```
+
+## Common field-shape confusions
+
+- **Test Type vs `issuetype`** — the Jira issue type is
+  `"Test"` (or `"Precondition"` etc.); the `Test Type` is the
+  Xray custom field that distinguishes Manual / Cucumber /
+  Generic. Both must be set at creation or Xray can't render the
+  Test.
+- **Test Run vs Test Execution** — the Test Run is a ROW inside a
+  Test Execution. Editing statuses and evidence targets the Test
+  Run, not the Execution.
+- **Precondition vs Test** — a Precondition looks like a Test
+  (same step shape) but is never executed standalone. Don't use a
+  Precondition as a test.
+- **Test Set vs Test Plan** — Test Sets group, Test Plans plan +
+  roll up. Pick Plan when you care about "what's the status of X
+  across runs", Set when you just want a named list.
+- **Coverage via Jira `links` field** — does not count. Use Xray's
+  requirement-coverage endpoint.
+- **Changing Test Type post-creation** — possible but lossy
+  (Manual → Cucumber drops steps; Cucumber → Manual drops the
+  gherkin). Avoid; create a new Test instead when the kind
+  changes.

--- a/skills/xray-testing/references/jira-rest-fallback.md
+++ b/skills/xray-testing/references/jira-rest-fallback.md
@@ -1,0 +1,209 @@
+# Jira-REST fallback — what works without Xray Cloud credentials
+
+When the Xray Cloud API is unreachable — credentials rejected,
+`client_id`/`client_secret` not yet issued, regional endpoint
+mis-set, or the tenant is mid-outage — you can still do a
+**significant chunk of diagnostic / discovery work** using
+Jira REST alone (any API token that authenticates against
+`<site>.atlassian.net/rest/api/3/*` via Basic auth).
+
+This reference documents precisely what's reachable in that
+degraded mode, so an agent can keep working instead of dead-
+ending. It does NOT replace the Xray API — anything to do with
+structured Test bodies, Test Runs, or results import still
+requires working Xray creds.
+
+## Authentication (Jira REST only)
+
+Jira Cloud API tokens (the `ATATT3x…` format) **only** work with
+Basic auth. The token is the "password" half; your Atlassian email
+is the "username" half:
+
+```bash
+curl -u "you@example.com:ATATT3x..." -H 'Accept: application/json' \
+  https://<site>.atlassian.net/rest/api/3/myself
+```
+
+Bearer auth is explicitly rejected (`403 Failed to parse Connect
+Session Auth Token`). If you only have the token and not the email,
+you cannot authenticate — ask the operator for the email.
+
+## What IS reachable
+
+### 1. Discover Xray issue types in a project
+
+All six Xray entities are Jira issues with specific types:
+
+```
+POST /rest/api/3/issue/createmeta?projectKeys=<PROJ>
+→ response.projects[0].issuetypes[*].name
+```
+
+Look for: `Test`, `Pre condition`, `Test Set`, `Test Plan`,
+`Test Execution`. All five present ⇒ the project has Xray
+installed.
+
+### 2. List / filter Tests with JQL
+
+Atlassian Cloud's search API migrated to `/rest/api/3/search/jql`
+(POST) in late 2025. The old `/rest/api/3/search` (GET) is
+deprecated.
+
+```
+POST /rest/api/3/search/jql
+{
+  "jql":         "project = PROJ AND issuetype = Test",
+  "fields":      ["summary","status","labels"],
+  "maxResults":  100
+}
+```
+
+Pagination uses `nextPageToken` / `isLast`, not `startAt`.
+
+For an exact count, use the approximate-count endpoint:
+
+```
+POST /rest/api/3/search/approximate-count
+{ "jql": "project = PROJ AND issuetype = Test" }
+→ { "count": 1305 }
+```
+
+### 3. Filter Tests by Test Type via entity-property JQL
+
+Xray stores each issue's Test Type in a Jira **entity property**
+(not a custom field, on recent Xray Cloud versions). JQL supports
+`issue.property["<key>"].<field>` syntax:
+
+```
+jql: project = PROJ AND issuetype = Test
+     AND issue.property["testType"].kind = "Manual"
+```
+
+Allowed `kind` values: `Manual`, `Cucumber`, `Generic` (lowercase
+form may vary — the property also has a `name` field with capital
+casing).
+
+### 4. Read Test Type + Xray-issue-type per issue
+
+```
+GET /rest/api/3/issue/<KEY>/properties
+→ list of property keys (filter for the ones below)
+
+GET /rest/api/3/issue/<KEY>/properties/testType
+→ { "key":"testType",
+    "value":{ "id":"...", "name":"Manual", "kind":"manual" } }
+
+GET /rest/api/3/issue/<KEY>/properties/xrayIssueType
+→ { "key":"xrayIssueType",
+    "value":{ "name":"Test" } }
+```
+
+The UI-panel marker properties (prefix
+`com.xpandit.plugins.xray_xray-test-*-panel-new`) carry only
+`{"added": "<panel-key>"}` and are useless for data — don't fetch
+them expecting content.
+
+### 5. Read Jira-side fields on a Test
+
+Standard fields always work:
+
+```
+GET /rest/api/3/issue/<KEY>?fields=summary,status,description,labels,assignee,reporter,priority,issuelinks,attachment,comment
+```
+
+Useful for: building a catalogue, filtering by labels, reading
+links / attachments / comments the author put directly on the
+Jira issue.
+
+### 6. File a bug / clarification issue
+
+Standard Jira issue-create works:
+
+```
+POST /rest/api/3/issue
+{
+  "fields": {
+    "project":    { "key": "PROJ" },
+    "summary":    "Login returns 500 on plus-sign email",
+    "issuetype":  { "name": "Bug" },
+    "description": { /* ADF — see atlassian-content skill */ }
+  }
+}
+```
+
+Use the **`atlassian-content`** skill for ADF shape + mentions +
+post-creation verification.
+
+### 7. Find Jira-link-based coverage
+
+Some teams use standard Jira `issuelinks` (`Tests` / `Is tested by`)
+on top of or instead of Xray's coverage link:
+
+```
+GET /rest/api/3/issue/<STORY-KEY>?fields=issuelinks
+→ fields.issuelinks[] with type.name like "Tests" / "Is tested by"
+```
+
+Fast and cheap; works without Xray. But this is NOT Xray's
+official coverage — coverage rollups still need the Xray API.
+
+## What is NOT reachable via Jira REST
+
+All of these live in Xray Cloud's own store and require the Xray
+API (`xray.cloud.getxray.app/api/v2` or regional):
+
+- **Manual Test step list** — the `action / data / result` rows.
+  Not in custom fields, not in entity properties. Xray-Cloud-only.
+- **Cucumber Test scenario** — the Gherkin body beyond whatever
+  the author typed into the Jira `description`.
+- **Generic Test "definition"** (when separated from `description`).
+- **Preconditions** linked to a Test — the Xray link type is not
+  a standard Jira issue link on modern Xray Cloud installs.
+- **Test Set / Test Plan → Test membership** — again, not a Jira
+  issue-link type on modern installs.
+- **Test Execution → Test Run contents** — statuses, timestamps,
+  evidence, per-step results, executor. The Test Execution Jira
+  issue only exposes UI-panel markers via entity properties.
+- **Coverage rollups** — "which requirements have passing tests,
+  across which test environments, in the current Test Plan".
+- **Results import** — JUnit / Cucumber / Xray JSON. The `import/
+  execution/*` endpoints are Xray-API-only.
+- **Any write operation** on Test Type, step list, scenario, or
+  Test Run status.
+
+## Decision tree for degraded mode
+
+```
+Can the agent reach xray.cloud.getxray.app with valid JWT?
+├─ YES  → use the Xray API (SKILL.md § Transport priority)
+└─ NO   → Jira-REST fallback (this doc)
+         ├─ Need: list / count / filter Tests by type or label?
+         │        → JQL search + issue-property filter ✓
+         ├─ Need: Test Type per issue, summary, status, links?
+         │        → /rest/api/3/issue + /properties ✓
+         ├─ Need: file a bug / clarification?
+         │        → standard Jira POST + atlassian-content skill ✓
+         ├─ Need: structured step list, scenario, run status?
+         │        → BLOCKED. Surface the blocker to the operator;
+         │          ask them to re-issue Xray API keys.
+         └─ Need: upload results / create Test Runs?
+                  → BLOCKED. Same ask.
+```
+
+## Surfacing the blocker
+
+If the agent lands in "BLOCKED" branches above, do not silently
+drop the work. Report clearly:
+
+```
+Xray API unreachable (<reason>: 401 invalid client credentials /
+network error / regional endpoint mismatch). Operating in Jira-
+REST fallback mode — can still list / filter / update issue
+shells and file defects. Cannot read test bodies, runs, or
+import results until the operator re-issues Xray API keys and
+populates XRAY_CLIENT_ID / XRAY_CLIENT_SECRET. See
+scripts/README.md § Configure via environment.
+```
+
+Then continue on whatever it can do, and leave the degraded items
+as `Unconfirmed` or `Blocked` in the deliverable.

--- a/skills/xray-testing/references/results-import.md
+++ b/skills/xray-testing/references/results-import.md
@@ -1,0 +1,281 @@
+# Results import — JUnit, Cucumber, TestNG, NUnit, xUnit, Xray JSON
+
+Xray can import test results from every mainstream runner. The
+import endpoints create a **Test Execution** and one **Test Run**
+per reported test case. Mapping report rows to existing Tests
+relies on conventions you need to get right — a mis-mapped report
+creates a 0-run Execution and fails silently.
+
+## 1. Endpoints
+
+Same path on Cloud and Server; only the base URL differs:
+
+```
+Cloud  : https://xray.cloud.getxray.app/api/v2/import/execution/...
+Server : https://<your-jira>/rest/raven/2.0/import/execution/...
+```
+
+| Format | Endpoint suffix | Body |
+|---|---|---|
+| JUnit XML | `/junit` | multipart file |
+| JUnit (multi-file) | `/junit/multipart` | multipart, multiple files |
+| TestNG XML | `/testng` | multipart file |
+| NUnit XML (v2, v3) | `/nunit`, `/nunit/multipart` | multipart file |
+| xUnit XML | `/xunit`, `/xunit/multipart` | multipart file |
+| Cucumber JSON | `/cucumber` | JSON body |
+| Robot Framework | `/robot` (if plugin present) | multipart file |
+| Xray JSON (canonical) | `/` (just `/import/execution`) | JSON body |
+
+Common query params:
+
+- `projectKey=PROJ` — where the new Test Execution lands
+- `testExecKey=PROJ-TE7` — append results to an existing Execution
+- `testPlanKey=PROJ-P7` — link to a Test Plan (rollup)
+- `fixVersion=2.7.0`, `revision=abc123`, `testEnvironments=staging`
+
+## 2. JUnit XML — the default for most JS / Python runners
+
+Standard JUnit shape:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="smoke" tests="3" failures="1" errors="0" skipped="0">
+    <testcase classname="login.PlusSignEmail" name="accepts plus sign"
+              time="1.234"/>
+    <testcase classname="login.ShortPassword" name="rejects short password"
+              time="0.321">
+      <failure message="AssertionError: expected 200, got 500"
+               type="AssertionError">
+        at /app/tests/login.spec.ts:42
+      </failure>
+    </testcase>
+    <testcase classname="login.SSO" name="redirects to IdP" time="0.0">
+      <skipped message="SSO disabled in this env"/>
+    </testcase>
+  </testsuite>
+</testsuites>
+```
+
+### How Xray maps JUnit rows to Jira Test keys
+
+Xray looks at `classname` + `name` against Jira Test keys using
+one of these strategies (configurable per project):
+
+1. **Test description / summary match** — if your Jira Test
+   summary is `"accepts plus sign"` and the JUnit `<testcase
+   name>` matches, Xray may match. Unreliable — strings drift.
+2. **Label match** — each Jira Test carries a label
+   `automation:<classname>.<name>`; Xray uses that as the mapping
+   key. Reliable, but requires maintenance.
+3. **Cucumber Test Issue Key** (Cucumber only) — the scenario's
+   `@TEST_PROJ-T42` tag becomes the mapping key. Most reliable
+   for BDD flows.
+4. **Exact Jira key in `classname`** — `classname="PROJ-T42"`,
+   `name="<description>"`. Most reliable for XML-based runners:
+   make your runner emit Jira keys as classnames. The dmtools-cli
+   + Elitea SDK patterns both use this approach.
+
+Pick ONE strategy for the project and document it in
+`.agents/testing.md` so both the runner config and the Xray
+project match. The single biggest import-failure cause is
+runners and Xray disagreeing on mapping.
+
+### Status mapping (JUnit → Xray)
+
+| JUnit | Xray (default) |
+|---|---|
+| `<testcase>` (no child elements) | `PASSED` |
+| `<failure>` | `FAILED` |
+| `<error>` | `FAILED` (or `ABORTED` in some configs) |
+| `<skipped>` | `TODO` (or `SKIPPED` if that status is configured) |
+
+Failure messages go into the Test Run `comment`; text inside
+`<failure>` becomes the error output.
+
+### Minimal working call (Cloud)
+
+```
+curl -H "Authorization: Bearer $JWT" \
+     -F "file=@results.xml" \
+     "https://xray.cloud.getxray.app/api/v2/import/execution/junit?projectKey=PROJ&testPlanKey=PROJ-P7"
+```
+
+Response:
+
+```json
+{
+  "id":    "99902",
+  "key":   "PROJ-TE7",
+  "self":  "https://your-site.atlassian.net/browse/PROJ-TE7"
+}
+```
+
+## 3. Cucumber JSON
+
+Standard `cucumber-json` output:
+
+```json
+[
+  {
+    "uri": "features/login.feature",
+    "id": "login",
+    "name": "Login",
+    "elements": [
+      {
+        "id": "login;plus-sign-email-login",
+        "name": "Plus-sign email login",
+        "type": "scenario",
+        "tags": [{ "name": "@TEST_PROJ-T42" }],
+        "steps": [
+          { "keyword": "Given ", "name": "I am on the login page",
+            "result": { "status": "passed", "duration": 123000000 } },
+          { "keyword": "When ", "name": "I submit user+tag@x.com",
+            "result": { "status": "passed", "duration": 50000000 } },
+          { "keyword": "Then ", "name": "I see the dashboard",
+            "result": { "status": "failed",
+                        "error_message": "Timeout after 2000ms",
+                        "duration": 2100000000 } }
+        ]
+      }
+    ]
+  }
+]
+```
+
+Import:
+
+```
+curl -H "Authorization: Bearer $JWT" \
+     -H "Content-Type: application/json" \
+     --data-binary @cucumber.json \
+     "https://xray.cloud.getxray.app/api/v2/import/execution/cucumber?projectKey=PROJ"
+```
+
+Key rule: each scenario must carry `@TEST_PROJ-T<key>` in its
+tags for unambiguous mapping. Without the tag, Xray tries
+name-match, which drifts.
+
+## 4. Xray canonical JSON — full control
+
+When JUnit / Cucumber shapes don't fit (custom runner, need to
+upload evidence per step, need per-step actualResult):
+
+```json
+{
+  "info": {
+    "project":            "PROJ",
+    "summary":            "Smoke 2026-04-22 / staging",
+    "description":        "Automated run from CI #1087",
+    "user":               "<username or accountId>",
+    "revision":           "abc123",
+    "testPlanKey":        "PROJ-P7",
+    "testEnvironments":   ["staging"],
+    "startDate":          "2026-04-22T09:00:00Z",
+    "finishDate":         "2026-04-22T09:14:22Z"
+  },
+  "tests": [
+    {
+      "testKey":      "PROJ-T42",
+      "status":       "PASSED",
+      "comment":      "All three steps green.",
+      "executedBy":   "<username or accountId>",
+      "start":        "2026-04-22T09:00:00Z",
+      "finish":       "2026-04-22T09:02:11Z",
+      "steps": [
+        { "status": "PASSED", "actualResult": "Form visible" },
+        { "status": "PASSED", "actualResult": "Submit accepted" },
+        { "status": "PASSED", "actualResult": "Dashboard rendered 1.4s" }
+      ],
+      "evidence": [
+        { "filename": "final-dashboard.png",
+          "contentType": "image/png",
+          "data": "<base64>" }
+      ]
+    },
+    {
+      "testKey":    "PROJ-T43",
+      "status":     "FAILED",
+      "comment":    "Submit step timed out after 2s.",
+      "defects":    ["PROJ-201"]
+    }
+  ]
+}
+```
+
+Import:
+
+```
+curl -H "Authorization: Bearer $JWT" \
+     -H "Content-Type: application/json" \
+     --data-binary @xray-results.json \
+     "https://xray.cloud.getxray.app/api/v2/import/execution"
+```
+
+## 5. Validation after import — non-negotiable
+
+A 200 response does NOT prove the import landed correctly. Every
+import must be followed by:
+
+1. **Count check** — re-fetch the created Test Execution, count
+   `testRuns`. It must equal the number of cases in the source
+   report. A count of zero is the silent-fail signature of
+   broken mapping.
+2. **Status distribution check** — sum PASSED / FAILED / …
+   against the source report. Off-by-many is a mapping error;
+   off-by-one is often a skipped test reported as two rows.
+3. **Spot-check one PASSED and one FAILED** — verify the comment
+   / error message matches the source.
+4. **Evidence check** (if attached) — re-fetch each Test Run's
+   evidence list, confirm filenames / sizes.
+
+Cloud:
+
+```graphql
+query { getTestExecution(issueId: "<id>") {
+  jira(fields: ["key"])
+  testRuns(limit: 1000) {
+    total
+    results { status { name } test { jira(fields: ["key"]) } comment }
+  }
+} }
+```
+
+Server:
+
+```
+GET /rest/raven/2.0/api/testexec/PROJ-TE7/test
+```
+
+## 6. Common pitfalls
+
+- **`Unknown test: …`** / 0 runs imported — `classname` or
+  `@TEST_PROJ-…` tag doesn't map to an existing Test in the
+  target project. Fix the runner config OR pre-create the Tests.
+- **All runs show as `TODO`** — a status value your runner
+  emitted isn't in the project's status catalogue. Query
+  `getStatuses` / `/settings/teststatuses` and map explicitly.
+- **Evidence not attached** — base64 mis-encoded or
+  `contentType` missing. Xray silently drops malformed evidence
+  entries.
+- **Test Execution links to wrong Test Plan** — `testPlanKey`
+  query param was omitted; Execution was created without the
+  Plan link. Fix with an update, OR re-import with the param.
+- **Multiple TMs updating the same Execution race** — JUnit
+  multipart import is not atomic across concurrent posts. Import
+  per-suite sequentially, OR create one Execution per CI shard
+  and link all to the same Test Plan.
+- **Big reports time out** — split into chunks by suite or by
+  class, import sequentially into the same Execution with
+  `testExecKey=`.
+
+## 7. Choosing a format
+
+| Situation | Use |
+|---|---|
+| JS / Python / Java runners emit JUnit by default | JUnit |
+| BDD project (Cucumber / SpecFlow / Behave) | Cucumber JSON |
+| Custom runner; need per-step results + evidence | Xray canonical JSON |
+| .NET runner with NUnit/xUnit output | NUnit/xUnit |
+| Robot Framework and plugin is installed | Robot |
+| Unclear / heterogeneous pipelines | Xray canonical JSON (most control) |

--- a/skills/xray-testing/references/server-rest.md
+++ b/skills/xray-testing/references/server-rest.md
@@ -1,0 +1,278 @@
+# Xray Server / Data Center — REST API
+
+Xray Server / DC exposes its API under the Jira instance — no
+separate service. Base:
+
+```
+https://<your-jira>/rest/raven/2.0/   (v2 — preferred)
+https://<your-jira>/rest/raven/1.0/   (v1 — legacy endpoints)
+```
+
+## 1. Authentication
+
+Two options, same as Jira Server / DC itself:
+
+- **Personal Access Token (PAT)** — bearer token, preferred:
+  ```
+  Authorization: Bearer <PAT>
+  ```
+- **Basic auth** — username + password / API token:
+  ```
+  Authorization: Basic <base64(user:pass)>
+  ```
+
+Store in env (`JIRA_TOKEN` or `JIRA_USER` + `JIRA_TOKEN`).
+
+Xray Server uses Jira's permission model — the token needs the
+"Browse Projects" + Xray-app permissions on the target project.
+
+## 2. Endpoint map (v2 unless noted)
+
+### Test
+
+```
+GET  /rest/raven/2.0/api/test/<key>                → Test details
+GET  /rest/raven/2.0/api/test/<key>/step           → Steps (Manual)
+POST /rest/raven/2.0/api/test/<key>/step           → Add a step
+PUT  /rest/raven/2.0/api/test/<key>/step/<id>      → Update step
+DELETE /rest/raven/2.0/api/test/<key>/step/<id>    → Delete step
+GET  /rest/raven/2.0/api/test/<key>/preconditions  → Linked preconditions
+GET  /rest/raven/2.0/api/test/<key>/testsets       → Test Sets containing this Test
+GET  /rest/raven/2.0/api/test/<key>/testplans      → Test Plans containing this Test
+GET  /rest/raven/2.0/api/test/<key>/testexecutions → Test Executions containing this Test
+```
+
+Creating a Test is a two-step operation:
+
+```
+1. POST /rest/api/2/issue                          (standard Jira — creates the Test issue)
+   body: { fields: { project, summary, issuetype: { name: "Test" },
+                     "customfield_<TestType>": { "value": "Manual" } } }
+2. POST /rest/raven/2.0/api/test/<new-key>/step    (for each step)
+   body: { step: "<action>", data: "<data>", result: "<expected>" }
+```
+
+The Test Type custom-field ID (`customfield_XXXXX`) is
+project-dependent — fetch it once:
+
+```
+GET /rest/api/2/field
+→ find { "name": "Test Type", "id": "customfield_10200", ... }
+```
+
+Cache the field ID per session.
+
+### Precondition
+
+```
+GET  /rest/raven/2.0/api/precondition/<key>
+GET  /rest/raven/2.0/api/precondition/<key>/test   → Tests using this Precondition
+POST /rest/raven/2.0/api/test/<testKey>/preconditions
+     body: { "add": ["<preKey1>", "<preKey2>"] }
+```
+
+Create: same two-step pattern (Jira issue with `issuetype=Precondition` +
+type/body populated via Xray endpoints).
+
+### Test Set
+
+```
+GET  /rest/raven/2.0/api/testset/<key>
+GET  /rest/raven/2.0/api/testset/<key>/test        → Tests in the Test Set
+POST /rest/raven/2.0/api/testset/<key>/test
+     body: { "add": ["PROJ-T42", "PROJ-T43"] }
+POST /rest/raven/2.0/api/testset/<key>/test
+     body: { "remove": ["PROJ-T42"] }
+```
+
+Create the Test Set as a Jira issue (`issuetype=Test Set`), then
+add Tests with the endpoint above.
+
+### Test Plan
+
+```
+GET  /rest/raven/2.0/api/testplan/<key>
+GET  /rest/raven/2.0/api/testplan/<key>/test
+POST /rest/raven/2.0/api/testplan/<key>/test
+     body: { "add": ["PROJ-T42"] }
+```
+
+### Test Execution
+
+```
+GET  /rest/raven/2.0/api/testexec/<key>
+GET  /rest/raven/2.0/api/testexec/<key>/test       → List of Test Runs in this Execution
+POST /rest/raven/2.0/api/testexec/<key>/test
+     body: { "add": ["PROJ-T42"] }                 → Add tests to execute
+```
+
+Response from `/testexec/<key>/test` returns per-row:
+
+```json
+[
+  { "id":        123,
+    "status":    "TODO",
+    "testKey":   "PROJ-T42",
+    "rank":      1,
+    "testRunId": "abcd-1234..." }
+]
+```
+
+Note two IDs: the numeric `id` and the opaque `testRunId`. The
+Test Run endpoints use one or the other depending on version —
+check both in your responses.
+
+### Test Run
+
+```
+GET  /rest/raven/2.0/api/testrun/<id>              → Full Test Run
+PUT  /rest/raven/2.0/api/testrun/<id>              → Update status / comment / defects
+     body: {
+       "status":   "PASSED",
+       "comment":  "Verified on 2026-04-22 staging",
+       "defects":  ["PROJ-123"],
+       "executedBy": "<username>"
+     }
+POST /rest/raven/2.0/api/testrun/<id>/attachment   → Attach evidence (multipart)
+```
+
+Evidence upload is multipart:
+
+```
+POST /rest/raven/2.0/api/testrun/<id>/attachment
+Content-Type: multipart/form-data
+  field 'file' → the binary
+```
+
+### Steps of a Test Run (Manual steps)
+
+```
+GET  /rest/raven/2.0/api/testrun/<id>/step
+PUT  /rest/raven/2.0/api/testrun/<id>/step/<stepId>
+     body: { "status": "PASSED", "comment": "…",
+             "actualResult": "…", "defects": [...] }
+```
+
+### Statuses
+
+```
+GET /rest/raven/2.0/api/settings/teststatuses
+→ [ { "id": 1, "name": "TODO", "final": false, ... },
+    { "id": 2, "name": "EXECUTING", ... },
+    { "id": 3, "name": "PASSED", "final": true, ... },
+    { "id": 4, "name": "FAILED", "final": true, ... },
+    { "id": 5, "name": "ABORTED", ... },
+    { "id": 6, "name": "BLOCKED", ... } ]
+```
+
+Like Cloud, these are project-configurable. Always fetch before
+posting status values.
+
+## 3. Results import (brief — full details in results-import.md)
+
+The import endpoints accept multipart bodies or raw JSON depending
+on the format:
+
+```
+POST /rest/raven/2.0/import/execution/junit                (multipart)
+POST /rest/raven/2.0/import/execution/junit/multipart      (multi-file)
+POST /rest/raven/2.0/import/execution/testng               (multipart)
+POST /rest/raven/2.0/import/execution/cucumber             (JSON body)
+POST /rest/raven/2.0/import/execution                      (Xray JSON body)
+POST /rest/raven/2.0/import/execution/robot                (if Robot plugin present)
+```
+
+Common query params:
+
+- `projectKey=PROJ` — where to create the Test Execution
+- `testExecKey=PROJ-TE7` — append results to an existing Execution
+- `testPlanKey=PROJ-P7` — tie the Execution to a Test Plan
+- `fixVersion=1.4.0`, `revision=abc123`, `testEnvironments=staging`
+
+## 4. Worked example — end-to-end
+
+**Goal:** "Create a Manual Test for PROJ, add it to Test Set
+PROJ-TS10, create a Test Execution, and mark it PASSED."
+
+```
+# 1. Resolve Test Type custom-field ID
+GET /rest/api/2/field | jq '.[] | select(.name == "Test Type")'
+→ customfield_10200
+
+# 2. Create the Test issue
+POST /rest/api/2/issue
+{
+  "fields": {
+    "project":     { "key": "PROJ" },
+    "summary":     "Login with plus-sign email",
+    "issuetype":   { "name": "Test" },
+    "customfield_10200": { "value": "Manual" }
+  }
+}
+→ { "key": "PROJ-T42", ... }
+
+# 3. Add steps
+POST /rest/raven/2.0/api/test/PROJ-T42/step
+{ "step": "Open login page", "data": "", "result": "Form visible" }
+POST /rest/raven/2.0/api/test/PROJ-T42/step
+{ "step": "Submit user+tag@x.com", "data": "", "result": "Dashboard" }
+
+# 4. Add to Test Set
+POST /rest/raven/2.0/api/testset/PROJ-TS10/test
+{ "add": ["PROJ-T42"] }
+
+# 5. Create the Test Execution (Jira issue)
+POST /rest/api/2/issue
+{ "fields": { "project": { "key": "PROJ" },
+              "summary": "Smoke 2026-04-22",
+              "issuetype": { "name": "Test Execution" } } }
+→ { "key": "PROJ-TE7", ... }
+
+# 6. Add the Test to the Execution
+POST /rest/raven/2.0/api/testexec/PROJ-TE7/test
+{ "add": ["PROJ-T42"] }
+
+# 7. Fetch the Test Run id
+GET /rest/raven/2.0/api/testexec/PROJ-TE7/test
+→ [ { "id": 123, "status": "TODO", "testKey": "PROJ-T42", ... } ]
+
+# 8. Mark PASSED
+PUT /rest/raven/2.0/api/testrun/123
+{ "status": "PASSED",
+  "comment": "Verified 2026-04-22 / staging" }
+
+# 9. Re-fetch to confirm
+GET /rest/raven/2.0/api/testrun/123
+→ status: PASSED ✓
+```
+
+## 5. Error responses
+
+- **401 / 403** → token missing / lacks Xray permissions on the
+  project.
+- **400 with "Cannot find Test"** → wrong project key or the issue
+  isn't a Test (created with the wrong issue type or missing Test
+  Type custom field).
+- **"Invalid status"** → status value not in this project's
+  `/settings/teststatuses` set.
+- **Empty response on 200 after a successful attach** — some Jira
+  reverse proxies buffer 1xx/2xx responses with body; follow with
+  a GET to confirm.
+
+## 6. Cloud ↔ Server parity notes
+
+The entity model is identical; only the call shape differs.
+Translation table for the most common operations:
+
+| Operation | Cloud (GraphQL) | Server (REST) |
+|---|---|---|
+| Get Test | `getTest(issueId)` | `GET /api/test/<key>` |
+| Create Manual Test | `createTest` mutation | `POST /rest/api/2/issue` + `/api/test/<key>/step` |
+| Add Test → Test Set | `addTestsToTestSet` | `POST /api/testset/<key>/test { add: […] }` |
+| Create Test Execution | `createTestExecution` | `POST /rest/api/2/issue` + `/api/testexec/<key>/test` |
+| Mark Test Run | `updateTestRunStatus(id, status)` | `PUT /api/testrun/<id> { status }` |
+| Import JUnit | `POST /import/execution/junit` | `POST /import/execution/junit` |
+
+Keep your code behind a thin adapter — switching between Cloud
+and Server is plausible mid-project, and the call shapes are the
+only thing that changes.

--- a/skills/xray-testing/scripts/README.md
+++ b/skills/xray-testing/scripts/README.md
@@ -1,0 +1,278 @@
+# `xray.py` — CLI quick reference
+
+Stdlib-only Python CLI for Xray Cloud (GraphQL) and Server / DC
+(REST). **Fallback only** — when your host has an MCP server
+covering Xray (`mcp__Elitea_Dev__…`, `mcp__dmtools-cli__…`,
+`mcp__mcp-xray__…`), use the MCP tools instead. See
+`../SKILL.md § Transport priority` for the decision order. This
+script is what you run when no MCP matches the operation, the MCP
+is offline, or you're debugging the transport itself.
+
+For concepts and anti-patterns, read `../SKILL.md`. For the
+underlying API shapes, `../references/*.md`. This file covers the
+CLI surface only.
+
+## Install
+
+Requires **Python 3.9+**. Zero dependencies.
+
+```bash
+# From the project, symlink onto PATH (optional):
+ln -s "$(pwd)/.github/skills/xray-testing/scripts/xray.py" ~/.local/bin/xray
+# Or invoke directly:
+python3 .github/skills/xray-testing/scripts/xray.py --help
+```
+
+Swap `.github/` for `.claude/` / `.cursor/` / `.windsurf/`
+depending on where sdlc-skills installed.
+
+## Configure via environment
+
+Deployment is auto-detected. Override with `XRAY_DEPLOYMENT=cloud|server`.
+
+**Cloud** (Xray Cloud):
+
+```bash
+export XRAY_CLIENT_ID="..."              # from Jira → Apps → Xray → API Keys
+export XRAY_CLIENT_SECRET="..."
+export JIRA_BASE_URL="https://<site>.atlassian.net"
+
+# Region: pick `global` (default) or `eu`. This sets the Xray
+# Cloud base URL automatically. Set XRAY_BASE_URL below only if
+# you need a non-standard endpoint; it overrides the region.
+export XRAY_REGION="eu"                  # global | us | eu
+# export XRAY_BASE_URL="https://eu.xray.cloud.getxray.app"
+
+# Needed for commands that read issueId / accountId / custom-field IDs
+# (anything that touches /rest/api/3/*). Xray JWT does NOT auth Jira REST.
+export JIRA_USER="<your-atlassian-email>"
+export JIRA_TOKEN="<Jira API token — id.atlassian.com / Security>"
+```
+
+Xray-only commands (`config`, `auth-verify`, `statuses`) run without
+the JIRA_USER / JIRA_TOKEN pair. Anything that needs to resolve a
+Jira key (`test get`, `test create`, `coverage`, …) needs both.
+
+**Server / Data Center**:
+
+```bash
+export JIRA_BASE_URL="https://<your-jira>"
+export JIRA_TOKEN="<PAT>"              # preferred
+# Or basic auth:
+# export JIRA_USER="<username>"
+# export JIRA_TOKEN="<api-token>"
+```
+
+Shared:
+
+```bash
+# JWT cache location (cloud only). Default: ~/.cache/xray
+# export XRAY_CACHE_DIR=".xray-cache"
+```
+
+Never commit these values. Store in a local `.env` your runner
+sources, or in your shell profile.
+
+Sanity check:
+
+```bash
+xray config
+xray auth-verify
+```
+
+## Command surface
+
+Every write (`create`, `add`, `status`, `evidence`, `import`)
+re-fetches the target afterwards and compares counts / status.
+Exit **3** means the write landed but validation failed — check
+the target manually.
+
+### Test
+
+```bash
+# Read
+xray test get PROJ-T42
+xray test get PROJ-T42 --raw          # structured body (ADF / REST JSON)
+
+# Create (Manual)
+#   --steps file: JSON array of {action,data,result}
+#   or plain text: one step per line "action|data|result"
+xray test create --project PROJ --summary "login plus-sign email" \
+  --type Manual --steps steps.txt --assignee alex@example.com
+
+# Create AND link to the story it covers in one atomic call.
+# Uses Xray's coverage link (addTestsToRequirement), not the plain
+# Jira issuelinks field — see SKILL.md § "Link Tests to stories".
+# The script re-fetches the story's coverage and exits 3 if the
+# Test isn't in the list.
+xray test create --project PROJ --summary "login plus-sign email" \
+  --type Manual --steps steps.txt --link-to PROJ-123
+
+# Create (Cucumber / Generic)
+xray test create --project PROJ --summary "plus-sign scenario" \
+  --type Cucumber --gherkin scenario.feature
+xray test create --project PROJ --summary "perf budget for /login" \
+  --type Generic --definition definition.md
+
+# Mutate
+xray test add-step PROJ-T42 --action "Click Submit" \
+  --data "" --result "Dashboard renders within 2s"
+xray test link-requirement PROJ-T42 PROJ-123
+```
+
+### Test Set / Test Plan
+
+```bash
+xray testset add PROJ-TS10 PROJ-T42 PROJ-T43
+xray testplan add PROJ-P7 PROJ-T42 PROJ-T43
+```
+
+### Test Execution + Test Run
+
+```bash
+# Create an Execution (optionally linked to a Plan)
+xray exec create --project PROJ \
+  --summary "Smoke 2026-04-22 / staging" \
+  --tests PROJ-T42,PROJ-T43 \
+  --plan PROJ-P7
+
+# List runs inside an Execution (run-id, status, test key)
+xray exec list-runs PROJ-TE7
+
+# Update a run
+xray run status <runId> --set PASSED --comment "Verified 04-22 staging"
+xray run evidence <runId> --file path/to/screenshot.png
+```
+
+### Results import
+
+```bash
+# JUnit XML (multipart)
+xray import junit target/junit.xml \
+  --project PROJ --plan PROJ-P7 --env staging
+
+# Append to an existing Execution
+xray import junit target/junit.xml --exec PROJ-TE7
+
+# Cucumber JSON
+xray import cucumber cucumber-results.json --project PROJ --plan PROJ-P7
+
+# Canonical Xray JSON (project/plan/env come from the body)
+xray import xray-json results.json
+```
+
+All import commands check the resulting Test Execution's run
+count. **A count of zero is the silent-fail signature of broken
+mapping** (runner `classname`/`name` not matching any Jira Test
+key) — the script exits 3 in that case. Fix the mapping and
+re-import.
+
+### Coverage + statuses
+
+```bash
+xray coverage PROJ-123      # tests covering a requirement
+xray statuses               # project-allowed Test Run status list
+```
+
+## JSON output for scripting
+
+Pass `--json` (global flag, BEFORE the subcommand) to emit pure
+JSON:
+
+```bash
+xray --json test get PROJ-T42 | jq '.steps | length'
+xray --json exec list-runs PROJ-TE7 | jq '.[] | .id'
+```
+
+## Mapping conventions for results import
+
+The single biggest import-failure cause is a mismatch between
+runner output and Jira Test keys. Document the convention you
+choose in `.agents/testing.md`. Common patterns:
+
+| Convention | JUnit shape | Cucumber shape |
+|---|---|---|
+| Jira key in classname | `<testcase classname="PROJ-T42" name="..."/>` | n/a |
+| Tag-based (Cucumber) | n/a | `@TEST_PROJ-T42` on the scenario |
+| Jira key in labels | set `automation:<classname>` label on each Test | — |
+
+The script doesn't enforce a convention — it submits the report
+as-is and trusts Xray's project configuration. After the first
+import, spot-check that `xray exec list-runs <key>` shows the
+expected number of runs before automating further.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success; the write was re-fetched and verified against expected counts / status. |
+| `2` | Anything that prevented the intended call from completing successfully. Catch-all (see sub-categories below) — the accompanying `xray: <message>` on stderr names the specific cause. |
+| `3` | Write landed at the API (2xx) but post-write verification failed — mismatched step / test / run count, or the linked entity didn't appear on both sides. |
+
+`2` is overloaded by design (single exit code keeps shell scripts
+simple) — the stderr message disambiguates. Common sub-categories
+and the phrasing they use:
+
+| Sub-category | Example stderr line |
+|---|---|
+| CLI arg / argparse error | `usage: xray …` followed by argparse's own messages |
+| Missing env / config | `xray: JIRA_BASE_URL is required on cloud.` |
+| Auth failure | `xray: /authenticate returned 401` |
+| Network / HTTP error | `xray: HTTP 503 on POST /rest/raven/2.0/api/testexec` |
+| Xray GraphQL error | `xray: GraphQL error: field 'testIssueIds' is required` |
+| Unresolvable identity | `xray: no user found for query 'alice'` |
+| Malformed response | `xray: unexpected /rest/api/2/field response` |
+
+If you're scripting around the CLI and need to distinguish these
+programmatically, grep the stderr line (it's always prefixed with
+`xray:`). A v0.2 could split `2` into finer-grained codes — but the
+current contract is `0` = verified ok, `2` = broke before verify,
+`3` = API accepted but verify caught divergence.
+
+## Extending this script
+
+The CLI is a living tool, not frozen source. Agents using it are
+**explicitly allowed to fix or extend `xray.py`** when they hit one
+of these during real use — modify the script + this README as part
+of the same task, don't route around:
+
+- A real bug (auth flow edge case, wrong default, pagination error,
+  GraphQL limit mismatch, off-by-one, mis-typed env var)
+- A missing capability needed for a legitimate workflow (new import
+  format, unused entity operation, richer error output, extra
+  subcommand that parallels a new MCP tool)
+- Error messages too terse to diagnose from — expand them
+- A regional endpoint or tenant variation the script doesn't handle
+
+**What to preserve while editing:**
+
+- Existing subcommand names + env var names — don't break agents or
+  humans that already scripted against them
+- The `0 / 2 / 3` exit-code contract (success / usage-or-HTTP /
+  write-verification-failed)
+- The re-fetch-and-verify discipline after every write — if you add
+  a new write subcommand, add its matching verification
+- Stdlib-only (`urllib.request`, `base64`, `json`, …). No new
+  dependencies
+- Python 3.9+ compatibility
+
+**After editing:**
+
+- Syntax-check with
+  `python3 -c "import ast; ast.parse(open('xray.py').read())"`
+  before you claim you're done.
+- Run `xray config` + `xray auth-verify` against a reachable Xray
+  instance if you have credentials; otherwise state in your reply
+  that the change is syntax-verified only.
+- Update this README to match (command surface, env vars, exit codes).
+- Commit with a message that names the specific case you hit ("Fix
+  exec list-runs limit — Xray caps at 100" is good; "update script"
+  is not).
+
+## Graceful degradation
+
+If the Xray API is unreachable (rejected credentials, regional
+mismatch, outage) you can still do meaningful work via Jira REST
+alone — list / filter Tests by type, read issue shells, file
+defects. See `../references/jira-rest-fallback.md` for the full
+capability matrix in that degraded mode.

--- a/skills/xray-testing/scripts/xray.py
+++ b/skills/xray-testing/scripts/xray.py
@@ -1,0 +1,1060 @@
+#!/usr/bin/env python3
+"""Xray CLI — thin HTTP surface over Xray Cloud (GraphQL) and Server/DC (REST).
+
+See ../SKILL.md and ../references/*.md for the concepts; this script is
+the fallback when an MCP tool isn't wired. Every write verifies itself by
+re-fetching the target and checking counts / status. Stdlib only.
+
+Jira REST API version
+---------------------
+This CLI hits `/rest/api/2/...` for its Jira lookups (`issue/{key}`,
+`user/search`, `field`). v2 vs v3 differs materially for rich-text
+fields (v2 returns wiki markup on Cloud, v3 returns ADF), but this
+CLI only ever reads `id` / `summary` / `accountId` / field metadata
+— none of which differ between versions — so v2 is retained for
+simplicity. The sibling `atlassian-content` skill uses v3 where
+rich-text shape matters.
+
+Environment
+-----------
+Deployment is auto-detected. Override with XRAY_DEPLOYMENT=cloud|server.
+
+  Cloud:
+    XRAY_CLIENT_ID       client ID from Jira → Apps → Xray → API Keys
+    XRAY_CLIENT_SECRET   the secret paired with XRAY_CLIENT_ID
+    JIRA_BASE_URL        https://<site>.atlassian.net        (for issueId lookups)
+    XRAY_BASE_URL        https://xray.cloud.getxray.app/api/v2 (optional)
+
+  Server / DC:
+    JIRA_BASE_URL        https://<your-jira>
+    JIRA_TOKEN           PAT (preferred) or API token
+    JIRA_USER            only for basic auth (paired with JIRA_TOKEN)
+
+Cache
+-----
+  XRAY_CACHE_DIR         default ~/.cache/xray    (JWT cache for Cloud)
+
+Output
+------
+Default is human-readable. Pass --json for pure JSON on stdout so you can
+pipe to jq. Non-zero exit on any validation mismatch after a write.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import dataclasses
+import json
+import mimetypes
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Config + environment
+# ────────────────────────────────────────────────────────────────────────
+
+DEFAULT_CLOUD_BASE = "https://xray.cloud.getxray.app/api/v2"
+
+# Regional Xray Cloud endpoints. Set XRAY_REGION to pick one without
+# having to spell out XRAY_BASE_URL (XRAY_BASE_URL still wins if both are set).
+# If your tenant is on a region not listed here, set XRAY_BASE_URL directly.
+XRAY_REGION_BASES = {
+    "global": "https://xray.cloud.getxray.app/api/v2",
+    "us":     "https://xray.cloud.getxray.app/api/v2",  # alias for global
+    "eu":     "https://eu.xray.cloud.getxray.app/api/v2",
+    "au":     "https://au.xray.cloud.getxray.app/api/v2",
+    "apac":   "https://au.xray.cloud.getxray.app/api/v2",  # alias for au
+}
+
+
+@dataclasses.dataclass
+class Config:
+    deployment: str                # "cloud" | "server"
+    xray_base_url: str             # /api/v2 root (cloud) OR /rest/raven/2.0 root (server)
+    jira_base_url: str             # for Jira REST lookups (issueId)
+    auth_header: str               # Authorization header for Xray API calls
+    jira_auth_header: str | None   # Authorization for Jira REST; None on Cloud without JIRA_USER+JIRA_TOKEN
+    cache_dir: Path
+    # Lazily-populated cache of Jira custom fields (name → id). Populated
+    # on first `custom_field_id()` call and reused for subsequent lookups
+    # in the same process — avoids fetching `/rest/api/2/field` three times
+    # for a single Server `test create` (Test Type, Generic Definition,
+    # Cucumber Content).
+    _field_cache: dict[str, str] | None = None
+
+
+def _die(msg: str, code: int = 2) -> None:
+    print(f"xray: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def load_config() -> Config:
+    deployment = os.environ.get("XRAY_DEPLOYMENT", "").strip().lower()
+    client_id = os.environ.get("XRAY_CLIENT_ID", "").strip()
+    client_secret = os.environ.get("XRAY_CLIENT_SECRET", "").strip()
+    jira_base_url = os.environ.get("JIRA_BASE_URL", "").strip().rstrip("/")
+    jira_token = os.environ.get("JIRA_TOKEN", "").strip()
+    jira_user = os.environ.get("JIRA_USER", "").strip()
+    cache_dir = Path(os.environ.get("XRAY_CACHE_DIR", Path.home() / ".cache" / "xray"))
+
+    if not deployment:
+        if client_id and client_secret:
+            deployment = "cloud"
+        elif jira_token:
+            deployment = "server"
+        else:
+            _die(
+                "cannot detect deployment. Set XRAY_CLIENT_ID+XRAY_CLIENT_SECRET "
+                "for cloud, or JIRA_TOKEN (+JIRA_BASE_URL) for server, "
+                "or export XRAY_DEPLOYMENT=cloud|server."
+            )
+
+    if deployment == "cloud":
+        if not (client_id and client_secret):
+            _die("cloud deployment requires XRAY_CLIENT_ID + XRAY_CLIENT_SECRET.")
+        if not jira_base_url:
+            _die("JIRA_BASE_URL is required on cloud.")
+        # Resolve Xray base URL: XRAY_BASE_URL (exact) > XRAY_REGION lookup > default global.
+        raw_base = os.environ.get("XRAY_BASE_URL", "").strip()
+        if raw_base:
+            xray_base_url = raw_base.rstrip("/")
+        else:
+            region = os.environ.get("XRAY_REGION", "global").strip().lower()
+            if region not in XRAY_REGION_BASES:
+                _die(
+                    f"unknown XRAY_REGION={region!r}. "
+                    f"Known aliases: {', '.join(sorted(XRAY_REGION_BASES))}. "
+                    "If your tenant is on a non-listed region, set "
+                    "XRAY_BASE_URL to the exact endpoint."
+                )
+            xray_base_url = XRAY_REGION_BASES[region]
+        # Tolerate base URL without /api/v2 suffix so bare regional URLs work
+        # (e.g. XRAY_BASE_URL=https://eu.xray.cloud.getxray.app).
+        if not xray_base_url.endswith("/api/v2"):
+            xray_base_url = xray_base_url + "/api/v2"
+        jwt = _cloud_get_jwt(xray_base_url, client_id, client_secret, cache_dir)
+        auth_header = f"Bearer {jwt}"
+        # Jira REST on Cloud uses email+API-token via Basic auth; the Xray JWT
+        # does NOT authenticate against /rest/api/3/*.
+        if jira_user and jira_token:
+            raw = f"{jira_user}:{jira_token}".encode()
+            jira_auth_header = "Basic " + base64.b64encode(raw).decode()
+        else:
+            jira_auth_header = None
+    elif deployment == "server":
+        if not jira_base_url:
+            _die("server deployment requires JIRA_BASE_URL.")
+        if not jira_token:
+            _die("server deployment requires JIRA_TOKEN.")
+        xray_base_url = f"{jira_base_url}/rest/raven/2.0"
+        if jira_user:
+            raw = f"{jira_user}:{jira_token}".encode()
+            auth_header = "Basic " + base64.b64encode(raw).decode()
+        else:
+            auth_header = f"Bearer {jira_token}"
+        # Same credential authenticates both Xray-on-Jira and Jira REST on Server/DC.
+        jira_auth_header = auth_header
+    else:
+        _die(f"unknown XRAY_DEPLOYMENT: {deployment!r}")
+        raise SystemExit(2)  # unreachable, for type checkers
+
+    return Config(
+        deployment=deployment,
+        xray_base_url=xray_base_url,
+        jira_base_url=jira_base_url,
+        auth_header=auth_header,
+        jira_auth_header=jira_auth_header,
+        cache_dir=cache_dir,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────
+# HTTP
+# ────────────────────────────────────────────────────────────────────────
+
+def _http(
+    url: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    data: bytes | None = None,
+    expect_json: bool = True,
+) -> Any:
+    req = urllib.request.Request(url, method=method, data=data, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as e:  # includes 4xx / 5xx
+        detail = e.read().decode("utf-8", "replace")[:2000]
+        _die(f"HTTP {e.code} on {method} {url}\n  {detail}")
+    except urllib.error.URLError as e:
+        _die(f"network error on {method} {url}: {e.reason}")
+
+    if not body:
+        return None
+    if expect_json:
+        try:
+            return json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            return body.decode("utf-8", "replace")
+    return body
+
+
+def _cloud_get_jwt(base_url: str, client_id: str, client_secret: str, cache_dir: Path) -> str:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_file = cache_dir / "token.json"
+    now = int(time.time())
+
+    if cache_file.exists():
+        try:
+            cached = json.loads(cache_file.read_text())
+            # Cache hit requires matching base URL **and** client_id —
+            # otherwise rotating XRAY_CLIENT_ID (or switching tenants at
+            # the same base URL) would silently reuse the stale JWT
+            # until expiry.
+            if (
+                cached.get("base_url") == base_url
+                and cached.get("client_id") == client_id
+                and cached.get("expires_at", 0) > now + 60
+            ):
+                return cached["jwt"]
+        except Exception:
+            pass
+
+    payload = json.dumps({
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }).encode()
+    jwt = _http(
+        f"{base_url}/authenticate",
+        method="POST",
+        headers={"Content-Type": "application/json"},
+        data=payload,
+        expect_json=True,
+    )
+    if not isinstance(jwt, str):
+        _die(f"unexpected /authenticate response type: {type(jwt).__name__}")
+    # Xray JWTs live ~24h; cache 23h to be safe.
+    cache_file.write_text(json.dumps({
+        "base_url": base_url,
+        "client_id": client_id,
+        "jwt": jwt,
+        "expires_at": now + 23 * 3600,
+    }))
+    try:
+        cache_file.chmod(0o600)
+    except OSError:
+        pass
+    return jwt
+
+
+def _call_xray(
+    cfg: Config,
+    path: str,
+    *,
+    method: str = "GET",
+    params: dict[str, Any] | None = None,
+    json_body: Any = None,
+    multipart: list[tuple[str, str, bytes, str]] | None = None,
+) -> Any:
+    url = cfg.xray_base_url + path
+    if params:
+        flat = {k: v for k, v in params.items() if v is not None}
+        if flat:
+            url = url + ("&" if "?" in url else "?") + urllib.parse.urlencode(flat)
+    headers = {"Authorization": cfg.auth_header}
+    data: bytes | None = None
+
+    if multipart is not None:
+        boundary = "----xray-boundary-" + uuid.uuid4().hex
+        headers["Content-Type"] = f"multipart/form-data; boundary={boundary}"
+        data = _encode_multipart(multipart, boundary)
+    elif json_body is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(json_body).encode()
+
+    return _http(url, method=method, headers=headers, data=data)
+
+
+def _call_jira(cfg: Config, path: str, *, method: str = "GET", json_body: Any = None) -> Any:
+    if not cfg.jira_auth_header:
+        _die(
+            "Jira REST call requires JIRA_USER (email) + JIRA_TOKEN on cloud. "
+            "Set both to enable issueId / accountId / field-id lookups."
+        )
+    url = cfg.jira_base_url + path
+    headers = {"Authorization": cfg.jira_auth_header, "Accept": "application/json"}
+    data: bytes | None = None
+    if json_body is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(json_body).encode()
+    return _http(url, method=method, headers=headers, data=data)
+
+
+def _encode_multipart(
+    parts: list[tuple[str, str, bytes, str]], boundary: str
+) -> bytes:
+    """parts: list of (field_name, filename, data, content_type)."""
+    crlf = b"\r\n"
+    buf: list[bytes] = []
+    for name, filename, content, ctype in parts:
+        buf.append(f"--{boundary}".encode())
+        disp = f'Content-Disposition: form-data; name="{name}"; filename="{filename}"'
+        buf.append(disp.encode())
+        buf.append(f"Content-Type: {ctype}".encode())
+        buf.append(b"")
+        buf.append(content)
+    buf.append(f"--{boundary}--".encode())
+    buf.append(b"")
+    return crlf.join(buf)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Shared identity helpers
+# ────────────────────────────────────────────────────────────────────────
+
+def resolve_issue_id(cfg: Config, key: str) -> str:
+    """Jira numeric issueId (required by Cloud GraphQL)."""
+    data = _call_jira(cfg, f"/rest/api/2/issue/{key}?fields=summary")
+    if not isinstance(data, dict) or "id" not in data:
+        _die(f"could not resolve issueId for {key}")
+    return str(data["id"])
+
+
+def resolve_account_id(cfg: Config, query: str) -> str:
+    """Cloud: resolve an email / display-name to an accountId.
+
+    Server / DC: Jira expects a **username**, not an accountId — the input
+    is returned as-is and the caller is responsible for passing a valid
+    Server username. Passing an email (e.g. `alice@example.com`) on Server
+    will cause Jira to reject the subsequent create/update with a
+    ``user not found`` error; use the operator's Jira username instead.
+    """
+    if cfg.deployment != "cloud":
+        return query  # server uses username directly — see docstring above
+    data = _call_jira(
+        cfg, "/rest/api/2/user/search?query=" + urllib.parse.quote(query)
+    )
+    if not isinstance(data, list) or not data:
+        _die(f"no user found for query {query!r}")
+    if len(data) > 1:
+        _die(
+            f"ambiguous user query {query!r} matched {len(data)} users; "
+            "narrow it down (e.g. use email)."
+        )
+    return data[0]["accountId"]
+
+
+def custom_field_id(cfg: Config, field_name: str) -> str:
+    """Server-only: resolve a custom-field name to its customfield_XXXXX id.
+
+    Memoized on the Config instance — a single ``test create`` can trigger
+    three lookups (Test Type, Generic Definition, Cucumber Content) on
+    Server, and ``/rest/api/2/field`` is a full-catalog response; we fetch
+    it once per process.
+    """
+    if cfg._field_cache is None:
+        data = _call_jira(cfg, "/rest/api/2/field")
+        if not isinstance(data, list):
+            _die("unexpected /rest/api/2/field response")
+        cfg._field_cache = {
+            fld["name"]: fld["id"]
+            for fld in data
+            if isinstance(fld, dict) and "name" in fld and "id" in fld
+        }
+    if field_name in cfg._field_cache:
+        return cfg._field_cache[field_name]
+    _die(f"custom field {field_name!r} not found in this Jira project.")
+    raise SystemExit(2)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# GraphQL helper (Cloud)
+# ────────────────────────────────────────────────────────────────────────
+
+def _graphql(cfg: Config, query: str, variables: dict[str, Any] | None = None) -> Any:
+    body = {"query": query, "variables": variables or {}}
+    out = _call_xray(cfg, "/graphql", method="POST", json_body=body)
+    if isinstance(out, dict) and out.get("errors"):
+        msgs = "; ".join(e.get("message", "?") for e in out["errors"])
+        _die(f"GraphQL error: {msgs}")
+    if not isinstance(out, dict):
+        _die(f"unexpected GraphQL response shape: {type(out).__name__}")
+    return out.get("data")
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Entity ops — dispatched on cfg.deployment
+# ────────────────────────────────────────────────────────────────────────
+
+def test_get(cfg: Config, key: str) -> dict:
+    if cfg.deployment == "cloud":
+        issue_id = resolve_issue_id(cfg, key)
+        data = _graphql(cfg, """
+            query($id: String!) {
+              getTest(issueId: $id) {
+                issueId projectId
+                testType { name kind }
+                jira(fields: ["key","summary","status"])
+                steps { id action data result attachments { filename } }
+                gherkin
+                unstructured
+                preconditions(limit: 50) { total results { jira(fields:["key","summary"]) } }
+              }
+            }
+        """, {"id": issue_id})
+        test = (data or {}).get("getTest") or _die(f"Test {key} not found.")
+        return test
+    # server
+    t = _call_xray(cfg, f"/api/test/{key}")
+    steps = _call_xray(cfg, f"/api/test/{key}/step") or []
+    pre = _call_xray(cfg, f"/api/test/{key}/preconditions") or []
+    if not isinstance(t, dict):
+        _die(f"Test {key} not found or wrong issue type.")
+    t["steps"] = steps
+    t["preconditions"] = pre
+    return t
+
+
+def test_create(
+    cfg: Config,
+    project_key: str,
+    summary: str,
+    test_type: str,
+    steps: list[dict] | None,
+    gherkin: str | None,
+    definition: str | None,
+    assignee: str | None,
+) -> str:
+    if cfg.deployment == "cloud":
+        jira_fields: dict[str, Any] = {"project": {"key": project_key}, "summary": summary}
+        if assignee:
+            jira_fields["assignee"] = {"accountId": resolve_account_id(cfg, assignee)}
+        variables: dict[str, Any] = {
+            "tt": {"name": test_type},
+            "jira": {"fields": jira_fields},
+        }
+        mutation = """
+          mutation($tt: UpdateTestTypeInput!, $jira: JSON!,
+                   $steps: [CreateStepInput], $gherkin: String, $unstructured: String) {
+            createTest(testType: $tt, jira: $jira,
+                       steps: $steps, gherkin: $gherkin, unstructured: $unstructured) {
+              test { issueId jira(fields: ["key"]) }
+              warnings
+            }
+          }
+        """
+        if test_type == "Manual":
+            variables["steps"] = steps or []
+        elif test_type == "Cucumber":
+            variables["gherkin"] = gherkin or ""
+        else:
+            variables["unstructured"] = definition or ""
+        data = _graphql(cfg, mutation, variables)
+        node = ((data or {}).get("createTest") or {}).get("test") or _die("createTest returned no test.")
+        key = node["jira"]["key"]
+        return key
+    # server
+    tt_field = custom_field_id(cfg, "Test Type")
+    fields: dict[str, Any] = {
+        "project":   {"key": project_key},
+        "summary":   summary,
+        "issuetype": {"name": "Test"},
+        tt_field:    {"value": test_type},
+    }
+    if assignee:
+        fields["assignee"] = {"name": assignee}
+    if test_type == "Generic" and definition:
+        defn_field = custom_field_id(cfg, "Generic Test Definition")
+        fields[defn_field] = definition
+    if test_type == "Cucumber" and gherkin:
+        gherkin_field = custom_field_id(cfg, "Cucumber Test Content")
+        fields[gherkin_field] = gherkin
+    created = _call_jira(cfg, "/rest/api/2/issue", method="POST", json_body={"fields": fields})
+    key = created["key"]
+    if test_type == "Manual":
+        for step in steps or []:
+            _call_xray(cfg, f"/api/test/{key}/step", method="POST", json_body={
+                "step": step.get("action", ""),
+                "data": step.get("data", ""),
+                "result": step.get("result", ""),
+            })
+    return key
+
+
+def test_add_step(cfg: Config, key: str, action: str, data_val: str, result: str) -> None:
+    if cfg.deployment == "cloud":
+        issue_id = resolve_issue_id(cfg, key)
+        _graphql(cfg, """
+            mutation($id: String!, $step: CreateStepInput!) {
+              addTestStep(issueId: $id, step: $step) { warnings }
+            }
+        """, {"id": issue_id, "step": {"action": action, "data": data_val, "result": result}})
+        return
+    _call_xray(cfg, f"/api/test/{key}/step", method="POST", json_body={
+        "step": action, "data": data_val, "result": result,
+    })
+
+
+def test_link_requirement(cfg: Config, test_key: str, req_key: str) -> None:
+    if cfg.deployment == "cloud":
+        _graphql(cfg, """
+            mutation($req: String!, $tests: [String]!) {
+              addTestsToRequirement(issueId: $req, testIssueIds: $tests) { addedTests warning }
+            }
+        """, {"req": resolve_issue_id(cfg, req_key),
+              "tests": [resolve_issue_id(cfg, test_key)]})
+        return
+    _call_xray(cfg, f"/api/test/{test_key}/requirement",
+               method="POST", json_body={"add": [req_key]})
+
+
+def testset_add(cfg: Config, set_key: str, test_keys: list[str]) -> None:
+    if cfg.deployment == "cloud":
+        _graphql(cfg, """
+            mutation($id: String!, $tests: [String]!) {
+              addTestsToTestSet(issueId: $id, testIssueIds: $tests) { addedTests warning }
+            }
+        """, {"id": resolve_issue_id(cfg, set_key),
+              "tests": [resolve_issue_id(cfg, k) for k in test_keys]})
+        return
+    _call_xray(cfg, f"/api/testset/{set_key}/test",
+               method="POST", json_body={"add": test_keys})
+
+
+def testplan_add(cfg: Config, plan_key: str, test_keys: list[str]) -> None:
+    if cfg.deployment == "cloud":
+        _graphql(cfg, """
+            mutation($id: String!, $tests: [String]!) {
+              addTestsToTestPlan(issueId: $id, testIssueIds: $tests) { addedTests warning }
+            }
+        """, {"id": resolve_issue_id(cfg, plan_key),
+              "tests": [resolve_issue_id(cfg, k) for k in test_keys]})
+        return
+    _call_xray(cfg, f"/api/testplan/{plan_key}/test",
+               method="POST", json_body={"add": test_keys})
+
+
+def exec_create(
+    cfg: Config,
+    project_key: str,
+    summary: str,
+    test_keys: list[str],
+    plan_key: str | None,
+) -> str:
+    if cfg.deployment == "cloud":
+        variables: dict[str, Any] = {
+            "tests": [resolve_issue_id(cfg, k) for k in test_keys],
+            "jira":  {"fields": {"project": {"key": project_key}, "summary": summary}},
+        }
+        if plan_key:
+            variables["plan"] = resolve_issue_id(cfg, plan_key)
+            mutation = """
+              mutation($plan: String!, $tests: [String]!, $jira: JSON!) {
+                createTestExecution(testPlanIssueId: $plan,
+                                    testIssueIds: $tests, jira: $jira) {
+                  testExecution { jira(fields: ["key"]) } warnings
+                }
+              }
+            """
+        else:
+            mutation = """
+              mutation($tests: [String]!, $jira: JSON!) {
+                createTestExecution(testIssueIds: $tests, jira: $jira) {
+                  testExecution { jira(fields: ["key"]) } warnings
+                }
+              }
+            """
+        data = _graphql(cfg, mutation, variables)
+        node = ((data or {}).get("createTestExecution") or {}).get("testExecution") \
+            or _die("createTestExecution returned no execution.")
+        return node["jira"]["key"]
+    # server
+    created = _call_jira(cfg, "/rest/api/2/issue", method="POST", json_body={
+        "fields": {
+            "project":   {"key": project_key},
+            "summary":   summary,
+            "issuetype": {"name": "Test Execution"},
+        },
+    })
+    exec_key = created["key"]
+    if test_keys:
+        _call_xray(cfg, f"/api/testexec/{exec_key}/test",
+                   method="POST", json_body={"add": test_keys})
+    if plan_key:
+        _call_xray(cfg, f"/api/testplan/{plan_key}/testexecution",
+                   method="POST", json_body={"add": [exec_key]})
+    return exec_key
+
+
+def exec_list_runs(cfg: Config, exec_key: str) -> list[dict]:
+    if cfg.deployment == "cloud":
+        issue_id = resolve_issue_id(cfg, exec_key)
+        # Xray caps `limit` at 100 per query; paginate with `start`.
+        results: list[dict] = []
+        start = 0
+        while True:
+            data = _graphql(cfg, """
+                query($id: String!, $start: Int!) {
+                  getTestExecution(issueId: $id) {
+                    testRuns(limit: 100, start: $start) {
+                      total
+                      results {
+                        id
+                        status { name }
+                        test { jira(fields: ["key","summary"]) }
+                      }
+                    }
+                  }
+                }
+            """, {"id": issue_id, "start": start})
+            tr = ((data or {}).get("getTestExecution") or {}).get("testRuns") or {}
+            batch = tr.get("results") or []
+            results.extend(batch)
+            total = tr.get("total") or 0
+            start += len(batch)
+            if len(batch) == 0 or start >= total:
+                break
+        return results
+    rows = _call_xray(cfg, f"/api/testexec/{exec_key}/test") or []
+    return rows if isinstance(rows, list) else []
+
+
+def run_set_status(cfg: Config, run_id: str, status: str, comment: str | None) -> None:
+    if cfg.deployment == "cloud":
+        _graphql(cfg, """
+            mutation($id: String!, $status: String!) {
+              updateTestRunStatus(id: $id, status: $status) { warnings }
+            }
+        """, {"id": run_id, "status": status})
+        if comment:
+            _graphql(cfg, """
+                mutation($id: String!, $c: String!) {
+                  updateTestRunComment(id: $id, comment: $c) { warnings }
+                }
+            """, {"id": run_id, "c": comment})
+        return
+    body: dict[str, Any] = {"status": status}
+    if comment:
+        body["comment"] = comment
+    _call_xray(cfg, f"/api/testrun/{run_id}", method="PUT", json_body=body)
+
+
+def run_add_evidence(cfg: Config, run_id: str, file_path: Path) -> None:
+    content = file_path.read_bytes()
+    ctype = mimetypes.guess_type(str(file_path))[0] or "application/octet-stream"
+    if cfg.deployment == "cloud":
+        _graphql(cfg, """
+            mutation($id: String!, $ev: [AttachmentDataInput]) {
+              addEvidenceToTestRun(id: $id, evidence: $ev) { warnings }
+            }
+        """, {"id": run_id, "ev": [{
+            "filename": file_path.name,
+            "mimeType": ctype,
+            "data": base64.b64encode(content).decode(),
+        }]})
+        return
+    _call_xray(
+        cfg, f"/api/testrun/{run_id}/attachment",
+        method="POST",
+        multipart=[("file", file_path.name, content, ctype)],
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Results import
+# ────────────────────────────────────────────────────────────────────────
+
+def _import_query(project_key: str, plan_key: str | None, env: str | None,
+                  exec_key: str | None) -> dict[str, str]:
+    return {
+        "projectKey":       project_key if not exec_key else None,
+        "testExecKey":      exec_key,
+        "testPlanKey":      plan_key,
+        "testEnvironments": env,
+    }
+
+
+def import_junit(cfg: Config, path: Path, project_key: str, plan_key: str | None,
+                 env: str | None, exec_key: str | None) -> str:
+    content = path.read_bytes()
+    res = _call_xray(
+        cfg, "/import/execution/junit",
+        method="POST",
+        params=_import_query(project_key, plan_key, env, exec_key),
+        multipart=[("file", path.name, content, "application/xml")],
+    )
+    key = _extract_exec_key(res)
+    return key
+
+
+def import_cucumber(cfg: Config, path: Path, project_key: str,
+                    plan_key: str | None, env: str | None, exec_key: str | None) -> str:
+    content = json.loads(path.read_text())
+    res = _call_xray(
+        cfg, "/import/execution/cucumber",
+        method="POST",
+        params=_import_query(project_key, plan_key, env, exec_key),
+        json_body=content,
+    )
+    return _extract_exec_key(res)
+
+
+def import_xray_json(cfg: Config, path: Path) -> str:
+    content = json.loads(path.read_text())
+    res = _call_xray(cfg, "/import/execution", method="POST", json_body=content)
+    return _extract_exec_key(res)
+
+
+def _extract_exec_key(resp: Any) -> str:
+    if isinstance(resp, dict):
+        if "key" in resp:
+            return resp["key"]
+        tr = resp.get("testExecIssue") or resp.get("testExecIssueKey")
+        if isinstance(tr, dict) and "key" in tr:
+            return tr["key"]
+        if isinstance(tr, str):
+            return tr
+    _die(f"could not locate Test Execution key in import response: {resp!r}")
+    raise SystemExit(2)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Misc queries
+# ────────────────────────────────────────────────────────────────────────
+
+def coverage(cfg: Config, req_key: str) -> list[dict]:
+    if cfg.deployment == "cloud":
+        issue_id = resolve_issue_id(cfg, req_key)
+        results: list[dict] = []
+        start = 0
+        while True:
+            data = _graphql(cfg, """
+                query($id: String!, $start: Int!) {
+                  getCoverableIssue(issueId: $id) {
+                    tests(limit: 100, start: $start) {
+                      total
+                      results { jira(fields: ["key","summary"]) }
+                    }
+                  }
+                }
+            """, {"id": issue_id, "start": start})
+            inner = ((data or {}).get("getCoverableIssue") or {}).get("tests") or {}
+            batch = inner.get("results") or []
+            results.extend(batch)
+            total = inner.get("total") or 0
+            start += len(batch)
+            if len(batch) == 0 or start >= total:
+                break
+        return results
+    rows = _call_xray(cfg, f"/api/requirement/{req_key}/test") or []
+    return rows if isinstance(rows, list) else []
+
+
+def statuses(cfg: Config) -> list[dict]:
+    if cfg.deployment == "cloud":
+        data = _graphql(cfg, "query { getStatuses { name description color final } }")
+        return (data or {}).get("getStatuses") or []
+    rows = _call_xray(cfg, "/api/settings/teststatuses") or []
+    return rows if isinstance(rows, list) else []
+
+
+# ────────────────────────────────────────────────────────────────────────
+# Output helpers
+# ────────────────────────────────────────────────────────────────────────
+
+def _out(args: argparse.Namespace, data: Any, human: str | None = None) -> None:
+    if getattr(args, "json", False):
+        print(json.dumps(data, indent=2, sort_keys=True))
+    elif human is not None:
+        print(human)
+    else:
+        print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def _parse_steps_file(path: Path | None) -> list[dict]:
+    if not path:
+        return []
+    raw = path.read_text()
+    if path.suffix == ".json":
+        data = json.loads(raw)
+        if not isinstance(data, list):
+            _die("--steps file must contain a JSON array of {action,data,result} objects.")
+        return data
+    # plain text: one step per line with "|" separator
+    out: list[dict] = []
+    for line in raw.splitlines():
+        if not line.strip() or line.strip().startswith("#"):
+            continue
+        parts = [p.strip() for p in line.split("|", 2)]
+        while len(parts) < 3:
+            parts.append("")
+        out.append({"action": parts[0], "data": parts[1], "result": parts[2]})
+    return out
+
+
+# ────────────────────────────────────────────────────────────────────────
+# CLI
+# ────────────────────────────────────────────────────────────────────────
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="xray", description="Xray CLI (stdlib-only).")
+    p.add_argument("--json", action="store_true",
+                   help="emit JSON on stdout (default: human-readable).")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("config", help="print effective configuration.")
+    sub.add_parser("statuses", help="list project-allowed Test Run statuses.")
+    sub.add_parser("auth-verify", help="one-shot API reachability check.")
+
+    # test
+    t = sub.add_parser("test", help="Test CRUD.").add_subparsers(dest="sub", required=True)
+    tg = t.add_parser("get"); tg.add_argument("key")
+    tg.add_argument("--raw", action="store_true")
+    tc = t.add_parser("create")
+    tc.add_argument("--project", required=True)
+    tc.add_argument("--summary", required=True)
+    tc.add_argument("--type", default="Manual", choices=["Manual", "Cucumber", "Generic"])
+    tc.add_argument("--steps", type=Path, help="steps file (.json array or .txt action|data|result)")
+    tc.add_argument("--gherkin", type=Path)
+    tc.add_argument("--definition", type=Path)
+    tc.add_argument("--assignee", help="email / accountId (cloud) or username (server)")
+    tc.add_argument("--link-to", dest="link_to",
+                    help="story/requirement key to link as Xray coverage (e.g. PROJ-123). "
+                         "Creates an Xray requirement link — the correct link type for "
+                         "coverage rollup. Verified after create; exit 3 on mismatch.")
+    ts = t.add_parser("add-step")
+    ts.add_argument("key"); ts.add_argument("--action", required=True)
+    ts.add_argument("--data", default=""); ts.add_argument("--result", required=True)
+    tl = t.add_parser("link-requirement")
+    tl.add_argument("test_key"); tl.add_argument("req_key")
+
+    # sets / plans
+    ss = sub.add_parser("testset", help="Test Set ops.").add_subparsers(dest="sub", required=True)
+    sa = ss.add_parser("add")
+    sa.add_argument("set_key"); sa.add_argument("test_keys", nargs="+")
+    pp = sub.add_parser("testplan", help="Test Plan ops.").add_subparsers(dest="sub", required=True)
+    pa = pp.add_parser("add")
+    pa.add_argument("plan_key"); pa.add_argument("test_keys", nargs="+")
+
+    # executions + runs
+    ex = sub.add_parser("exec", help="Test Execution ops.").add_subparsers(dest="sub", required=True)
+    ec = ex.add_parser("create")
+    ec.add_argument("--project", required=True)
+    ec.add_argument("--summary", required=True)
+    ec.add_argument("--tests", required=True, help="comma-separated Test keys")
+    ec.add_argument("--plan")
+    er = ex.add_parser("list-runs"); er.add_argument("exec_key")
+
+    rn = sub.add_parser("run", help="Test Run ops.").add_subparsers(dest="sub", required=True)
+    rs = rn.add_parser("status")
+    rs.add_argument("run_id"); rs.add_argument("--set", dest="status", required=True)
+    rs.add_argument("--comment")
+    re_ = rn.add_parser("evidence")
+    re_.add_argument("run_id"); re_.add_argument("--file", required=True, type=Path)
+
+    # import
+    imp = sub.add_parser("import", help="Results import.").add_subparsers(dest="sub", required=True)
+    for fmt in ("junit", "cucumber", "xray-json"):
+        ip = imp.add_parser(fmt)
+        ip.add_argument("file", type=Path)
+        if fmt != "xray-json":
+            ip.add_argument("--project", required=True)
+            ip.add_argument("--plan"); ip.add_argument("--env")
+            ip.add_argument("--exec")
+
+    # coverage
+    cv = sub.add_parser("coverage"); cv.add_argument("req_key")
+
+    return p
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+
+    if args.cmd == "config":
+        try:
+            cfg = load_config()
+        except SystemExit:
+            raise
+        _out(args, {
+            "deployment": cfg.deployment,
+            "xray_base_url": cfg.xray_base_url,
+            "jira_base_url": cfg.jira_base_url,
+            "cache_dir": str(cfg.cache_dir),
+        }, human=(
+            f"deployment: {cfg.deployment}\n"
+            f"xray:       {cfg.xray_base_url}\n"
+            f"jira:       {cfg.jira_base_url}\n"
+            f"cache:      {cfg.cache_dir}"
+        ))
+        return
+
+    cfg = load_config()
+
+    if args.cmd == "auth-verify":
+        sts = statuses(cfg)
+        _out(args, {"ok": True, "status_count": len(sts)},
+             human=f"OK: {cfg.deployment} reachable, {len(sts)} statuses configured.")
+        return
+    if args.cmd == "statuses":
+        sts = statuses(cfg)
+        _out(args, sts, human="\n".join(
+            f"{s.get('name'):12} final={s.get('final')}" for s in sts))
+        return
+
+    if args.cmd == "test" and args.sub == "get":
+        t = test_get(cfg, args.key)
+        if args.raw or getattr(args, "json", False):
+            _out(args, t)
+        else:
+            key = (t.get("jira") or {}).get("key") or t.get("key")
+            summary = (t.get("jira") or {}).get("summary") or t.get("summary")
+            tt = (t.get("testType") or {}).get("name") or t.get("testType", "?")
+            tt_kind = (t.get("testType") or {}).get("kind", "").lower()
+            steps = t.get("steps") or []
+            gherkin = t.get("gherkin") or ""
+            unstructured = t.get("unstructured") or ""
+            lines = [f"{key}  [{tt}]  {summary}"]
+            if steps:
+                lines.append(f"  {len(steps)} step(s)")
+                for i, s in enumerate(steps, 1):
+                    lines.append(f"    {i}. {s.get('action','')}  →  {s.get('result','')}")
+            if gherkin.strip():
+                lines.append("  gherkin:")
+                lines.extend("    " + ln for ln in gherkin.splitlines())
+            if unstructured.strip():
+                lines.append("  definition:")
+                lines.extend("    " + ln for ln in unstructured.splitlines())
+            if not steps and not gherkin.strip() and not unstructured.strip():
+                lines.append(f"  (no body — {tt_kind or 'unknown'} test has no content)")
+            print("\n".join(lines))
+        return
+
+    if args.cmd == "test" and args.sub == "create":
+        steps = _parse_steps_file(args.steps) if args.type == "Manual" else None
+        gherkin = args.gherkin.read_text() if args.gherkin else None
+        definition = args.definition.read_text() if args.definition else None
+        key = test_create(cfg, args.project, args.summary, args.type,
+                          steps, gherkin, definition, args.assignee)
+        expected_steps = len(steps or []) if args.type == "Manual" else None
+        verify = test_get(cfg, key)
+        if expected_steps is not None:
+            actual = len(verify.get("steps") or [])
+            if actual != expected_steps:
+                _die(f"created {key} but step count mismatch: expected {expected_steps}, got {actual}", 3)
+        linked_note = ""
+        if args.link_to:
+            test_link_requirement(cfg, key, args.link_to)
+            # Verify coverage landed on the story side.
+            covering = coverage(cfg, args.link_to)
+            keys_on_story = {
+                ((t.get("jira") or {}).get("key")) or t.get("key") for t in covering
+            }
+            if key not in keys_on_story:
+                _die(f"created {key} and called addTestsToRequirement({args.link_to}), "
+                     f"but {key} is NOT in {args.link_to}'s coverage list after re-fetch. "
+                     f"Verify Xray permissions on the story and re-link.", 3)
+            linked_note = f"; linked as coverage of {args.link_to}  ✓"
+        _out(args, {"key": key, "linked_to": args.link_to} if args.link_to else {"key": key},
+             human=f"Created Test {key}  ✓ verified{linked_note}")
+        return
+
+    if args.cmd == "test" and args.sub == "add-step":
+        before = len(test_get(cfg, args.key).get("steps") or [])
+        test_add_step(cfg, args.key, args.action, args.data, args.result)
+        after = len(test_get(cfg, args.key).get("steps") or [])
+        if after != before + 1:
+            _die(f"step count did not increase on {args.key}: {before} → {after}", 3)
+        _out(args, {"ok": True, "steps": after},
+             human=f"{args.key} now has {after} step(s) ✓")
+        return
+
+    if args.cmd == "test" and args.sub == "link-requirement":
+        test_link_requirement(cfg, args.test_key, args.req_key)
+        _out(args, {"ok": True}, human=f"Linked {args.test_key} → {args.req_key} ✓")
+        return
+
+    if args.cmd == "testset" and args.sub == "add":
+        testset_add(cfg, args.set_key, args.test_keys)
+        _out(args, {"ok": True, "added": args.test_keys},
+             human=f"Added {len(args.test_keys)} test(s) to {args.set_key} ✓")
+        return
+
+    if args.cmd == "testplan" and args.sub == "add":
+        testplan_add(cfg, args.plan_key, args.test_keys)
+        _out(args, {"ok": True, "added": args.test_keys},
+             human=f"Added {len(args.test_keys)} test(s) to {args.plan_key} ✓")
+        return
+
+    if args.cmd == "exec" and args.sub == "create":
+        test_keys = [k.strip() for k in args.tests.split(",") if k.strip()]
+        key = exec_create(cfg, args.project, args.summary, test_keys, args.plan)
+        runs = exec_list_runs(cfg, key)
+        if len(runs) != len(test_keys):
+            _die(f"exec created {key} but run count != requested tests ({len(runs)} vs {len(test_keys)})", 3)
+        _out(args, {"key": key, "runs": len(runs)},
+             human=f"Created Test Execution {key} with {len(runs)} run(s) ✓")
+        return
+
+    if args.cmd == "exec" and args.sub == "list-runs":
+        runs = exec_list_runs(cfg, args.exec_key)
+        if getattr(args, "json", False):
+            _out(args, runs)
+        else:
+            for r in runs:
+                rid = r.get("id") or r.get("testRunId")
+                status = (r.get("status") or {}).get("name") if isinstance(r.get("status"), dict) else r.get("status")
+                key = ((r.get("test") or {}).get("jira") or {}).get("key") or r.get("testKey")
+                print(f"{rid}  {status:10}  {key}")
+        return
+
+    if args.cmd == "run" and args.sub == "status":
+        run_set_status(cfg, args.run_id, args.status, args.comment)
+        _out(args, {"ok": True}, human=f"Run {args.run_id} → {args.status} ✓")
+        return
+
+    if args.cmd == "run" and args.sub == "evidence":
+        run_add_evidence(cfg, args.run_id, args.file)
+        _out(args, {"ok": True}, human=f"Attached {args.file.name} to {args.run_id} ✓")
+        return
+
+    if args.cmd == "import":
+        if args.sub == "junit":
+            key = import_junit(cfg, args.file, args.project, args.plan, args.env, args.exec)
+        elif args.sub == "cucumber":
+            key = import_cucumber(cfg, args.file, args.project, args.plan, args.env, args.exec)
+        else:  # xray-json
+            key = import_xray_json(cfg, args.file)
+        runs = exec_list_runs(cfg, key)
+        if not runs:
+            _die(f"import created {key} but 0 Test Runs — likely mapping failure. "
+                 f"Check classname/name-to-Test-key convention.", 3)
+        _out(args, {"key": key, "runs": len(runs)},
+             human=f"Imported into Test Execution {key}: {len(runs)} run(s) ✓")
+        return
+
+    if args.cmd == "coverage":
+        tests = coverage(cfg, args.req_key)
+        if getattr(args, "json", False):
+            _out(args, tests)
+        else:
+            for t in tests:
+                key = ((t.get("jira") or {}).get("key")) or t.get("key")
+                summ = ((t.get("jira") or {}).get("summary")) or t.get("summary", "")
+                print(f"{key}  {summ}")
+        return
+
+    _die(f"unhandled command: {args.cmd}/{getattr(args, 'sub', '')}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Focused skill for Xray (Jira-based TMS). Transport-agnostic (MCP → bundled CLI → raw HTTP). Ships a 1013-line stdlib-only Python CLI (`scripts/xray.py`) with auto Cloud/Server detection, JWT caching, and re-fetch-and-verify on every write. Self-contained — no agent changes in this PR.

**Enforced rules:** transport priority (MCP first); don't fake a Test by POSTing `issuetype=Test` to plain Jira; coverage linking is mandatory and atomic (`addTestsToRequirement`, not plain issuelinks); don't rewrite step IDs; zero runs after an import = broken classname/name mapping (CLI exits 3).

**Files:** `skills/xray-testing/SKILL.md` (414L) + 5 references (cloud-graphql, server-rest, entities, results-import, jira-rest-fallback) + `scripts/xray.py` (1013L) + `scripts/README.md`. `skills.json`, `AGENTS.md`, `GEMINI.md`, `README.md` catalog entries.

**Dependencies:** complements #3 (atlassian-content) — atlassian-content owns Jira issue/comment ADF, xray-testing owns Xray-specific endpoints. Works on every supported host.