### PR TITLE
xray-testing: smoother creds onboarding (.env auto-load, `config set`, --issue-id bypass)

### DIFF
--- a/skills/xray-testing/SKILL.md
+++ b/skills/xray-testing/SKILL.md
@@ -158,12 +158,21 @@ post-write re-fetch discipline (exit 3 on mismatch). Common ops:
 
 ```bash
 xray auth-verify                          # reachability + status set check
-xray test get PROJ-T42                    # summary + step list
+xray test get PROJ-T42                    # summary + step list (Cloud: needs Jira creds)
+xray test get --issue-id 10042            # bypass Jira: use a known issueId directly
 xray test create --project PROJ --summary "..." --type Manual --steps steps.txt
 xray exec create --project PROJ --summary "Smoke 04-22" \
   --tests PROJ-T42,PROJ-T43 --plan PROJ-P7
 xray import junit target/junit.xml --project PROJ --plan PROJ-P7
 ```
+
+**Jira creds are command-scoped.** Cloud's Xray-only commands (`config`,
+`auth-verify`, `statuses`, `run *`, `import *`) work with **only** `XRAY_*`
+set. Anything that translates a Jira key → numeric `issueId` (`test *`,
+`testset *`, `testplan *`, `exec create`, `coverage`) needs `JIRA_BASE_URL`
++ `JIRA_USER` + `JIRA_TOKEN`. If you already have the `issueId` from
+elsewhere — Atlassian MCP, prior CLI call, JQL search — pass `--issue-id`
+where supported and skip the Jira-REST hop entirely.
 
 ## Entity model + coverage linking
 

--- a/skills/xray-testing/references/cloud-graphql.md
+++ b/skills/xray-testing/references/cloud-graphql.md
@@ -37,7 +37,7 @@ the repo.
 
 Xray's GraphQL schema keys entities by **internal Jira issueId**
 (numeric string). You'll usually have a Jira key (`PROJ-T42`);
-resolve to issueId via the Jira REST API:
+the canonical resolver is the Jira REST API:
 
 ```
 GET /rest/api/3/issue/PROJ-T42?fields=summary
@@ -45,6 +45,16 @@ GET /rest/api/3/issue/PROJ-T42?fields=summary
 ```
 
 Cache `key → issueId` per session.
+
+**Avoid the Jira hop when you can.** If the issueId is already in
+hand — from an Atlassian MCP (`mcp__Elitea_Dev__JiraIntegration_*`,
+`mcp__atlassian__*`, etc.), a prior CLI call's JSON output, or a
+JQL search via `getTests(jql: …) { results { issueId } }` —
+pass it directly. The bundled CLI exposes `--issue-id <numeric>` on
+commands that accept a key (e.g. `xray test get --issue-id 123456`),
+which skips the `/rest/api/3/issue` lookup entirely. That keeps the
+CLI usable on Cloud with **only** `XRAY_CLIENT_ID` / `XRAY_CLIENT_SECRET`
+set — no `JIRA_BASE_URL` / `JIRA_USER` / `JIRA_TOKEN` needed.
 
 Many queries accept a `jql` string as an alternative to
 `issueIds`; for ad-hoc filters, JQL is often simpler:

--- a/skills/xray-testing/scripts/.env.example
+++ b/skills/xray-testing/scripts/.env.example
@@ -1,0 +1,40 @@
+# xray-testing — environment variable template.
+#
+# Copy to `.env` in your project root, fill in real values, then either
+# (a) let xray.py auto-load it (default — drop the file and run any command), or
+# (b) export manually: `set -a; source .env; set +a`, or use direnv.
+#
+# Already-exported shell env vars always win over .env values.
+#
+# To populate this file interactively without editing by hand:
+#   xray config set --client-id ... --client-secret ... --jira-base-url ...
+#
+# Never commit .env. Make sure your project's .gitignore covers it.
+
+# ─── Deployment ───────────────────────────────────────────────────
+# Auto-detected from the other fields. Set explicitly only to override.
+# XRAY_DEPLOYMENT=cloud           # cloud | server
+
+# ─── Xray Cloud (GraphQL) ─────────────────────────────────────────
+# Issue at: Jira → Apps → Xray → API Keys → Create
+XRAY_CLIENT_ID=
+XRAY_CLIENT_SECRET=
+
+# Pick one. `global` is the default; set `eu` / `us` if your tenant is regional.
+# XRAY_REGION sets the Xray Cloud base URL automatically.
+XRAY_REGION=global              # global | us | eu
+# XRAY_BASE_URL=                 # only if you need a non-standard endpoint
+
+# ─── Jira (always required for anything that touches /rest/api/3/*) ──
+# Cloud:  JIRA_BASE_URL=https://<site>.atlassian.net
+# Server: JIRA_BASE_URL=https://<your-jira>
+JIRA_BASE_URL=
+
+# Issue at: id.atlassian.com → Security → API tokens → Create (Cloud)
+# Or:       Jira → Profile → Personal Access Tokens (Server / DC)
+JIRA_USER=                       # your atlassian email (Cloud) — empty for Server PAT
+JIRA_TOKEN=                      # API token (Cloud) or PAT (Server)
+
+# ─── Optional ─────────────────────────────────────────────────────
+# JWT cache (cloud only). Default: ~/.cache/xray
+# XRAY_CACHE_DIR=.xray-cache

