### PR TITLE
Add microsoft/playwright-cli external skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ of native plugin formats and a shared npx installer.
   `obsidian-vault`, `msgraph`, `project-seeder`.
 - **`skills.json`** — catalog of all skills, monorepo and external.
   The installer uses it to resolve + fetch external skills (from
-  `mattpocock/skills`, `obra/superpowers`, `twostraws/*-Agent-Skill`).
+  `mattpocock/skills`, `obra/superpowers`, `twostraws/*-Agent-Skill`,
+  `microsoft/playwright-cli`).
 
 ## Install — the recommended path
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -41,6 +41,7 @@ are capability definitions, not always-on context.
 | `git-workflow` | Branching, commits, PRs, rebasing |
 | `memory` | Need to remember something across sessions |
 | `playwright-testing` | Writing or running E2E browser tests |
+| `playwright-cli` | Driving Playwright from the CLI — interactive browser sessions, snapshot/locator interaction, network mocking, tracing, test generation (external, by Microsoft) |
 | `browser-verify` | Quick visual / smoke check in a browser |
 | `issue-tracking` | Managing GitHub / Linear / GitLab issues |
 | `goal-verifier` | Checking whether a task actually achieved its outcome |

--- a/README.md
+++ b/README.md
@@ -42,11 +42,13 @@ flowchart TB
         ext_matt[["mattpocock/skills<br/>tdd"]]
         ext_obra[["obra/superpowers<br/>brainstorming, debugging,<br/>verification, ..."]]
         ext_tws[["twostraws/*-Agent-Skill<br/>SwiftUI, SwiftData,<br/>Swift Testing, Concurrency"]]
+        ext_msft[["microsoft/playwright-cli<br/>playwright-cli"]]
     end
 
     installer ==>|fetch at install time| ext_matt
     installer ==>|fetch at install time| ext_obra
     installer ==>|fetch at install time| ext_tws
+    installer ==>|fetch at install time| ext_msft
 
     sdlc ==>|direct install via<br/>plugin manifest or npx| ides
     sdlc ==>|install.sh delegates<br/>content to npx| octobots
