### PR TITLE
Fix tdd external-skill fetch path

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ flowchart TB
 
     subgraph externals["upstream external skill sources"]
         direction LR
-        ext_matt[["mattpocock/skills<br/>tdd"]]
+        ext_matt[["mattpocock/skills<br/>skills/engineering/tdd"]]
         ext_obra[["obra/superpowers<br/>brainstorming, debugging,<br/>verification, ..."]]
         ext_tws[["twostraws/*-Agent-Skill<br/>SwiftUI, SwiftData,<br/>Swift Testing, Concurrency"]]
     end
@@ -338,7 +338,7 @@ catalog.
 
 | Skill | Source | Used by |
 |---|---|---|
-| `tdd` | [`mattpocock/skills`](https://github.com/mattpocock/skills) → `tdd/` | `python-dev`, `js-dev`, `ios-dev` |
+| `tdd` | [`mattpocock/skills`](https://github.com/mattpocock/skills) → `skills/engineering/tdd/` | `python-dev`, `js-dev`, `ios-dev` |
 | `brainstorming` | [`obra/superpowers`](https://github.com/obra/superpowers) → `skills/brainstorming/` | `ba` |
 | `systematic-debugging` | [`obra/superpowers`](https://github.com/obra/superpowers) → `skills/systematic-debugging/` | devs + `qa-engineer` |
 | `verification-before-completion` | [`obra/superpowers`](https://github.com/obra/superpowers) → `skills/verification-before-completion/` | devs + `qa-engineer` |
@@ -451,7 +451,7 @@ resolution — add a folder or a registry entry, it shows up on the next
 External skills are fetched from upstream at install time — this repo
 re-distributes nothing, only catalogs and wires.
 
-- **[`mattpocock/skills`](https://github.com/mattpocock/skills)** — Matt Pocock. `tdd/` (vertical-slice tracer bullets, integration-style tests, interface design for testability). MIT.
+- **[`mattpocock/skills`](https://github.com/mattpocock/skills)** — Matt Pocock. `skills/engineering/tdd/` (vertical-slice tracer bullets, integration-style tests, interface design for testability). MIT.
 - **[`obra/superpowers`](https://github.com/obra/superpowers)** — Jesse Vincent. `brainstorming`, `systematic-debugging`, `verification-before-completion`, `requesting-code-review`, `receiving-code-review`, `writing-skills`. MIT.
 - **Paul Hudson's Swift agent skills** — [`twostraws/SwiftUI-Agent-Skill`](https://github.com/twostraws/SwiftUI-Agent-Skill), [`twostraws/SwiftData-Agent-Skill`](https://github.com/twostraws/SwiftData-Agent-Skill), [`twostraws/Swift-Testing-Agent-Skill`](https://github.com/twostraws/Swift-Testing-Agent-Skill), [`twostraws/Swift-Concurrency-Agent-Skill`](https://github.com/twostraws/Swift-Concurrency-Agent-Skill). Powers the `ios-dev` agent. MIT.
 

--- a/skills.json
+++ b/skills.json
@@ -34,7 +34,7 @@
     {"id": "swift-testing-pro",     "repo": "twostraws/Swift-Testing-Agent-Skill",     "ref": "main", "description": "Swift Testing code review and authoring — modern APIs (by Paul Hudson)"},
     {"id": "swift-concurrency-pro", "repo": "twostraws/Swift-Concurrency-Agent-Skill", "ref": "main", "description": "Swift concurrency code review and authoring — actors, async/await, structured concurrency (by Paul Hudson)"},
 
-    {"id": "tdd",                         "repo": "mattpocock/skills",   "ref": "main", "subdir": "tdd",                            "description": "Test-driven development — vertical-slice tracer bullets, integration-style tests, interface design for testability (by Matt Pocock)"},
+    {"id": "tdd",                         "repo": "mattpocock/skills",   "ref": "main", "subdir": "skills/engineering/tdd",         "description": "Test-driven development — vertical-slice tracer bullets, integration-style tests, interface design for testability (by Matt Pocock)"},
     {"id": "brainstorming",               "repo": "obra/superpowers",    "ref": "main", "subdir": "skills/brainstorming",           "description": "Ideation before coding — explore the problem space before committing to a solution (from obra/superpowers)"},
     {"id": "systematic-debugging",        "repo": "obra/superpowers",    "ref": "main", "subdir": "skills/systematic-debugging",    "description": "Root-cause tracing, condition-based waiting, defense-in-depth for reproducing and fixing bugs (from obra/superpowers)"},
     {"id": "verification-before-completion", "repo": "obra/superpowers", "ref": "main", "subdir": "skills/verification-before-completion", "description": "Pre-handoff check — verify the work against the spec before calling it done (from obra/superpowers)"},


### PR DESCRIPTION
`mattpocock/skills` restructured — `tdd/` moved to `skills/engineering/tdd/`, so the installer was failing with `tdd not found in mattpocock/skills`. Update `skills.json` subdir + matching README references. Verified end-to-end: `init --skills tdd` now resolves and symlinks all five skill files.