--- a/skills/xray-testing/scripts/README.md
+++ b/skills/xray-testing/scripts/README.md
@@ -139,9 +139,15 @@ the target manually.
 ### Test
 
 ```bash
-# Read
+# Read — by Jira key (Cloud will resolve key → numeric issueId via Jira REST first)
 xray test get PROJ-T42
 xray test get PROJ-T42 --raw          # structured body (ADF / REST JSON)
+
+# Read — when you already have the issueId (e.g. via Atlassian MCP):
+# skips the Jira-REST lookup entirely. Lets the CLI work with only XRAY_*
+# creds set; no JIRA_BASE_URL / JIRA_USER / JIRA_TOKEN required.
+xray test get --issue-id 10042
+xray test get PROJ-T42 --issue-id 10042   # both forms; --issue-id wins
 
 # Create (Manual)
 #   --steps file: JSON array of {action,data,result}

--- a/skills/xray-testing/scripts/README.md
+++ b/skills/xray-testing/scripts/README.md
@@ -28,7 +28,34 @@ depending on where sdlc-skills installed.
 
 ## Configure via environment
 
-Deployment is auto-detected. Override with `XRAY_DEPLOYMENT=cloud|server`.
+Three ways to get credentials in. Pick one:
+
+```bash
+# (a) Interactive — writes/updates .env in cwd, mode 0600
+xray config set \
+    --client-id "$XRAY_ID" --client-secret "$XRAY_SECRET" \
+    --jira-base-url https://<site>.atlassian.net \
+    --jira-user you@example.com --jira-token <pat>
+
+# (b) Drop a .env file — auto-loaded by xray.py at startup
+cp <install-path>/skills/xray-testing/scripts/.env.example .env
+$EDITOR .env
+
+# (c) Pre-export in your shell / direnv / CI runner
+export XRAY_CLIENT_ID=… XRAY_CLIENT_SECRET=…
+```
+
+**Precedence**: already-exported env vars > `.env` in cwd > nothing.
+The script never overrides a value that's already in `os.environ`,
+so a stray `.env` won't surprise a CI run that exports its own vars.
+
+**Project-wide config** (e.g. `.agents/test-automation.yaml` from the
+project-seeder skill) is read by the agent — not by this script. The
+agent translates the YAML into env vars before invoking `xray`. The
+CLI itself only knows about env vars + `.env`.
+
+Deployment is auto-detected from the fields you set. Override with
+`XRAY_DEPLOYMENT=cloud|server`.
 
 **Cloud** (Xray Cloud):
 
@@ -70,14 +97,15 @@ Shared:
 # export XRAY_CACHE_DIR=".xray-cache"
 ```
 
-Never commit these values. Store in a local `.env` your runner
-sources, or in your shell profile.
+Never commit these values — `.env` and `token.json` should be in
+`.gitignore`. The CLI writes `.env` mode 0600 when you use
+`xray config set`.
 
 Sanity check:
 
 ```bash
-xray config
-xray auth-verify
+xray config              # show effective config (resolved env-vars + .env)
+xray auth-verify         # one-shot reachability check
 ```
 
 ## Command surface