@@ -349,6 +351,7 @@ catalog.
 | `swiftdata-pro` | [`twostraws/SwiftData-Agent-Skill`](https://github.com/twostraws/SwiftData-Agent-Skill) | `ios-dev` |
 | `swift-testing-pro` | [`twostraws/Swift-Testing-Agent-Skill`](https://github.com/twostraws/Swift-Testing-Agent-Skill) | `ios-dev` |
 | `swift-concurrency-pro` | [`twostraws/Swift-Concurrency-Agent-Skill`](https://github.com/twostraws/Swift-Concurrency-Agent-Skill) | `ios-dev` |
+| `playwright-cli` | [`microsoft/playwright-cli`](https://github.com/microsoft/playwright-cli) → `skills/playwright-cli/` | `qa-engineer`, `test-automation-engineer` |
 
 ## Using outside Octobots
 
@@ -454,6 +457,7 @@ re-distributes nothing, only catalogs and wires.
 - **[`mattpocock/skills`](https://github.com/mattpocock/skills)** — Matt Pocock. `tdd/` (vertical-slice tracer bullets, integration-style tests, interface design for testability). MIT.
 - **[`obra/superpowers`](https://github.com/obra/superpowers)** — Jesse Vincent. `brainstorming`, `systematic-debugging`, `verification-before-completion`, `requesting-code-review`, `receiving-code-review`, `writing-skills`. MIT.
 - **Paul Hudson's Swift agent skills** — [`twostraws/SwiftUI-Agent-Skill`](https://github.com/twostraws/SwiftUI-Agent-Skill), [`twostraws/SwiftData-Agent-Skill`](https://github.com/twostraws/SwiftData-Agent-Skill), [`twostraws/Swift-Testing-Agent-Skill`](https://github.com/twostraws/Swift-Testing-Agent-Skill), [`twostraws/Swift-Concurrency-Agent-Skill`](https://github.com/twostraws/Swift-Concurrency-Agent-Skill). Powers the `ios-dev` agent. MIT.
+- **[`microsoft/playwright-cli`](https://github.com/microsoft/playwright-cli)** — Microsoft Playwright. `skills/playwright-cli/` (drive Playwright from the command line — browser launch, navigation, snapshot/locator interaction, tabs and storage, network mocking, tracing, test generation). Used by `qa-engineer` and `test-automation-engineer`. Apache-2.0.
 
 Thanks to all maintainers.
 

--- a/TEST-AUTOMATION-ONBOARDING.md
+++ b/TEST-AUTOMATION-ONBOARDING.md
@@ -68,7 +68,7 @@ cd /path/to/your-automation-repo
 npx github:arozumenko/sdlc-skills init \
   --target copilot \
   --agents scout,project-manager,tech-lead,qa-engineer,test-automation-engineer \
-  --skills project-seeder,test-case-analysis,test-automation-workflow,playwright-testing,browser-verify,bugfix-workflow,code-review,task-completion,issue-tracking,atlassian-content,xray-testing,memory,tdd,git-workflow,plan-feature \
+  --skills project-seeder,test-case-analysis,test-automation-workflow,playwright-testing,playwright-cli,browser-verify,bugfix-workflow,code-review,task-completion,issue-tracking,atlassian-content,xray-testing,memory,tdd,git-workflow,plan-feature \
   --yes
 ```
 

--- a/agents/qa-engineer/AGENT.md
+++ b/agents/qa-engineer/AGENT.md
@@ -6,7 +6,7 @@ color: green
 group: qa
 theme: {color: colour156, icon: "🧪", short_name: qa}
 aliases: [qa, sage]
-skills: [playwright-testing, browser-verify, bugfix-workflow, test-case-analysis, systematic-debugging, verification-before-completion, issue-tracking, memory]
+skills: [playwright-testing, playwright-cli, browser-verify, bugfix-workflow, test-case-analysis, systematic-debugging, verification-before-completion, issue-tracking, memory]
 ---
 
 @.agents/memory/qa-engineer/snapshot.md

--- a/agents/test-automation-engineer/AGENT.md
+++ b/agents/test-automation-engineer/AGENT.md
@@ -7,7 +7,7 @@ workspace: clone
 group: qa
 theme: {color: colour208, icon: "🤖", short_name: tae}
 aliases: [test-automation-engineer, axel, automation]
-skills: [test-automation-workflow, playwright-testing, browser-verify, tdd, code-review, bugfix-workflow, systematic-debugging, verification-before-completion, requesting-code-review, receiving-code-review, git-workflow, task-completion, memory]
+skills: [test-automation-workflow, playwright-testing, playwright-cli, browser-verify, tdd, code-review, bugfix-workflow, systematic-debugging, verification-before-completion, requesting-code-review, receiving-code-review, git-workflow, task-completion, memory]
 ---
 
 @.agents/memory/test-automation-engineer/snapshot.md

--- a/skills.json
+++ b/skills.json
@@ -40,6 +40,8 @@
     {"id": "verification-before-completion", "repo": "obra/superpowers", "ref": "main", "subdir": "skills/verification-before-completion", "description": "Pre-handoff check — verify the work against the spec before calling it done (from obra/superpowers)"},
     {"id": "writing-skills",              "repo": "obra/superpowers",    "ref": "main", "subdir": "skills/writing-skills",          "description": "Meta-skill for authoring SKILL.md files — structure, triggers, and verification (from obra/superpowers)"},
     {"id": "requesting-code-review",      "repo": "obra/superpowers",    "ref": "main", "subdir": "skills/requesting-code-review",  "description": "How to hand off work for review — prepare context, state scope, make the reviewer's job easy (from obra/superpowers)"},
-    {"id": "receiving-code-review",       "repo": "obra/superpowers",    "ref": "main", "subdir": "skills/receiving-code-review",   "description": "How to process review feedback — verify technically, don't perform agreement (from obra/superpowers)"}
+    {"id": "receiving-code-review",       "repo": "obra/superpowers",    "ref": "main", "subdir": "skills/receiving-code-review",   "description": "How to process review feedback — verify technically, don't perform agreement (from obra/superpowers)"},
+
+    {"id": "playwright-cli",              "repo": "microsoft/playwright-cli", "ref": "main", "subdir": "skills/playwright-cli",      "description": "Drive Playwright from the command line — launch browsers, navigate, interact via snapshots/locators, manage tabs and storage, mock network, record traces, and generate Playwright tests (by Microsoft Playwright)"}
   ]
 }

--- a/skills/test-automation-workflow/SKILL.md
+++ b/skills/test-automation-workflow/SKILL.md
@@ -10,10 +10,14 @@ metadata:
 ## Test Automation Workflow: Explore → Specify → Implement → Review
 
 **Core philosophy:** do not automate what you have not executed. Every case is
-run manually (via `browser-verify` or Playwright MCP) first — defects, missing
-data, and environmental gaps are surfaced *before* a line of automation code is
-written. Then a separate engineer implements the automation inside the
-project's existing framework. Then a reviewer re-runs it.
+run manually first — pick whichever browser tool is wired and fits the
+challenge (`playwright-testing` over MCP, `playwright-cli` from the shell,
+`browser-verify` over CDP; full triage in
+[`references/browser-tools.md`](references/browser-tools.md)) — so defects,
+missing data, and environmental gaps are surfaced *before* a line of
+automation code is written. Then a separate engineer implements the
+automation inside the project's existing framework. Then a reviewer
+re-runs it.
 
 **Why split the work into two agents:** context. The analysis pass
 carries exploration state (DOM snapshots, test data, console noise)
@@ -25,8 +29,11 @@ one context breaks the bot; the skill split keeps each workspace lean
 even though only two personas touch it.
 
 **Re-used skills:** composes on top of `playwright-testing`,
-`browser-verify`, `bugfix-workflow`, `code-review`, `tdd`,
-`task-completion`, and `project-seeder`. It does not reinvent them.
+`playwright-cli`, `browser-verify`, `bugfix-workflow`, `code-review`,
+`tdd`, `task-completion`, and `project-seeder`. It does not reinvent
+them. The browser-tool triage (which of the three Playwright/CDP
+skills to use for a given challenge) lives in
+[`references/browser-tools.md`](references/browser-tools.md).
 
 ## Routing — how PM resolves slots to agents
 

--- a/skills/test-automation-workflow/references/browser-tools.md
+++ b/skills/test-automation-workflow/references/browser-tools.md
@@ -1,0 +1,80 @@
+# Browser tools — pick the right one
+
+Three skills can drive a browser in this monorepo. None replaces the
+others — they sit at different layers and excel at different things.
+Load this reference when you have to pick (or switch) during AFS
+authoring, ad-hoc verification, or while implementing a test.
+
+## The three tools
+
+| Skill | Layer | Best at | Reach for it when |
+|---|---|---|---|
+| [`playwright-testing`](../../playwright-testing/) | Playwright **MCP server** (in-host tool calls) | Snapshot-driven interaction — `browser_snapshot`, `browser_click`, `browser_fill`, `browser_navigate`. Accessible-name discovery falls out for free. | **Default** for analyst exploration and any interactive check when the Playwright MCP server is wired into the host. |
+| [`playwright-cli`](../../playwright-cli/) | Microsoft Playwright **CLI** (shell) | Same Playwright browser surface, driven from `npx playwright-cli` / `playwright-cli` commands. Multi-tab, storage, request mocking, tracing, `codegen` (test generation), persistent profiles. | The Playwright MCP server isn't available, or you want a reproducible **shell command** instead of a tool call — CI smoke, trace capture, codegen, deep CLI flows. |
+| [`browser-verify`](../../browser-verify/) | **Chrome DevTools Protocol** (CDP) | Computed styles, real CDP input events, storage/cookies dump, axe accessibility audit, screenshot diffs. Lighter than full Playwright. | Visual smoke check, accessibility audit, deep DOM inspection, or when Playwright (MCP + CLI) is overkill for the question. |
+
+## Availability — check before you pick
+
+Before choosing a tool, scan the host's environment:
+
+1. **Playwright MCP server up?** Look for `mcp__playwright__*` /
+   `playwright/*` entries in the host's tool list (Claude Code, Copilot
+   CLI, Cursor, Windsurf). If present, `playwright-testing` is the
+   default.
+2. **`playwright-cli` installed?** Check `npx playwright-cli --version`,
+   or whether the `playwright-cli` skill is loaded into the session. If
+   yes, it's an in-shell substitute when MCP is down — and a complement
+   for CLI-native workflows like `codegen` and trace recording.
+3. **`browser-verify` skill loaded?** It's a monorepo skill, almost
+   always installed for QA / test-automation agents. Use it for
+   visual / CDP / accessibility checks regardless of the above.
+
+If only `browser-verify` is available you can still execute most
+analyst-side flows — you'll just be more verbose. Note that constraint
+in the AFS / PR so the next reader knows what produced what.
+
+## Pick by challenge
+
+- **Authoring an AFS step-by-step** → `playwright-testing` (snapshot
+  yields the ref + accessible name in one call). Falls back to
+  `playwright-cli` if MCP is offline; to `browser-verify` if neither.
+- **Selector is flaky / accessible name unclear** → re-snapshot via
+  `playwright-testing`; or use `browser-verify` for computed-style /
+  shadow-DOM dive; or `playwright-cli codegen` to see the locator
+  Playwright itself proposes.
+- **Visual regression / pixel-level diff** → `browser-verify`
+  (screenshot + diff).
+- **Accessibility audit (axe)** → `browser-verify`.
+- **Multi-tab / multi-window / storage manipulation** →
+  `playwright-testing` if the MCP server exposes the relevant tools;
+  `playwright-cli` otherwise (first-class CLI territory).
+- **Capturing a trace for a flake report** → `playwright-cli`
+  (`--trace=on`). The resulting `.zip` opens in Playwright Trace Viewer.
+- **Generating starter Playwright code** → `playwright-cli codegen`.
+  Treat output as a sketch; rewrite to project conventions
+  (page-object style, fixture pattern, naming) before committing.
+- **CI smoke from a shell script** → `playwright-cli` (deterministic,
+  no MCP runtime needed).
+
+## Switching is fine — but log why
+
+If the first tool you try doesn't give the answer (snapshot is stale,
+MCP times out, CDP can't reach a deeply nested iframe), switch to the
+next. Don't ping-pong silently — note in the AFS (or PR body) which
+tool produced which observation:
+
+> Logged in via `playwright-testing` (snapshot ref `s4f2`).
+> Verified computed `aria-expanded` via `browser-verify` because the
+> snapshot wasn't surfacing it after the dropdown animation.
+
+This is **guidance, not a hard rule**. Use your judgement. The only
+firm constraint is honesty: don't synthesize an observation you
+couldn't reproduce through any of these tools — that masks real
+product behaviour.
+
+## Agents that load this reference
+
+- `qa-engineer` (Sage) — via `test-case-analysis` during AFS authoring.
+- `test-automation-engineer` (Axel) — via `test-automation-workflow`
+  during implementation, when a chosen tool isn't producing useful
+  evidence and a switch may unblock the test.

--- a/skills/test-case-analysis/SKILL.md
+++ b/skills/test-case-analysis/SKILL.md
@@ -64,15 +64,25 @@ linked story, attachments.
 
 ### 3. Execute
 
-Primary tool: the [`playwright-testing`](../playwright-testing/) skill
-(`browser_navigate`, `browser_snapshot`, `browser_click`, …). Prefer
-`browser_snapshot` for accessible-name discovery — it yields both the
-ref you need to click and the role-name pair you'll assert on.
+Three browser tools sit at different layers; pick by what's wired and
+what challenge you're solving. Full triage:
+[`../test-automation-workflow/references/browser-tools.md`](../test-automation-workflow/references/browser-tools.md).
+In short:
 
-Fallback / deep inspection:
-[`browser-verify`](../browser-verify/) — use when you need computed
-styles, real CDP input events, storage/cookies, or axe accessibility
-audits.
+- **Default** — [`playwright-testing`](../playwright-testing/)
+  (Playwright MCP). Prefer `browser_snapshot` for accessible-name
+  discovery — it yields both the ref you need to click and the
+  role-name pair you'll assert on.
+- **MCP server not wired** — [`playwright-cli`](../playwright-cli/)
+  drives the same browser surface from the shell (`codegen`,
+  `--trace`, multi-tab, storage, request mocking).
+- **Visual / CDP / a11y** — [`browser-verify`](../browser-verify/)
+  for computed styles, real CDP input events, storage/cookies, or axe
+  audits.
+
+Soft guidance, not a hard rule: switching tools mid-case is fine when
+the first one isn't producing useful evidence — note which tool
+produced which observation in the AFS so the next reader can follow.
 
 For each step:
 


### PR DESCRIPTION
Adds `microsoft/playwright-cli` to the external skill catalog and a triage guide for choosing between MCP and CLI browser tooling. Gives agents a lightweight, host-portable browser automation path alongside the MCP approach.