--- a/skills/xray-testing/scripts/README.md
+++ b/skills/xray-testing/scripts/README.md
@@ -97,9 +97,30 @@ Shared:
 # export XRAY_CACHE_DIR=".xray-cache"
 ```
 
-Never commit these values — `.env` and `token.json` should be in
-`.gitignore`. The CLI writes `.env` mode 0600 when you use
-`xray config set`.
+### Secrets hygiene — gitignore before first write
+
+Mode 0600 on `.env` (set by `xray config set`) only protects against
+other unix users. **It does NOT stop `git add`** — one stray commit
+and the file is published. Before running `xray config set` for the
+first time, make sure `.env` and `token.json` are gitignored:
+
+```bash
+# idempotent — appends only if missing
+grep -qxF '.env' .gitignore 2>/dev/null || cat >> .gitignore <<'EOF'
+
+# Local creds — never commit
+.env
+.xray-cache/
+EOF
+
+# token.json lives in XRAY_CACHE_DIR (default ~/.cache/xray, outside
+# the repo); only relevant if you set XRAY_CACHE_DIR=.xray-cache
+```
+
+This matters more if your `.env` already has tokens for other tools
+(`DATABASE_URL`, `AWS_ACCESS_KEY_ID`, `GH_TOKEN`, etc.) — `xray
+config set` preserves them all verbatim, but anything in the file
+travels with `git add`. Audit before staging.
 
 Sanity check:
 

--- a/skills/xray-testing/scripts/xray.py
+++ b/skills/xray-testing/scripts/xray.py
@@ -157,8 +157,10 @@ def load_config() -> Config:
     if deployment == "cloud":
         if not (client_id and client_secret):
             _die("cloud deployment requires XRAY_CLIENT_ID + XRAY_CLIENT_SECRET.")
-        if not jira_base_url:
-            _die("JIRA_BASE_URL is required on cloud.")
+        # JIRA_BASE_URL is NOT required at build time on Cloud — Xray-only commands
+        # (auth-verify, statuses, run *, import *, config) work with just XRAY_*.
+        # The check is deferred to _call_jira() / resolve_issue_id(), which fail with
+        # a precise message naming exactly what's missing for the command you ran.
         # Resolve Xray base URL: XRAY_BASE_URL (exact) > XRAY_REGION lookup > default global.
         raw_base = os.environ.get("XRAY_BASE_URL", "").strip()
         if raw_base:
@@ -322,10 +324,20 @@ def _call_xray(
 
 
 def _call_jira(cfg: Config, path: str, *, method: str = "GET", json_body: Any = None) -> Any:
-    if not cfg.jira_auth_header:
+    # Lazy validation — Jira creds are only required for commands that hit
+    # /rest/api/* (issueId / accountId / custom-field lookups). Build-time
+    # config is intentionally permissive; this is the gate.
+    missing: list[str] = []
+    if not cfg.jira_base_url:
+        missing.append("JIRA_BASE_URL")
+    if cfg.deployment == "cloud" and not cfg.jira_auth_header:
+        missing.append("JIRA_USER + JIRA_TOKEN")
+    if missing:
         _die(
-            "Jira REST call requires JIRA_USER (email) + JIRA_TOKEN on cloud. "
-            "Set both to enable issueId / accountId / field-id lookups."
+            "this command needs Jira REST: " + ", ".join(missing) + ". "
+            "Tip: pass --issue-id <numeric> on commands that support it to skip "
+            "the Jira lookup entirely. Otherwise set the missing vars (or run "
+            "`xray config set --jira-base-url … --jira-user … --jira-token …`)."
         )
     url = cfg.jira_base_url + path
     headers = {"Authorization": cfg.jira_auth_header, "Accept": "application/json"}
@@ -432,9 +444,22 @@ def _graphql(cfg: Config, query: str, variables: dict[str, Any] | None = None) -
 # Entity ops — dispatched on cfg.deployment
 # ────────────────────────────────────────────────────────────────────────
 
-def test_get(cfg: Config, key: str) -> dict:
+def test_get(cfg: Config, key: str | None = None, *, issue_id: str | None = None) -> dict:
+    """Fetch a Test by key OR by pre-resolved numeric issueId.
+
+    Pass `issue_id=` to skip Jira lookup entirely — useful when the id was
+    fetched via an Atlassian MCP, a previous CLI call, or any other path.
+    Cloud returns the key/summary in the GraphQL response, so omitting `key`
+    is fine when `issue_id` is given.
+
+    Server accepts the human key directly (no issueId translation), so on
+    Server `key` is required and `issue_id` is informational only.
+    """
     if cfg.deployment == "cloud":
-        issue_id = resolve_issue_id(cfg, key)
+        if not issue_id:
+            if not key:
+                _die("test get on cloud needs either a Jira key or --issue-id <numeric>.")
+            issue_id = resolve_issue_id(cfg, key)
         data = _graphql(cfg, """
             query($id: String!) {
               getTest(issueId: $id) {
@@ -448,7 +473,7 @@ def test_get(cfg: Config, key: str) -> dict:
               }
             }
         """, {"id": issue_id})
-        test = (data or {}).get("getTest") or _die(f"Test {key} not found.")
+        test = (data or {}).get("getTest") or _die(f"Test {key or issue_id} not found.")
         return test
     # server
     t = _call_xray(cfg, f"/api/test/{key}")
@@ -869,8 +894,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     # test
     t = sub.add_parser("test", help="Test CRUD.").add_subparsers(dest="sub", required=True)
-    tg = t.add_parser("get"); tg.add_argument("key")
-    tg.add_argument("--raw", action="store_true")
+    tg = t.add_parser("get")
+    tg.add_argument("key", nargs="?", help="Jira key (e.g. PROJ-T42). Omit if --issue-id is given.")
+    tg.add_argument("--issue-id", dest="issue_id", help="Numeric issueId — skip Jira lookup. Use when you already have the id (e.g. from an Atlassian MCP).")
+    tg.add_argument("--raw", action="store_true", help="emit raw response (alias for --json)")
     tc = t.add_parser("create")
     tc.add_argument("--project", required=True)
     tc.add_argument("--summary", required=True)
@@ -978,11 +1005,31 @@ def cmd_config_set(args) -> None:
 
     new_keys = [(k, v) for k, v in updates.items() if k not in seen]
     if new_keys:
-        if out and out[-1].strip() != "":
-            out.append("")
-        out.append("# xray-testing — added by `xray config set`")
-        for k, v in new_keys:
-            out.append(f"{k}={v}")
+        # Reuse an existing "# xray-testing — added by ..." section if one is
+        # already in the file (we wrote it on a prior run). Insert new keys at
+        # the end of that section. Avoids stacking duplicate headers across
+        # re-runs of `config set`.
+        header = "# xray-testing — added by `xray config set`"
+        last_header_idx = -1
+        for i, line in enumerate(out):
+            if line.strip() == header:
+                last_header_idx = i
+        new_lines = [f"{k}={v}" for k, v in new_keys]
+        if last_header_idx >= 0:
+            # Insert at end of the existing section (header + its KEY=VAL lines).
+            end = last_header_idx + 1
+            while end < len(out):
+                stripped = out[end].lstrip()
+                if "=" in stripped and not stripped.startswith("#"):
+                    end += 1
+                else:
+                    break
+            out = out[:end] + new_lines + out[end:]
+        else:
+            if out and out[-1].strip() != "":
+                out.append("")
+            out.append(header)
+            out.extend(new_lines)
 
     body = "\n".join(out).rstrip() + "\n"
     target.write_text(body)
@@ -1036,7 +1083,7 @@ def main() -> None:
         return
 
     if args.cmd == "test" and args.sub == "get":
-        t = test_get(cfg, args.key)
+        t = test_get(cfg, args.key, issue_id=getattr(args, "issue_id", None))
         if args.raw or getattr(args, "json", False):
             _out(args, t)
         else:

--- a/skills/xray-testing/scripts/xray.py
+++ b/skills/xray-testing/scripts/xray.py
@@ -96,7 +96,44 @@ def _die(msg: str, code: int = 2) -> None:
     sys.exit(code)
 
 
+def _load_dotenv(path: Path = Path(".env")) -> None:
+    """Populate os.environ from a .env file in cwd.
+
+    Already-exported env vars always win — `setdefault` never overrides.
+    Silent if the file doesn't exist; warns (does not fail) on parse errors.
+    Format: KEY=VALUE per line. Blank lines and `#` comments ignored.
+    Surrounding single or double quotes around the value are stripped.
+    Inline `# comment` after an unquoted value is stripped.
+    """
+    if not path.is_file():
+        return
+    try:
+        for lineno, raw in enumerate(path.read_text().splitlines(), 1):
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                print(f"xray: {path}:{lineno}: skipping malformed line", file=sys.stderr)
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            if key.startswith("export "):
+                key = key[len("export "):].strip()
+            value = value.strip()
+            if value and value[0] in ("'", '"') and value[-1] == value[0]:
+                value = value[1:-1]
+            else:
+                # Strip inline `# comment` only when value is unquoted
+                hash_at = value.find(" #")
+                if hash_at >= 0:
+                    value = value[:hash_at].rstrip()
+            os.environ.setdefault(key, value)
+    except OSError as e:
+        print(f"xray: could not read {path}: {e}", file=sys.stderr)
+
+
 def load_config() -> Config:
+    _load_dotenv()
     deployment = os.environ.get("XRAY_DEPLOYMENT", "").strip().lower()
     client_id = os.environ.get("XRAY_CLIENT_ID", "").strip()
     client_secret = os.environ.get("XRAY_CLIENT_SECRET", "").strip()
@@ -811,7 +848,22 @@ def build_parser() -> argparse.ArgumentParser:
                    help="emit JSON on stdout (default: human-readable).")
     sub = p.add_subparsers(dest="cmd", required=True)
 
-    sub.add_parser("config", help="print effective configuration.")
+    cfg_p = sub.add_parser("config", help="show or set effective configuration.")
+    cfg_sub = cfg_p.add_subparsers(dest="config_action")  # optional — default 'show'
+    cfg_sub.add_parser("show", help="print effective configuration.")
+    cfg_set = cfg_sub.add_parser("set", help="write/update .env in cwd.")
+    cfg_set.add_argument("--client-id", dest="client_id", help="XRAY_CLIENT_ID (cloud)")
+    cfg_set.add_argument("--client-secret", dest="client_secret", help="XRAY_CLIENT_SECRET (cloud)")
+    cfg_set.add_argument("--jira-base-url", dest="jira_base_url", help="JIRA_BASE_URL")
+    cfg_set.add_argument("--jira-user", dest="jira_user", help="JIRA_USER (atlassian email)")
+    cfg_set.add_argument("--jira-token", dest="jira_token", help="JIRA_TOKEN (Jira API token / PAT)")
+    cfg_set.add_argument("--xray-region", dest="xray_region", choices=["global", "us", "eu"], help="XRAY_REGION")
+    cfg_set.add_argument("--xray-base-url", dest="xray_base_url", help="XRAY_BASE_URL (override region)")
+    cfg_set.add_argument("--xray-deployment", dest="xray_deployment", choices=["cloud", "server"], help="XRAY_DEPLOYMENT")
+    cfg_set.add_argument("--xray-cache-dir", dest="xray_cache_dir", help="XRAY_CACHE_DIR")
+    cfg_set.add_argument("--env-file", dest="env_file", default=".env", help="target file (default: .env)")
+    cfg_set.add_argument("--print", dest="print_after", action="store_true", help="print masked summary after write")
+
     sub.add_parser("statuses", help="list project-allowed Test Run statuses.")
     sub.add_parser("auth-verify", help="one-shot API reachability check.")
 
@@ -877,10 +929,82 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
+_CONFIG_FIELDS: list[tuple[str, str]] = [
+    # (CLI dest, env var name) — order = .env write order
+    ("xray_deployment", "XRAY_DEPLOYMENT"),
+    ("client_id", "XRAY_CLIENT_ID"),
+    ("client_secret", "XRAY_CLIENT_SECRET"),
+    ("xray_region", "XRAY_REGION"),
+    ("xray_base_url", "XRAY_BASE_URL"),
+    ("jira_base_url", "JIRA_BASE_URL"),
+    ("jira_user", "JIRA_USER"),
+    ("jira_token", "JIRA_TOKEN"),
+    ("xray_cache_dir", "XRAY_CACHE_DIR"),
+]
+
+
+def cmd_config_set(args) -> None:
+    """Write/update the env-var file (default .env) in cwd.
+
+    Updates existing keys in place; appends new ones at the bottom under a
+    section header. Other lines (comments, unrelated vars) are preserved.
+    Mode is set to 0600 after write — credentials don't need to be readable
+    by other users.
+    """
+    target = Path(args.env_file)
+    updates: dict[str, str] = {}
+    for dest, env_var in _CONFIG_FIELDS:
+        v = getattr(args, dest, None)
+        if v is not None and v != "":
+            updates[env_var] = v
+    if not updates:
+        _die("no fields given — pass at least one of --client-id / --jira-token / etc.", 2)
+
+    existing = target.read_text() if target.is_file() else ""
+    lines = existing.splitlines()
+    seen: set[str] = set()
+    out: list[str] = []
+    for line in lines:
+        stripped = line.lstrip()
+        if "=" in stripped and not stripped.startswith("#"):
+            key = stripped.partition("=")[0].strip()
+            if key.startswith("export "):
+                key = key[len("export "):].strip()
+            if key in updates:
+                out.append(f"{key}={updates[key]}")
+                seen.add(key)
+                continue
+        out.append(line)
+
+    new_keys = [(k, v) for k, v in updates.items() if k not in seen]
+    if new_keys:
+        if out and out[-1].strip() != "":
+            out.append("")
+        out.append("# xray-testing — added by `xray config set`")
+        for k, v in new_keys:
+            out.append(f"{k}={v}")
+
+    body = "\n".join(out).rstrip() + "\n"
+    target.write_text(body)
+    try:
+        target.chmod(0o600)
+    except OSError:
+        pass
+
+    summary = {k: ("***" if k in {"XRAY_CLIENT_SECRET", "JIRA_TOKEN"} else v) for k, v in updates.items()}
+    print(f"xray: wrote {len(updates)} key(s) to {target} (mode 0600)")
+    for k, v in summary.items():
+        print(f"  {k}={v}")
+
+
 def main() -> None:
     args = build_parser().parse_args()
 
     if args.cmd == "config":
+        action = getattr(args, "config_action", None) or "show"
+        if action == "set":
+            cmd_config_set(args)
+            return
         try:
             cfg = load_config()
         except SystemExit:


### PR DESCRIPTION
## Summary

Closes four credential-setup gaps in `xray-testing` for new users. All TOSCA-style scoping; no behavior change for existing exported-env users.

| # | Change | File(s) |
|---|---|---|
| 1 | **`scripts/.env.example`** template — 7 vars + issuance pointers | new |
| 2 | **Auto-load `.env`** at `load_config()` — stdlib parser, `os.environ.setdefault` so exported vars always win; handles quoted values, `export` prefix, inline `# comments` | `scripts/xray.py` |
| 3 | **`xray config set`** — writes/updates `.env` in cwd (mode 0600), updates existing keys in place, single dedup'd header on iterative re-runs, masks secrets in stdout | `scripts/xray.py` |
| 4 | **`--issue-id <numeric>`** on `xray test get` — bypass Jira REST when issueId is already known (Atlassian MCP / prior call / JQL); lets Cloud `test get` run with only `XRAY_*` set | `scripts/xray.py` |

Bonus: deferred the `JIRA_BASE_URL` requirement on Cloud from `load_config()` to `_call_jira()` so `auth-verify` / `statuses` / `run *` / `import *` actually work with only `XRAY_*` set, as the README has long promised.

## Verified live (EU Xray Cloud tenant)

- `auth-verify` + `statuses` succeed with only `XRAY_CLIENT_ID` / `XRAY_CLIENT_SECRET` / `XRAY_BASE_URL`
- `test get` without Jira creds dies with a precise multi-line error pointing at `--issue-id` + `xray config set`
- `config set` × 4 against a populated `.env` with foreign tokens (`DATABASE_URL` / `AWS_*`): header count stays at 1, in-place updates work, foreign tokens preserved verbatim
- `.env` parser handles quoted, single-quoted, `export`-prefixed, inline-comment forms

## Docs

- `scripts/README.md` § Configure via environment — three concrete creds paths (`config set` / `.env.example` / pre-export), explicit precedence rule (shell > .env > nothing)
- `scripts/README.md` § Secrets hygiene — gitignore-before-first-write, idempotent append snippet, audit warning when `.env` already has DB/AWS/GH tokens
- `SKILL.md` § Common ops — both forms shown; per-command-scope Jira-creds note
- `references/cloud-graphql.md` § 2 — "avoid the Jira hop" recipe pointing at MCP / JQL / `--issue-id`