### PR TITLE
atlassian-content: add Jira Server/DC and Confluence Server support

### DIFF
--- a/skills/atlassian-content/SKILL.md
+++ b/skills/atlassian-content/SKILL.md
@@ -1,23 +1,26 @@
 ---
 name: atlassian-content
-description: Create well-formatted Jira issues/comments (ADF, API v3) and Confluence pages (storage format) with accountId-backed mentions and mandatory post-creation re-fetch + repair. Load for "file a bug", "review comment on JIRA-123", "write up a decision page", or any authored Atlassian content.
+description: Create well-formatted Jira issues/comments and Confluence pages on both Cloud (ADF + API v3, accountId mentions) and Server / Data Center (wiki markup + API v2, [~username] mentions), with mandatory post-creation re-fetch + repair. Load for "file a bug", "review comment on JIRA-123", "write up a decision page", or any authored Atlassian content.
 license: Apache-2.0
 metadata:
   author: octobots
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # Atlassian content — Jira + Confluence, done right
 
-Atlassian's two content surfaces have **two completely different
-formats**, and markdown is not either of them. Content submitted in
-the wrong format renders as a wall of asterisks, broken tables,
-orphan `@username` strings, and code blocks that display as plain
-paragraphs. This skill is the rulebook for getting it right the
-first time and verifying it after.
+Atlassian has **two deployments** (Cloud and Server / Data Center)
+and **two content surfaces** (Jira and Confluence). That's a 2×2
+grid of formats, mention syntaxes, and API versions — and markdown
+is none of them. Content submitted in the wrong format renders as
+a wall of asterisks, broken tables, orphan `@username` strings,
+and code blocks that display as plain paragraphs. This skill is
+the rulebook for getting it right the first time and verifying it
+after.
 
-**Core principle:** *Format-match the surface, resolve identities
-before you post, and always re-fetch what you wrote.*
+**Core principle:** *Detect the deployment, format-match the
+surface, resolve identities before you post, and always re-fetch
+what you wrote.*
 
 ## When to load this skill
 
@@ -37,15 +40,30 @@ field reads, user lookups) — those don't need formatting rules.
 
 ## Absolute boundaries
 
-- **Never post markdown into Jira or Confluence.** Jira Cloud API v3
-  expects **ADF** (Atlassian Document Format — a structured JSON
-  document). Confluence REST expects **storage format** (XHTML-ish
-  markup with `<ac:*>` / `<ri:*>` macros). Neither surface
-  interprets markdown natively via the API.
-- **Never mention by `@username`.** Both surfaces mention by
-  **`accountId`** (Cloud). A free-text `@Alexander` string posts as
-  a literal `@Alexander` — no notification, no link, no profile
-  card.
+- **Never post markdown into Jira or Confluence.** Each
+  deployment / surface has a specific expected format:
+  - **Jira Cloud** (API v3) → **ADF** (Atlassian Document Format,
+    a structured JSON document).
+  - **Jira Server / DC** (API v2) → **wiki markup** (plain string,
+    e.g. `h2. Title`, `*bold*`, `{code}…{code}`).
+  - **Confluence Cloud + Server / DC** → **storage format** (an
+    XHTML-ish markup with `<ac:*>` / `<ri:*>` macros — same on
+    both deployments). Confluence Server also accepts wiki markup
+    via `body.wiki` input as a one-shot convenience.
+
+  None of these surfaces interpret markdown natively via the API.
+- **Never mention by `@username` free-text.** Each deployment has
+  its own mention syntax:
+  - **Cloud (both Jira and Confluence)** → mention by
+    **`accountId`** (ADF `mention` node / `<ri:user
+    ri:account-id="…"/>`).
+  - **Jira Server / DC** → `[~username]` inside wiki markup,
+    where `username` is the login `name` from `/rest/api/2/user/search`.
+  - **Confluence Server / DC** → `<ri:user ri:userkey="…"/>` or
+    `<ri:user ri:username="…"/>` inside storage format.
+
+  A free-text `@Alexander` string posts as a literal `@Alexander`
+  on every surface — no notification, no link, no profile card.
 - **Never declare a post "done" without re-fetching it.** The only
   ground truth is what the server returns after creation. Run the
   verification pass (see `references/verification.md`) on every
@@ -53,8 +71,9 @@ field reads, user lookups) — those don't need formatting rules.
 - **Never update without first fetching the raw current body.**
   For any edit / append on an existing issue description, comment,
   or Confluence page, fetch the current content in its **raw
-  structured view** first (ADF doc for Jira, storage format string
-  for Confluence) — not the rendered HTML. Reading the raw body is
+  structured view** first — ADF JSON for Jira Cloud, wiki-markup
+  string for Jira Server / DC, storage-format XHTML for Confluence
+  (any deployment). NOT the rendered HTML. Reading the raw body is
   how you see the existing macros, custom nodes, versioned
   structure, and formatting conventions the page already uses.
   Edit *into* that structure; don't overwrite it with a fresh body
@@ -70,6 +89,43 @@ field reads, user lookups) — those don't need formatting rules.
   illustrates an API call, redact credentials. This skill writes
   user-facing content; credentials belong in `.env` / auth_env, not
   in descriptions.
+
+## Detect deployment first — Cloud vs Server / Data Center
+
+Before you assemble anything, know which deployment you're hitting.
+The format, the API version, and the mention syntax all depend on
+it.
+
+**Signals to read (in order of preference):**
+
+1. `.agents/profile.md` § Project systems — typically declares
+   `JIRA_BASE_URL` / `CONFLUENCE_BASE_URL` and which API the
+   project uses. If the profile says "Server" or names a v2
+   endpoint, follow that.
+2. **The base URL pattern:**
+   - `https://<tenant>.atlassian.net` (Jira Cloud) or
+     `https://<tenant>.atlassian.net/wiki` (Confluence Cloud)
+     → **Cloud**.
+   - Anything else (custom domain like `jira.company.com`,
+     `confluence.company.com`, IP, internal hostname)
+     → almost certainly **Server / DC**.
+3. **A probe `GET`** when in doubt:
+   - `GET /rest/api/3/myself` — 200 on Cloud, 404 on Server.
+   - `GET /rest/api/2/myself` — 200 on both, but the response
+     omits `accountId` on Server.
+   - On Confluence, `GET /rest/api/user/current` returns an
+     `accountId` field on Cloud and a `userKey` field on Server.
+
+**Decision table:**
+
+| Deployment | Jira API | Jira body format | Jira mention | Confluence API | Confluence body | Confluence mention |
+|---|---|---|---|---|---|---|
+| **Cloud** | `/rest/api/3/*` | ADF (JSON doc) | `accountId` mention node | `/wiki/rest/api/content` (v1) or `/wiki/api/v2/pages` (v2) | storage format (XHTML) | `<ri:user ri:account-id="…"/>` |
+| **Server / DC** | `/rest/api/2/*` | wiki markup (string) | `[~username]` | `/rest/api/content` (v1) | storage format (XHTML), also accepts `body.wiki` | `<ri:user ri:userkey="…"/>` or `ri:username` |
+
+Once you know the deployment, the rest of the loop is determined:
+the right reference file, the right user-lookup endpoint, the
+right re-fetch path.
 
 ## Transport — MCP preferred, curl fallback, browser last resort
 
@@ -88,12 +144,17 @@ same ADF as ADF over curl.
 ```
 0. If updating an existing resource:
    Raw-fetch first  → GET the current body in its structured form
-                      (ADF for Jira, storage format for Confluence),
+                      (Cloud Jira → ADF JSON; Server Jira → wiki markup
+                      string; Confluence → storage-format XHTML),
                       read it, and merge your change into it —
                       don't regenerate from scratch.
 1. Detect surface      → Jira issue, Jira comment, or Confluence page?
-2. Resolve identities  → mentions by accountId; project/space keys; issue keys
-3. Assemble body       → ADF (Jira) or storage format (Confluence)
+                         (deployment was determined upfront — see
+                         § "Detect deployment first")
+2. Resolve identities  → mentions by accountId (Cloud) / username (Server);
+                         project/space keys; issue keys
+3. Assemble body       → ADF (Cloud Jira), wiki markup (Server Jira),
+                         or storage format (Confluence either way)
 4. Submit              → MCP tool or REST endpoint
 5. Re-fetch            → GET the resource back, don't trust the POST response alone
 6. Validate            → run the checklist in references/verification.md
@@ -105,43 +166,71 @@ filed.
 
 ### 1. Detect surface
 
-Three surfaces, three format rules:
+You already know the **deployment** (Cloud vs Server / DC — see
+the decision table in § "Detect deployment first"). Now pick the
+surface:
 
-| Surface | Format | Endpoint (Cloud) |
+| Surface | Format (Cloud) | Format (Server / DC) |
 |---|---|---|
-| Jira issue create / update | **ADF** under `fields.description` (+ other rich-text custom fields) | `POST /rest/api/3/issue`, `PUT /rest/api/3/issue/{key}` |
-| Jira comment | **ADF** under `body` | `POST /rest/api/3/issue/{key}/comment` |
-| Confluence page create / update | **storage format** (string) under `body.storage.value`, `representation: "storage"` | `POST /wiki/rest/api/content`, `PUT /wiki/rest/api/content/{id}` |
+| Jira issue create / update | **ADF** under `fields.description` (+ rich-text custom fields) — `POST /rest/api/3/issue`, `PUT /rest/api/3/issue/{key}` | **wiki markup** string under `fields.description` — `POST /rest/api/2/issue`, `PUT /rest/api/2/issue/{key}` |
+| Jira comment | **ADF** under `body` — `POST /rest/api/3/issue/{key}/comment` | **wiki markup** string under `body` — `POST /rest/api/2/issue/{key}/comment` |
+| Confluence page create / update | **storage format** (XHTML string) under `body.storage.value`, `representation: "storage"` — `POST /wiki/rest/api/content` | **storage format** under `body.storage.value` — `POST /rest/api/content` (no `/wiki/` prefix) |
 
 If you're unsure which surface you're targeting: a Jira issue key
 (`PROJ-123`) → Jira. A Confluence space key + page title → Confluence.
 
 ### 2. Resolve identities
 
-Before assembling the body, collect every identity you'll reference:
+Before assembling the body, collect every identity you'll
+reference. The lookup endpoint and identifier you carry depend on
+the deployment:
 
-- **Users** → `accountId`. Look up via `GET /rest/api/3/user/search?query=<email-or-name>`
-  (Jira) or `GET /wiki/rest/api/user?username=...` (Confluence) if
-  you only know a name/email. **Cache per session** — the same
-  person has the same `accountId` across both surfaces in a given
-  Atlassian tenant.
+- **Users:**
+  - **Cloud** → `accountId`. Look up via
+    `GET /rest/api/3/user/search?query=<email-or-name>` (Jira)
+    or `GET /wiki/rest/api/user?username=…` (Confluence).
+  - **Jira Server / DC** → `name` (the login username) and `key`
+    (stable internal id, e.g. `JIRAUSER10042`). Look up via
+    `GET /rest/api/2/user/search?username=<query>` or the fuzzier
+    `GET /rest/api/2/user/picker?query=<text>`. The `name` is
+    what goes inside `[~name]`.
+  - **Confluence Server / DC** → `userKey` (preferred) or
+    `username`. Look up via `GET /rest/api/user?username=<name>`.
+
+  **Cache per session.** On Cloud, the same `accountId` works
+  across Jira and Confluence in the same tenant. On Server,
+  Jira and Confluence are usually separate installs with
+  separate user directories — don't reuse identifiers across them
+  unless the operator confirms shared SSO.
 - **Jira project key** → usually known from the task
-  (`.agents/profile.md` § Project systems). If not, `GET /rest/api/3/project`.
+  (`.agents/profile.md` § Project systems). If not,
+  `GET /rest/api/{2|3}/project`.
 - **Confluence space key** → likewise from profile; otherwise
-  `GET /wiki/rest/api/space`.
-- **Linked issues** → the issue keys themselves; ADF `inlineCard`
-  or `mention`-style cards render them.
+  `GET /rest/api/space` (Server) or `GET /wiki/rest/api/space` (Cloud).
+- **Linked issues** → the issue keys themselves. On Cloud, ADF
+  `inlineCard` renders them as live cards; on Server, bare
+  `PROJ-123` strings auto-link.
 
 If you cannot resolve a user, **do not invent a mention**. Fall
 back to plain text (`"Hi Alexander, "`) or ask the operator.
 
 ### 3. Assemble body
 
-- **Jira** → build an ADF document. See `references/jira-adf.md`
-  for the complete node/mark reference and working examples.
-- **Confluence** → build a storage-format XHTML string. See
-  `references/confluence-storage.md`.
-- **Mentions** (both surfaces) → see `references/mentions.md`.
+Pick the right reference for the deployment + surface you landed
+on in step 1:
+
+- **Jira Cloud** → build an ADF document.
+  See `references/jira-adf.md`.
+- **Jira Server / Data Center** → build a wiki-markup string.
+  See `references/jira-wiki-server.md` (covers `h2.` headings,
+  `*bold*`, `||header||` tables, `{code}` / `{panel}` / `{info}`
+  macros, `[~username]` mentions, and the renderer-trap).
+- **Confluence (any deployment)** → build a storage-format XHTML
+  string. See `references/confluence-storage.md` for the body
+  syntax. For Server-specific wrapper / mention / auth
+  differences, see `references/confluence-server.md`.
+- **Mentions** (all surfaces, both deployments) → see
+  `references/mentions.md`.
 
 ### 4. Submit
 
@@ -150,16 +239,29 @@ the body you assembled in step 3 is the body you send.
 
 ### 5. Re-fetch
 
-Read back what you just wrote:
+Read back what you just wrote. Endpoint depends on the deployment:
+
+**Cloud:**
 
 - `GET /rest/api/3/issue/{key}?expand=renderedFields` — compare
-  ADF in `fields.description` and the rendered HTML in
-  `renderedFields.description`. If the rendered HTML is empty,
-  malformed, or missing expected elements, your ADF is wrong.
+  ADF in `fields.description` with rendered HTML in
+  `renderedFields.description`. Empty / malformed HTML = ADF is wrong.
 - `GET /rest/api/3/issue/{key}/comment/{id}?expand=renderedBody`
 - `GET /wiki/rest/api/content/{id}?expand=body.storage,body.view` —
-  compare `body.storage` (what you submitted) with `body.view` (how
-  Confluence renders it).
+  compare `body.storage` (what you submitted) with `body.view`
+  (how Confluence renders it).
+
+**Server / Data Center:**
+
+- `GET /rest/api/2/issue/{key}?expand=renderedFields` — compare
+  the wiki source in `fields.description` with the rendered HTML
+  in `renderedFields.description`. **If the rendered HTML contains
+  literal `h2.` / `*asterisks*` instead of `<h2>` / `<strong>`,
+  the field is on Default Text Renderer** — see
+  `references/jira-wiki-server.md` § "The renderer trap".
+- `GET /rest/api/2/issue/{key}/comment/{id}?expand=renderedBody`
+- `GET /rest/api/content/{id}?expand=body.storage,body.view` —
+  same storage-vs-view comparison as Cloud, just no `/wiki/` prefix.
 
 ### 6. Validate
 
@@ -174,6 +276,8 @@ Non-negotiable items:
 - Headings render as headings (not bold paragraphs)
 - Links are clickable (not bare URLs in text)
 - No literal `**bold**` / `# heading` markdown artefacts
+- (Jira Server only) No literal `h2.` / `*asterisks*` / `||pipes||`
+  in the rendered HTML — that signals Default Text Renderer
 
 ### 7. Repair
 
@@ -186,20 +290,27 @@ is a broken window.
 
 ```
 Task: "file a bug for case X"
-  └─ surface = Jira issue
-     └─ format = ADF under fields.description
-        └─ mentions of reporter / assignee → accountId nodes
-           └─ submit → re-fetch → validate → (repair if needed)
+  └─ deployment = Cloud?
+     │   └─ surface = Jira issue, format = ADF (fields.description)
+     │      mentions → accountId mention nodes
+     │      endpoint → POST /rest/api/3/issue
+     └─ deployment = Server / DC?
+         └─ surface = Jira issue, format = wiki markup string
+            mentions → [~username]
+            endpoint → POST /rest/api/2/issue
+            check the field renderer before trusting the rendering
+  └─ submit → re-fetch → validate → (repair if needed)
 
 Task: "add a review comment on JIRA-123"
-  └─ surface = Jira comment
-     └─ format = ADF under body
-        └─ submit → re-fetch renderedBody → validate
+  └─ Cloud  → ADF body, POST /rest/api/3/issue/JIRA-123/comment
+  └─ Server → wiki body, POST /rest/api/2/issue/JIRA-123/comment
+  └─ submit → re-fetch renderedBody → validate
 
 Task: "document the migration plan on the Engineering space"
-  └─ surface = Confluence page
-     └─ format = storage format under body.storage.value
-        └─ submit → re-fetch body.view → validate
+  └─ surface = Confluence page (storage format, both deployments)
+     Cloud  → POST /wiki/rest/api/content with ri:account-id mentions
+     Server → POST /rest/api/content      with ri:userkey mentions
+  └─ submit → re-fetch body.view → validate
 ```
 
 ## Anti-patterns (things that look fine but aren't)
@@ -225,33 +336,64 @@ Task: "document the migration plan on the Engineering space"
   format tolerates `<br/>` but prefers paragraph boundaries for
   prose. ADF has no `<br>` — use paragraph splits or `hardBreak`
   nodes.
+- **"I posted wiki markup to Cloud / ADF to Server"** —
+  symmetric and equally broken. ADF posted to a Server v2 field
+  serialises as JSON-string garbage. Wiki markup posted to a
+  Cloud v3 ADF field is rejected. Detect the deployment first.
+- **"My `[~username]` rendered as plain text on Server"** —
+  the field is configured for the Default Text Renderer, OR the
+  username doesn't match the user's `name` exactly. Probe via
+  `?expand=renderedFields` or fall back to plain text.
+- **"I sent `assignee.accountId` to Server"** — silently
+  ignored or rejected. On Server, use `assignee.name`.
 
 ## Escalation — when to ask the operator
 
 - The project's `.agents/profile.md` § Project systems doesn't
-  specify an issue tracker or the tracker is on-prem Jira Server
-  (which uses wiki markup, not ADF — different API version).
+  specify an issue tracker, OR doesn't tell you which deployment
+  (Cloud vs Server / DC) you're hitting — and a probe (see §
+  "Detect deployment first") doesn't disambiguate.
 - Credentials aren't configured and MCP isn't online.
-- A mention target can't be resolved to an accountId (user left
-  the company, ambiguous name).
+- A mention target can't be resolved to an identifier
+  (`accountId` on Cloud, `name` / `userKey` on Server) — user
+  left the company, ambiguous name, or the directory hides the
+  field.
+- (Server only) The rendered HTML from a probe still shows
+  literal `h2.` / `*asterisks*` — the field is on the Default
+  Text Renderer and the operator may need to flip the
+  configuration scheme or you may need to fall back to plain
+  text for that field.
 - The space / project requires fields you don't have values for
   (custom required fields on a specific issue type).
 
 ## References
 
-- `references/jira-adf.md` — ADF node/mark catalogue, the JIRA
-  SYNTAX REFERENCE, working examples (story with headings, lists,
-  tables, panels, code blocks, mentions)
-- `references/confluence-storage.md` — storage format primer,
-  common macros (`<ac:structured-macro>`), page creation examples
-- `references/mentions.md` — accountId lookup + mention nodes for
-  both surfaces
+- `references/jira-adf.md` — **Jira Cloud (API v3)**. ADF node /
+  mark catalogue and the JIRA SYNTAX REFERENCE for Cloud, with
+  working examples (story with headings, lists, tables, panels,
+  code blocks, mentions).
+- `references/jira-wiki-server.md` — **Jira Server / Data Center
+  (API v2)**. Wiki markup syntax, the renderer trap, `[~username]`
+  mentions, PAT auth, full bug-report payload.
+- `references/confluence-storage.md` — **Confluence storage
+  format**, applies to both Cloud and Server / DC. The XHTML body
+  primer (headings, lists, tables, code / info / panel macros,
+  `<ac:structured-macro>`).
+- `references/confluence-server.md` — Confluence Server / DC
+  specifics: base URL (no `/wiki/`), `ri:userkey` / `ri:username`
+  mentions, PAT auth, the `body.wiki` input shortcut.
+- `references/mentions.md` — user lookup + mention syntax across
+  every deployment / surface combination.
 - `references/verification.md` — post-creation checklist and
-  repair recipes
+  repair recipes for both deployments.
 
 External:
 
 - https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/
 - https://developer.atlassian.com/cloud/confluence/rest/v1/intro/
+- https://developer.atlassian.com/server/jira/platform/jira-rest-api-examples/
+- https://developer.atlassian.com/server/confluence/confluence-server-rest-api/
+- https://confluence.atlassian.com/adminjiraserver/configuring-renderers-938847270.html
+- https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html
 - https://github.com/sooperset/mcp-atlassian/tree/main/docs/guides
   (working MCP-server example with ADF + storage-format recipes)

--- a/skills/atlassian-content/references/confluence-server.md
+++ b/skills/atlassian-content/references/confluence-server.md
@@ -1,0 +1,247 @@
+# Confluence Server / Data Center — what's different from Cloud
+
+The **storage format** is the same XHTML-ish dialect on Server and
+on Cloud — Cloud inherited it from Server. Read
+`confluence-storage.md` for the body syntax (paragraphs, lists,
+tables, macros). This file covers **only** the Server-specific
+differences: base URL, API path, auth, mentions, and the
+`body.wiki` input shortcut.
+
+## Base URL — no `/wiki/` prefix
+
+| Deployment | Typical base | API path |
+|---|---|---|
+| Cloud | `https://acme.atlassian.net/wiki` | `…/wiki/rest/api/content` |
+| Server / DC | `https://confluence.company.com` | `…/rest/api/content` |
+
+Server installs Confluence at its own root (or under `/confluence`
+if explicitly configured). There is **no implicit `/wiki/`
+prefix** — hard-coding `/wiki/` will return 404.
+
+Check the deployment's actual context path in
+`.agents/profile.md` § Project systems or ask the operator.
+
+## REST endpoints (Server / DC v1)
+
+| Operation | Method + path |
+|---|---|
+| Create page | `POST /rest/api/content` |
+| Read page | `GET /rest/api/content/{id}?expand=body.storage,version,space` |
+| Update page | `PUT /rest/api/content/{id}` (must include `version.number + 1`) |
+| Delete page | `DELETE /rest/api/content/{id}` |
+| Find by space+title | `GET /rest/api/content?spaceKey=ENG&title=My+Page&expand=version` |
+| Add page comment | `POST /rest/api/content` with `"type": "comment"` + `container` |
+| User by username | `GET /rest/api/user?username=<name>` |
+| User by userkey | `GET /rest/api/user?key=<userKey>` |
+| Convert wiki → storage | `POST /rest/api/contentbody/convert/storage` |
+
+The wrapper JSON shape is identical to Cloud v1. Create payload:
+
+```json
+POST /rest/api/content
+{
+  "type": "page",
+  "title": "API Architecture Notes",
+  "space": { "key": "ENG" },
+  "ancestors": [ { "id": "65538" } ],
+  "body": {
+    "storage": {
+      "value": "<p>Hello <strong>world</strong>.</p>",
+      "representation": "storage"
+    }
+  }
+}
+```
+
+Update payload — **`version.number` is required and must be the
+current value + 1**:
+
+```json
+PUT /rest/api/content/{id}
+{
+  "type": "page",
+  "title": "API Architecture Notes",
+  "version": { "number": 5 },
+  "body": {
+    "storage": {
+      "value": "<p>Updated content.</p>",
+      "representation": "storage"
+    }
+  }
+}
+```
+
+Read raw + rendered:
+
+```
+GET /rest/api/content/{id}?expand=body.storage,body.view,version
+```
+
+## Authentication
+
+| Method | Header |
+|---|---|
+| Basic auth | `Authorization: Basic base64(user:password)` |
+| Personal Access Token | `Authorization: Bearer <PAT>` (Confluence 7.9+ / DC) |
+
+PATs are created at avatar → Profile → Personal Access Tokens.
+They cannot be used as a Basic password — that returns 401
+`AUTHENTICATED_FAILED`.
+
+## Mentions — `ri:userkey` or `ri:username`, never `ri:account-id`
+
+Cloud uses `ri:account-id`. **Server / DC does not.** Use either
+of these forms inside storage format:
+
+```html
+<ac:link>
+  <ri:user ri:userkey="ff8080814ba236dc014ba236f4e40001" />
+</ac:link>
+```
+
+```html
+<ac:link>
+  <ri:user ri:username="jsmith" />
+</ac:link>
+```
+
+Confluence Server will normalise `ri:username` → `ri:userkey` on
+save (the `userkey` is the stable per-instance identifier).
+
+Posting `ri:account-id="…"` to Server produces a broken-link
+placeholder in the rendered page.
+
+### Look up the userkey / username
+
+```
+GET /rest/api/user?username=jsmith
+→ {
+    "username": "jsmith",
+    "userKey": "ff8080814ba236dc014ba236f4e40001",   ← ri:userkey
+    "displayName": "Jane Smith",
+    "type": "known"
+  }
+```
+
+In Confluence Server, **`accountId` is absent**. Cache by
+username, store the `userKey` so future mentions can use the
+stable form.
+
+Full paragraph example:
+
+```html
+<p>
+  Hi
+  <ac:link><ri:user ri:username="jsmith" /></ac:link>,
+  please review.
+</p>
+```
+
+## `body.wiki` — Jira-style wiki markup as input (Server-only)
+
+Confluence Server's v1 REST API accepts three input
+representations on `POST` / `PUT /rest/api/content`:
+
+- `storage` — XHTML storage format (canonical, recommended).
+- `editor` — the in-browser editor's intermediate format.
+- `wiki` — **Jira-style wiki markup**. Server-side converter
+  expands it to storage and persists that.
+
+This is a hidden escape hatch when your agent already speaks
+Jira wiki notation. Example:
+
+```json
+POST /rest/api/content
+{
+  "type": "page",
+  "title": "Release Notes 2026.05",
+  "space": { "key": "REL" },
+  "body": {
+    "wiki": {
+      "value": "h1. 2026.05\n\n* New: foo\n* Fixed: bar\n\n{code:bash}\n./deploy.sh\n{code}\n\ncc [~jsmith]",
+      "representation": "wiki"
+    }
+  }
+}
+```
+
+Caveats:
+
+- **Cloud v2 removed `body.wiki` from Update Content**; it still
+  works on Server / DC v1. Don't port the payload to Cloud
+  unchanged.
+- On `GET`, you cannot read back `body.wiki` — the API exposes
+  only `body.storage`, `body.view`, `body.export_view`,
+  `body.styled_view`, `body.editor`. To round-trip wiki, POST
+  the storage value back through the converter:
+
+  ```
+  POST /rest/api/contentbody/convert/storage
+  { "value": "h1. Hello", "representation": "wiki" }
+  → { "value": "<h1>Hello</h1>", "representation": "storage" }
+  ```
+
+- After a `wiki` POST, treat the page as storage-format from then
+  on — any subsequent updates should use the persisted
+  `body.storage.value` as the base (raw-fetch first, per
+  `verification.md` § "Before you update: raw-fetch first").
+
+## Storage format vs wiki markup — which to use
+
+| Use case | Recommended input |
+|---|---|
+| Net-new page authored programmatically | `body.storage` (XHTML) — explicit, round-trippable |
+| Net-new page where you already have wiki markup (e.g. ported from a Jira description) | `body.wiki` once, then storage from then on |
+| Updating an existing page | `body.storage` — preserves macros and custom nodes already on the page |
+
+Updating with `body.wiki` overwrites the entire page body —
+including any macros / custom nodes the previous storage value
+contained, since the converter only emits the subset it knows.
+**Always raw-fetch + edit-into-storage for updates.**
+
+## Worked example — full page-create payload (storage format)
+
+```json
+POST /rest/api/content
+{
+  "type": "page",
+  "title": "Checkout 500 — Investigation Notes (2026-05-14)",
+  "space": { "key": "ENG" },
+  "ancestors": [ { "id": "65538" } ],
+  "body": {
+    "storage": {
+      "representation": "storage",
+      "value": "<h1>Checkout 500 — Investigation Notes</h1><p>Author: <ac:link><ri:user ri:username=\"jsmith\" /></ac:link> · Date: 2026-05-14 · Related Jira: <a href=\"https://jira.company.com/browse/WEB-2001\">WEB-2001</a></p><ac:structured-macro ac:name=\"info\" ac:schema-version=\"1\"><ac:parameter ac:name=\"title\">Status</ac:parameter><ac:rich-text-body><p>Root cause identified; fix in PR <a href=\"https://github.com/acme/web/pull/8421\">#8421</a>.</p></ac:rich-text-body></ac:structured-macro><h2>Timeline</h2><table><tbody><tr><th>Time (UTC)</th><th>Event</th><th>Owner</th></tr><tr><td>09:12</td><td>First customer report (SUP-4421)</td><td>support</td></tr><tr><td>10:04</td><td>Repro confirmed on staging</td><td><ac:link><ri:user ri:username=\"jsmith\" /></ac:link></td></tr></tbody></table><h2>Repro</h2><ol><li>Add any item to cart</li><li>At <code>/checkout</code>, set Street = <code>Łódź 12/3</code></li><li>Submit → 500</li></ol><ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\"><ac:parameter ac:name=\"language\">java</ac:parameter><ac:parameter ac:name=\"title\">AddressValidator.java (before)</ac:parameter><ac:plain-text-body><![CDATA[public Address validate(String street) {\n    byte[] bytes = street.getBytes();\n    return parse(new String(bytes, StandardCharsets.UTF_8));\n}]]></ac:plain-text-body></ac:structured-macro><ac:structured-macro ac:name=\"warning\" ac:schema-version=\"1\"><ac:parameter ac:name=\"title\">Backport</ac:parameter><ac:rich-text-body><p>Must be cherry-picked to <strong>release/2026.05</strong> before next deploy window.</p></ac:rich-text-body></ac:structured-macro>"
+    }
+  }
+}
+```
+
+Same `\"` JSON-escaping rule as Cloud — escape only when
+embedding the XHTML inside a JSON string. If your transport
+takes the storage value as a separate parameter, write XHTML
+unescaped.
+
+## Server-specific pitfalls
+
+- **`/wiki/` prefix doesn't exist** — Server is at the root of
+  its host (or `/confluence` if customised).
+- **`ri:account-id` is silently broken** — must be `ri:userkey`
+  or `ri:username`.
+- **PAT as Basic password → 401.** Use `Authorization: Bearer`.
+- **`body.wiki` is Server-only on v1** — don't reuse the payload
+  on Cloud v2.
+- **`version.number` is mandatory on update** — forgetting it
+  returns 400 / 409.
+- **Imported `ri:userkey` from another instance** renders as a
+  broken mention — userkeys are per-instance. Always look up
+  via the destination Confluence's `/rest/api/user`.
+
+## References
+
+- https://developer.atlassian.com/server/confluence/confluence-rest-api-examples/
+- https://developer.atlassian.com/server/confluence/confluence-server-rest-api/
+- https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html
+  (storage format — shared with Cloud)
+- https://confluence.atlassian.com/conf59/info-tip-note-and-warning-macros-792499127.html
+- https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html

--- a/skills/atlassian-content/references/confluence-storage.md
+++ b/skills/atlassian-content/references/confluence-storage.md
@@ -1,12 +1,22 @@
 # Confluence storage format — the XHTML-ish markup
 
+> **Scope: Cloud AND Server / Data Center.** Confluence's
+> storage format is the same XHTML-ish dialect on both
+> deployments — Cloud inherited it from Server. Everything in
+> this file (headings, lists, tables, `<ac:structured-macro>`,
+> code / info / panel macros) applies to both. The bits that
+> differ between deployments — base URL, mention syntax,
+> `body.wiki` input shortcut, auth — are in
+> `references/confluence-server.md`.
+
 Confluence REST expects pages in **storage format**: an XHTML
 dialect with custom `<ac:*>` (Atlassian Confluence) and `<ri:*>`
 (resource identifier) elements for macros, links, and rich content.
 
-Markdown does not work. Wiki markup works only through a legacy
-converter endpoint. Storage format is the supported, stable
-surface for automation.
+Markdown does not work. Wiki markup works only through input
+representations (`body.wiki` on Server, conversion endpoint on
+both). Storage format is the supported, stable surface for
+automation.
 
 ## API version — v1 is used here; v2 is the future
 
@@ -262,9 +272,10 @@ Place at the top of long pages.
 
 ## Mentions
 
-Mentions in Confluence REST use an `<ac:link>` wrapping a
-`<ri:user>` with `ri:account-id`:
+Mentions in Confluence use an `<ac:link>` wrapping a `<ri:user>`,
+but the user-id attribute differs by deployment:
 
+**Cloud** — `ri:account-id`:
 ```html
 <p>
   Hi
@@ -275,10 +286,33 @@ Mentions in Confluence REST use an `<ac:link>` wrapping a
 </p>
 ```
 
-See `mentions.md` for accountId lookup. The same `accountId` works
-across Jira and Confluence in the same tenant.
+**Server / Data Center** — `ri:userkey` (preferred) or
+`ri:username`:
+```html
+<p>
+  Hi
+  <ac:link>
+    <ri:user ri:userkey="ff8080814ba236dc014ba236f4e40001" />
+  </ac:link>,
+  please review.
+</p>
+```
+
+Posting `ri:account-id` on Server, or `ri:userkey` / `ri:username`
+on Cloud, produces a broken-link placeholder in the rendered page.
+
+See `mentions.md` for lookup recipes per deployment. On Cloud, the
+same `accountId` works across Jira and Confluence in the same
+tenant. On Server, Jira and Confluence are typically separate
+installs — don't reuse identifiers across them.
 
 ## Worked example — a decision page with mention, code block, panel, table
+
+The example below is **Cloud-shaped** — endpoint `/wiki/rest/api/content`
+and `ri:account-id` for the mention. On Server / DC the endpoint
+is `/rest/api/content` (no `/wiki/`) and the mention uses
+`ri:userkey` or `ri:username`; everything between
+`"value": "..."` is otherwise identical.
 
 ```json
 POST /wiki/rest/api/content

--- a/skills/atlassian-content/references/jira-adf.md
+++ b/skills/atlassian-content/references/jira-adf.md
@@ -1,10 +1,18 @@
-# Jira ADF (Atlassian Document Format) — API v3
+# Jira ADF (Atlassian Document Format) — Cloud, API v3
 
-**JIRA SYNTAX REFERENCE:**
+> **Scope: Atlassian Cloud only.** Jira Server / Data Center
+> does NOT accept ADF — it uses wiki markup against API v2.
+> If you're hitting `https://<host>.atlassian.net/...`, you're
+> on Cloud and this file is the right reference. For any
+> custom-domain Jira (`https://jira.company.com/...`), switch to
+> `references/jira-wiki-server.md`. See `SKILL.md` § "Detect
+> deployment first" for how to tell.
+
+**JIRA SYNTAX REFERENCE (Cloud):**
 
 - Use **ADF** (Atlassian Document Format) — a structured JSON document.
-- Use **API v3** — `/rest/api/3/*`. API v2 accepts wiki markup, not
-  ADF, and is legacy for Cloud.
+- Use **API v3** — `/rest/api/3/*`. API v2 on Cloud accepts wiki
+  markup, not ADF, and is legacy.
 - Recommended: create professional, well-formatted Jira issues /
   comments with user mentions, code blocks, panels, tables, and
   links by assembling ADF documents and POSTing them.

--- a/skills/atlassian-content/references/jira-wiki-server.md
+++ b/skills/atlassian-content/references/jira-wiki-server.md
@@ -1,0 +1,409 @@
+# Jira Server / Data Center — wiki markup, API v2
+
+**JIRA SYNTAX REFERENCE (Server / Data Center):**
+
+- Use **wiki markup** — a plain string. Not JSON, not ADF.
+- Use **API v2** — `/rest/api/2/*` (or `/rest/api/latest/*`, an
+  alias). API v3 does not exist on Server / DC.
+- Mentions are **`[~username]`** — `username` is the login `name`
+  returned by `/rest/api/2/user/search`, NOT the display name and
+  NOT the email. `accountId` does not exist on Server.
+- One critical caveat: every rich-text field has a per-field
+  **renderer setting** (admin-controlled). If a field uses the
+  *Default Text Renderer*, your wiki markup renders as literal
+  `*asterisks*` and `h2.` text. See § "The renderer trap" below.
+
+## Document skeleton
+
+Every rich-text field is a JSON string containing wiki markup —
+not a structured document. Compare with Cloud:
+
+```
+Cloud v3 (ADF):   "description": { "type": "doc", "version": 1, "content": [...] }
+Server v2 (wiki): "description": "h2. Steps\n\n# do this\n# then this"
+```
+
+### Where the markup goes
+
+| Operation | Field |
+|---|---|
+| Create issue description | `fields.description` (string with wiki markup) |
+| Update issue description | same, in `fields` of `PUT /rest/api/2/issue/{key}` |
+| Issue environment | `fields.environment` (string with wiki markup) |
+| Post a comment | `body` (string with wiki markup) |
+| Worklog comment | `comment` (string with wiki markup) |
+| Custom rich-text field | `fields.customfield_XXXXX` (string) |
+
+Example issue-create payload:
+
+> **`issuetype`: prefer `id` for programmatic filing.** Project
+> admins rename issue types and multiple types can share a display
+> name across projects. Look up the valid set with
+> `GET /rest/api/2/issue/createmeta/{projectKey}/issuetypes`
+> (the legacy `?expand=projects.issuetypes` form was removed in
+> Jira 9.0).
+
+```json
+POST /rest/api/2/issue
+{
+  "fields": {
+    "project": { "key": "PROJ" },
+    "summary": "Login returns 500 on plus-sign emails",
+    "issuetype": { "name": "Bug" },
+    "assignee": { "name": "jsmith" },
+    "description": "h2. Summary\n\nReproduced on staging 2026-04-20.\n\n* See {{auth/views.py:117}}\n* cc [~jsmith]"
+  }
+}
+```
+
+> Server identifies users by `name` (login) and a stable `key`.
+> Do NOT send `assignee.accountId` — it is silently ignored or
+> returns 400. Same for `reporter`.
+
+Example comment payload:
+
+```json
+POST /rest/api/2/issue/PROJ-123/comment
+{
+  "body": "Verified the fix on staging. cc [~jsmith]"
+}
+```
+
+## The renderer trap — read this first
+
+Server has a **per-field renderer setting**, managed in:
+**Admin → Issues → Field Configurations → [scheme] → Renderers**.
+
+| Renderer | Behaviour |
+|---|---|
+| **Wiki Style Renderer** | Parses wiki markup → HTML. Default for `description`, `environment`, comments, worklog comment, and most text-area custom fields on a fresh install. |
+| **Default Text Renderer** | Treats the content as plain text. Auto-links bare URLs and issue keys, but prints `*bold*`, `h2. Heading`, `||header||` verbatim. |
+
+There is **no REST way to query the per-field renderer** without
+admin access. Three coping strategies:
+
+1. **Probe** — file one minimal test issue (or comment), then
+   `GET /rest/api/2/issue/{key}?expand=renderedFields` and check
+   whether `renderedFields.description` contains a real `<h2>`
+   element or a literal `h2.` string. Cache the answer per project.
+2. **Ask the operator** to confirm the field configuration scheme.
+3. **Fall back to plain text** — well-structured prose, bare URLs
+   (auto-link in both renderers), bare issue keys (also auto-link
+   in both). Plain text always renders correctly.
+
+A related failure mode: if the `atlassian-wiki-renderer` plugin is
+disabled, every wiki-style field silently falls back to the Default
+Text Renderer.
+
+## Wiki markup syntax — what you'll actually use
+
+### Headings
+
+```
+h1. Top heading
+h2. Section
+h3. Subsection
+h4. h5. h6. also valid
+```
+
+**Strict:** dot + single space + content, all at column 0. `h2.Foo`,
+` h2. Foo` (leading whitespace), and `h2.  Foo` (double space) all
+fall back to literal text.
+
+### Paragraphs and line breaks
+
+- A blank line ends a paragraph.
+- `\\` (two backslashes) at end of line → forced line break within
+  the same paragraph.
+- `----` on its own line → horizontal rule.
+- `---` becomes em-dash; `--` becomes en-dash.
+
+### Inline text formatting
+
+| Syntax | Result |
+|---|---|
+| `*strong*` | **bold** |
+| `_emphasis_` | *italic* |
+| `??citation??` | citation (`<cite>`) |
+| `-deleted-` | strikethrough |
+| `+inserted+` | underline |
+| `^superscript^` | superscript |
+| `~subscript~` | subscript |
+| `{{monospaced}}` | inline code |
+| `{color:red}red{color}` | red (or any colour name / `#hex`) |
+
+Inline-only — they do not span line breaks. A `*` at start of line
+followed by a space is a bullet, not bold; escape with `\*`.
+
+### Lists
+
+```
+* bullet
+** nested bullet
+*** even deeper
+# numbered
+## nested numbered
+*# mixed (bullet whose child is numbered)
+#* mixed (numbered whose child is bullet)
+```
+
+- Marker at column 0, single space after.
+- Blank line ends the list.
+
+### Tables
+
+```
+||Env||Result||Notes||
+|staging|fails|reproduced 2026-04-20|
+|prod|not deployed|waiting on release|
+```
+
+- `||` (double pipe) for header rows; `|` (single pipe) for body.
+- Row must start at column 0 with the pipe.
+- Newlines inside a cell break the table — use `\\` for in-cell
+  line breaks.
+- No native row colouring. Wrap a cell or the whole table in a
+  `{panel:bgColor=…}{panel}` for background colour.
+
+### Code, no-format, quote
+
+```
+{code}plain code, no language{code}
+
+{code:java}
+public void hello() {
+    System.out.println("hi");
+}
+{code}
+
+{code:title=Bar.java|borderStyle=solid|linenumbers=true|language=python}
+def deploy():
+    print("ok")
+{code}
+
+{noformat}
+Preformatted text. No highlighting, no markup interpretation.
+{noformat}
+```
+
+Common `language` values: `java`, `javascript`, `python`, `bash`,
+`sh`, `groovy`, `xml`, `html`, `css`, `sql`, `yaml`, `json`,
+`c`, `c++`, `csharp`, `ruby`, `perl`, `scala`, `actionscript`,
+`none`. Unsupported → renders without highlighting.
+
+You **cannot nest `{code}…{code}`** — the parser is non-greedy and
+closes at the first `{code}` after the opener. To show a literal
+`{code}` inside a code sample, use `{noformat}` for the outer
+wrapper.
+
+### Block quotes
+
+```
+bq. Single-line quote.
+
+{quote}
+Multi-line quote.
+Multiple paragraphs allowed.
+{quote}
+```
+
+### Panels & admonitions
+
+Generic panel:
+
+```
+{panel}simple panel body{panel}
+
+{panel:title=My title|borderStyle=dashed|borderColor=#ccc|titleBGColor=#F7D6C1|bgColor=#FFFFCE}
+Body text — may include _wiki_ markup.
+{panel}
+```
+
+Coloured admonition macros (Jira-native on Server):
+
+```
+{info}Generic info note.{info}
+{info:title=Heads up}body{info}
+
+{note}A note (yellow).{note}
+{warning}A warning (red).{warning}
+{tip}A useful tip (green).{tip}
+```
+
+All four accept `:title=…|icon=false` parameters identically.
+
+### Links
+
+| Syntax | Meaning |
+|---|---|
+| `https://example.com` | bare URL — auto-links |
+| `[https://example.com]` | URL as link text |
+| `[label\|https://example.com]` | link with display text |
+| `[label\|https://example.com\|Tooltip]` | with tooltip |
+| `[#anchor]` | jump to anchor on same page |
+| `{anchor:name}` | define an anchor |
+| `[~username]` | **user mention — see below** |
+| `[PROJ-123]` | explicit issue link (bare `PROJ-123` also auto-links) |
+| `[mailto:user@example.com]` | email link |
+| `[^attachment.png]` | link to an attachment on this issue |
+
+### Mentions — `[~username]`
+
+The token between `[~` and `]` is the **login username** — the
+`name` field returned by `/rest/api/2/user/search`. NOT the
+display name, NOT the email, NOT `accountId`.
+
+```
+cc [~jsmith] — can you triage by EOD?
+```
+
+#### Look up a username
+
+```
+GET /rest/api/2/user/search?username=<query>
+→ [ { "key": "JIRAUSER10042",
+      "name": "jsmith",                 ← this goes in [~name]
+      "emailAddress": "jsmith@company.com",
+      "displayName": "Jane Smith",
+      "active": true } ]
+```
+
+For fuzzy search across username / display name / email:
+
+```
+GET /rest/api/2/user/picker?query=<text>
+→ { "users": [ { "name": "jsmith", "html": "...", ... } ], ... }
+```
+
+- `name` is the login username — feed it to `[~name]`.
+- `key` (e.g. `JIRAUSER10042`) is the stable internal identifier;
+  it survives username renames and GDPR-anonymization. On
+  anonymized installs the `name` field becomes a `jirauserNNNN`
+  alias, and `[~jirauserNNNN]` works against the alias.
+- Cache `name` per session keyed by email.
+
+If a username contains `|` or `]`, escape with `\`. Plain `+`,
+`.`, `_` characters are usually fine. Case: most installs are
+case-sensitive on usernames at the wiki-parser level — use the
+exact `name` returned by the API.
+
+### Escaping
+
+Backslash escapes the next character. Inside `{noformat}` /
+`{code}` content is literal until the closing macro.
+
+```
+\*not bold\*
+\[PROJ-123\]   ← suppresses the auto-link
+\\             ← actually a line break, NOT a literal backslash
+```
+
+For a literal single backslash, use `\\\\` (or wrap in
+`{noformat}`).
+
+### Auto-linking quirks
+
+- Bare URLs (`https://…`) auto-link in BOTH renderers.
+- Strings matching `[A-Z][A-Z0-9_]+-\d+` auto-link to issues in
+  both renderers (e.g. `PROJ-123`, `OPS_DEV-7`).
+- This is often desired. To suppress: wrap in `{noformat}` or
+  escape the leading bracket with `\`.
+
+## Authentication on Server
+
+| Method | Header | Notes |
+|---|---|---|
+| Basic auth | `Authorization: Basic base64(user:password)` | Always available. Many corporate installs disable it. |
+| Personal Access Token | `Authorization: Bearer <PAT>` | **Jira 8.14+ / JSM 4.15+ / DC**. Created at user profile → Personal access tokens. |
+| Session cookie | After `POST /rest/auth/1/session` | Interactive scripts only. |
+
+PAT specifics:
+
+- Header is literally `Authorization: Bearer <token>` — the word
+  "Bearer" is fixed.
+- **PATs cannot be used as a Basic-auth password.** Doing so
+  returns 401 `AUTHENTICATED_FAILED`.
+- Tokens carry the creator's full permission set — no scopes.
+
+## Reading content back
+
+```
+GET /rest/api/2/issue/{key}?expand=renderedFields
+→ fields.description     — the wiki source you posted
+  renderedFields.description — the HTML Jira rendered
+
+GET /rest/api/2/issue/{key}/comment/{id}?expand=renderedBody
+→ body         — wiki source
+  renderedBody — rendered HTML
+```
+
+The renderer trap from § "The renderer trap" surfaces on read-back:
+if `renderedFields.description` contains literal `h2.` text instead
+of `<h2>` HTML, the field is on Default Text Renderer.
+
+## Worked example — a well-formatted bug report
+
+```json
+POST /rest/api/2/issue
+{
+  "fields": {
+    "project": { "key": "WEB" },
+    "issuetype": { "name": "Bug" },
+    "priority": { "name": "High" },
+    "summary": "Checkout: 500 when shipping address has a unicode character",
+    "labels": ["checkout", "regression"],
+    "assignee": { "name": "jsmith" },
+    "description": "h2. Summary\n\nCheckout returns *HTTP 500* whenever the shipping street contains a non-ASCII character.\n\nh2. Steps to reproduce\n\n# Add any item to the cart\n# Go to /checkout\n# In the *Street* field enter: {{Łódź 12/3}}\n# Click *Place order*\n\nh2. Expected\n\nOrder is placed and a confirmation page is shown.\n\nh2. Actual\n\nServer responds with 500. cc [~jsmith]\n\nh2. Stack trace\n\n{code:java}\njava.nio.charset.MalformedInputException: Input length = 1\n    at sun.nio.cs.UTF_8$Decoder.decodeLoop(UTF_8.java:578)\n    at com.example.checkout.AddressValidator.validate(AddressValidator.java:42)\n{code}\n\nh2. Environment\n\n||OS||Browser||Build||\n|macOS 14.4|Safari 17.4|2026.05.0-rc3|\n|Windows 11|Edge 124|2026.05.0-rc3|\n\n{panel:title=Workaround|borderColor=#ccc|titleBGColor=#F7D6C1|bgColor=#FFFFCE}\nTransliterating to ASCII at the form layer hides the bug. Do not ship as the fix.\n{panel}\n\n{warning:title=Customer-visible}\nAt least 12 customers reported the failure in support queue SUP-4421.\n{warning}\n\nRelated: WEB-1042, WEB-987"
+  }
+}
+```
+
+Notes on the payload:
+- `assignee.name` — Server identifier, never `accountId`.
+- `[~jsmith]` mentions are inline strings inside the JSON value.
+- `WEB-1042` and `WEB-987` auto-link without explicit `[…]`.
+- `{code:java}` triggers Java syntax highlighting.
+- `||header||` then `|body|` for the table.
+- `{panel}` / `{warning}` are recognised macros provided the
+  field uses Wiki Style Renderer.
+
+## Common pitfalls
+
+- **Default Text Renderer trap** — biggest source of surprise.
+  Always probe the renderer (or fall back to plain text) when
+  working in a new project.
+- **`\\` is TWO backslashes** for a line break. A single `\` only
+  escapes the next character.
+- **Heading whitespace strictness** — `h2.Foo` and ` h2. Foo`
+  don't render. Must be `h2. Foo` at column 0.
+- **Tables must start at column 0** with a pipe. Leading
+  whitespace breaks them; newlines inside cells break them.
+- **`{code}` cannot nest.** Use `{noformat}` for the outer
+  wrapper if you need to display literal `{code}…{code}` inside.
+- **Bare URLs and issue keys auto-link.** Wrap in `{noformat}`
+  or escape with `\` to suppress.
+- **Mention case sensitivity** — use the exact `name` from
+  `/user/search`. Don't title-case it, don't normalize.
+- **No `accountId` anywhere.** `assignee.accountId`,
+  `[~accountid:KEY]`, `reporter.accountId` — all Cloud-only and
+  silently ignored or rejected on Server.
+- **`createmeta` shape changed in Jira 9.0** — use
+  `/rest/api/2/issue/createmeta/{projectKey}/issuetypes` (and
+  `/.../issuetypes/{id}` for fields). The legacy
+  `?expand=projects.issuetypes` query was removed.
+- **`{quote}` blocks** must be on their own lines on most Jira
+  Server versions — `{quote}inline{quote}` renders as literal.
+- **Comment visibility on Server** uses `visibility.type =
+  "role"` or `"group"`, with `value` set to the role/group name.
+  There is no Cloud-style `identifier` field.
+
+## References
+
+- https://developer.atlassian.com/server/jira/platform/jira-rest-api-examples/
+- https://docs.atlassian.com/software/jira/docs/api/REST/latest/
+- https://confluence.atlassian.com/adminjiraserver/configuring-renderers-938847270.html
+- https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html
+- https://developer.atlassian.com/server/jira/platform/personal-access-token/
+- https://confluence.atlassian.com/adminjiraserver/anonymizing-users-992677655.html
+- In-product help on any Jira Server instance:
+  `https://<jira-host>/secure/WikiRendererHelpAction.jspa?section=all`

--- a/skills/atlassian-content/references/mentions.md
+++ b/skills/atlassian-content/references/mentions.md
@@ -1,17 +1,31 @@
-# Mentions — the correct way, on both surfaces
+# Mentions — the correct way, on every deployment / surface
+
+Mentions are the highest-leverage and most-failed piece of content
+to get right. A free-text `@username` string posts as literal
+text — no notification, no link, no profile card — on **every**
+surface. The right way depends on the deployment.
+
+| Deployment / surface | Identifier | Syntax in body |
+|---|---|---|
+| **Jira Cloud** | `accountId` | ADF `mention` node |
+| **Confluence Cloud** | `accountId` | `<ri:user ri:account-id="…"/>` |
+| **Jira Server / Data Center** | login `name` (the username) | `[~username]` inside wiki markup |
+| **Confluence Server / Data Center** | `userKey` (preferred) or `username` | `<ri:user ri:userkey="…"/>` or `<ri:user ri:username="…"/>` |
+
+The first task is always: **identify the deployment** (see
+`SKILL.md` § "Detect deployment first"), then use the lookup +
+syntax for that deployment.
+
+## 1. Cloud — `accountId`
 
 Atlassian Cloud mentions are backed by an **accountId** — an
-opaque string per user within a tenant (e.g.
-`61e1a042e67ea2006b5b2157`). `@username` / `@email` strings are
-**not mentions** when posted through the API — they render as
-literal text, no notification, no profile card, no link.
+opaque string per user within a tenant
+(e.g. `61e1a042e67ea2006b5b2157`). The same `accountId` works
+across Jira and Confluence in the same Cloud tenant.
 
-The same `accountId` works across Jira and Confluence in the same
-tenant.
+### 1.1 Look up the accountId
 
-## 1. Look up the accountId
-
-### From an email
+From an email:
 
 ```
 GET /rest/api/3/user/search?query=alexander@example.com
@@ -20,35 +34,23 @@ GET /rest/api/3/user/search?query=alexander@example.com
       "emailAddress": "alexander@example.com", ... } ]
 ```
 
-### From a display name (fuzzier — may return multiples)
+From a display name (fuzzier — may return multiples):
 
 ```
 GET /rest/api/3/user/search?query=Alexander Bychinskiy
 ```
 
-Verify: the `displayName` you get back matches what you searched
-for. If multiple users match, don't guess — ask the operator or
-fall back to plain text.
-
-### From the current authenticated user (myself)
+Self:
 
 ```
 GET /rest/api/3/myself
 → { "accountId": "...", "displayName": "...", ... }
 ```
 
-### Caching
+Verify the `displayName` you get back matches what you searched
+for. Multiple matches → ask the operator; don't guess.
 
-Cache accountIds per session, keyed by email or normalized
-display-name. Resolving the same user twice in one run is wasted
-calls; resolving them five times is a bug.
-
-Caching across sessions belongs in `.agents/memory/` or the
-project's profile, not in this skill.
-
-## 2. Use it in a Jira mention (ADF)
-
-Inside any inline-node context (paragraph, table cell, list item):
+### 1.2 Jira mention (ADF)
 
 ```json
 { "type": "mention",
@@ -57,12 +59,10 @@ Inside any inline-node context (paragraph, table cell, list item):
 ```
 
 - `id` → the accountId.
-- `text` → the **display fallback**, shown only when the mention
-  fails to render. Match the user's display name verbatim with a
-  leading `@` (e.g. `"@Alexander Bychinskiy"`); modern Atlassian
-  UIs render spaces fine.
+- `text` → the display fallback shown only if rendering fails.
+  Match the user's display name with a leading `@`.
 
-Full paragraph example:
+Full paragraph:
 
 ```json
 { "type": "paragraph",
@@ -75,9 +75,7 @@ Full paragraph example:
   ] }
 ```
 
-## 3. Use it in a Confluence mention (storage format)
-
-Inside any body content (paragraph, table cell, list item):
+### 1.3 Confluence mention (storage format)
 
 ```html
 <ac:link>
@@ -85,24 +83,118 @@ Inside any body content (paragraph, table cell, list item):
 </ac:link>
 ```
 
-Full paragraph example:
-
-```html
-<p>
-  Hi
-  <ac:link>
-    <ri:user ri:account-id="61e1a042e67ea2006b5b2157" />
-  </ac:link>,
-  please review.
-</p>
-```
-
 Confluence's renderer substitutes the user's current display name
 inside the anchor — you don't provide a fallback text node.
 
+## 2. Jira Server / Data Center — `[~username]`
+
+On Server, the mention token is the **login username** — the
+`name` field from `/rest/api/2/user/search`, NOT the display
+name, NOT the email, NOT an `accountId`.
+
+### 2.1 Look up the username
+
+```
+GET /rest/api/2/user/search?username=alexander
+→ [ { "self": "https://jira.company.com/rest/api/2/user?username=jsmith",
+      "key": "JIRAUSER10042",
+      "name": "jsmith",                    ← this goes in [~name]
+      "emailAddress": "jsmith@company.com",
+      "displayName": "Jane Smith",
+      "active": true } ]
+```
+
+For fuzzier search across username + display name + email:
+
+```
+GET /rest/api/2/user/picker?query=jane
+→ { "users": [ { "name": "jsmith", "html": "...", ... } ], ... }
+```
+
+- `name` is the login username — feed it verbatim into `[~name]`.
+- `key` (e.g. `JIRAUSER10042`) is the stable per-instance
+  identifier. On GDPR-anonymized installs (Jira 8.7+), `name`
+  becomes a `jirauserNNNN` alias and `[~jirauserNNNN]` works
+  against that alias.
+
+### 2.2 Use it in wiki markup
+
+```
+cc [~jsmith] — can you triage by EOD?
+```
+
+Full description snippet (Server v2 description is a JSON string,
+so `\n` is a literal newline):
+
+```json
+{
+  "fields": {
+    "description": "h2. Investigation\n\nLikely null-pointer in {{AddressValidator}}. cc [~jsmith] and [~agonzalez]."
+  }
+}
+```
+
+Username escaping:
+
+- `+`, `.`, `_` characters are usually fine.
+- `|`, `]`, `[`, `{`, `}` must be escaped with backslash.
+- **Case matters** on most installs — use the exact `name` from
+  the API.
+
+The Cloud-style `[~accountid:KEY]` syntax is **not officially
+supported on Server** and renders as literal text on most
+installs. Do not use it.
+
+## 3. Confluence Server / Data Center — `ri:userkey` / `ri:username`
+
+Cloud uses `ri:account-id`. **Server does not.** Use either of:
+
+```html
+<ac:link>
+  <ri:user ri:userkey="ff8080814ba236dc014ba236f4e40001" />
+</ac:link>
+```
+
+```html
+<ac:link>
+  <ri:user ri:username="jsmith" />
+</ac:link>
+```
+
+Confluence Server normalises `ri:username` → `ri:userkey` on save.
+The `userkey` is the stable per-instance identifier.
+
+Posting `ri:account-id="…"` on Server produces a broken-link
+placeholder in the rendered page.
+
+### 3.1 Look up the userkey on Server
+
+```
+GET /rest/api/user?username=jsmith
+→ { "username": "jsmith",
+    "userKey": "ff8080814ba236dc014ba236f4e40001",
+    "displayName": "Jane Smith",
+    "type": "known" }
+```
+
+Cache by username, store `userKey`. Note the lowercase
+`userKey` key in the JSON response vs the lowercase-and-hyphenated
+`ri:userkey` attribute in storage format — they refer to the same
+value.
+
+### 3.2 Cross-product on Server
+
+Jira and Confluence on Server are usually separate installs with
+separate user directories — DON'T reuse a Jira `name` as a
+Confluence `username` unless the operator confirms shared SSO /
+the same user directory. Look up each side independently.
+
 ## 4. Mentioning multiple users
 
-Fine — concatenate inline nodes separated by text:
+Patterns are the same on every surface — concatenate inline
+nodes / elements / tokens separated by text.
+
+**Jira Cloud (ADF):**
 
 ```json
 { "type": "paragraph",
@@ -117,38 +209,75 @@ Fine — concatenate inline nodes separated by text:
   ] }
 ```
 
-Confluence:
+**Jira Server (wiki):**
+
+```
+FYI [~anna] and [~bob]: please review.
+```
+
+**Confluence (any deployment, storage format):**
 
 ```html
 <p>
   FYI
-  <ac:link><ri:user ri:account-id="ACCOUNTID-A" /></ac:link>
+  <ac:link><ri:user ri:account-id="ACCOUNTID-A" /></ac:link>   <!-- Cloud -->
   and
-  <ac:link><ri:user ri:account-id="ACCOUNTID-B" /></ac:link>:
-  please review.
+  <ac:link><ri:user ri:userkey="USERKEY-B" /></ac:link>        <!-- Server -->
+  : please review.
 </p>
 ```
+
+(Don't actually mix Cloud and Server identifiers in one page —
+the line above is illustrative; in practice both mentions use the
+same deployment's identifier.)
 
 ## 5. Failure modes
 
 - **User search returns empty** → the user doesn't exist in this
-  tenant (may have left the company, may be a different tenant, or
-  the search term is too broad/narrow). Do not invent a mention;
-  fall back to plain text (`"Hi Alexander, "`).
-- **Multiple matches** → if you can't narrow down via email, ask
-  the operator which accountId to use.
-- **Deactivated user** → mention still posts, but shows as greyed
+  tenant / instance (may have left, may be a different
+  tenant/install, search term too narrow). Do not invent a
+  mention; fall back to plain text (`"Hi Alexander, "`).
+- **Multiple matches** → if you can't narrow down via email
+  (Cloud) or username (Server), ask the operator. Never guess.
+- **Deactivated user** → mention still posts, but shows greyed
   out. Decide whether that's useful (historical record) or
-  misleading (expecting a response) — often better to use plain
-  text with the name.
-- **Group mentions** → Jira supports `groupId`-based mention-like
-  behavior via **team mentions** (not covered here). Confluence
-  does not have built-in group mention in storage format. For
-  "the platform team", mention the team lead individually or add
-  a `@label` convention agreed with the team.
+  misleading (expecting a response).
+- **(Server) `[~name]` renders as plain text** → either the
+  field is on the Default Text Renderer, or the username is
+  wrong / case-mismatched. Probe via `?expand=renderedFields`
+  to disambiguate.
+- **(Server) `ri:userkey` doesn't render** → the key was
+  imported from a different Confluence instance (`userKey` is
+  per-instance). Re-look it up in the destination instance.
+- **Wrong identifier for the deployment** → `accountId` posted
+  to Server, or `[~username]` written into ADF, produces literal
+  text. Detect the deployment FIRST.
+- **Group mentions** → Jira Cloud supports `groupId`-based team
+  mentions (not covered here). Confluence does not have built-in
+  group mentions in storage format. Server has the same gap.
+  For "the platform team", mention the team lead individually or
+  use a `@label` convention agreed with the team.
 
-## 6. Privacy note
+## 6. Caching
 
-`accountId` is safe to log / persist internally — it's not PII by
-itself. Email addresses ARE PII — if you cache an email → accountId
-lookup, respect the project's data-handling policy.
+Cache lookups per session:
+
+- Cloud: key by email or normalized display-name → `accountId`.
+- Jira Server: key by email or display-name → `{ name, key }`.
+- Confluence Server: key by username → `{ userKey, displayName }`.
+
+Resolving the same user twice in one run is wasted calls;
+resolving them five times is a bug.
+
+Cross-session caching belongs in `.agents/memory/` or the
+project's profile, not in this skill.
+
+## 7. Privacy note
+
+- `accountId` (Cloud) is safe to log / persist internally — not
+  PII by itself.
+- `userKey` (Server) is similarly opaque and safe.
+- Login `name` (Server) is often a derivation of the user's real
+  name (`jsmith`, `alexander.b`) — treat as moderately sensitive.
+- Email addresses ARE PII — if you cache email → identifier,
+  respect the project's data-handling policy.

--- a/skills/atlassian-content/references/verification.md
+++ b/skills/atlassian-content/references/verification.md
@@ -7,6 +7,10 @@ checklist for turning "accepted" into "good".
 Run this every time. No exceptions. Ugly tickets are evidence of
 skipped verification.
 
+**Deployment matters.** Endpoint paths differ between Cloud and
+Server / Data Center — every snippet below has both forms. Detect
+deployment first (see `SKILL.md` § "Detect deployment first").
+
 > **If `.agents/profile.md` isn't populated yet** (project not
 > seeded, or seeded without the `Project systems` block), ask the
 > operator for the Jira base URL, auth env var, and — for
@@ -21,10 +25,15 @@ Verification covers the **after**. This section covers the
 comment, or Confluence page, always fetch the current body in its
 **raw structured view** before writing the update.
 
-"Raw" means the body as the API stores it — the ADF JSON for Jira,
-the storage-format XHTML string for Confluence. NOT the rendered
-HTML (`renderedFields.description` / `body.view.value`) which is
-output-only and loses macros, custom nodes, and structural hints.
+"Raw" means the body as the API stores it:
+
+- **Jira Cloud** → the ADF JSON document.
+- **Jira Server / DC** → the wiki-markup string.
+- **Confluence (any deployment)** → the storage-format XHTML string.
+
+NOT the rendered HTML (`renderedFields.description` /
+`body.view.value`) which is output-only and loses macros, custom
+nodes, and structural hints.
 
 ### Why
 
@@ -49,7 +58,7 @@ project. Pick the variant that returns the raw ADF / storage
 string, not a pre-rendered / human-readable summary.
 
 ```
-# --- Raw REST API ---
+# --- Raw REST API — Cloud ---
 
 # Jira issue description (and other rich-text fields)
 GET /rest/api/3/issue/{key}?fields=description,comment
@@ -63,6 +72,21 @@ GET /rest/api/3/issue/{key}/comment/{id}
 GET /wiki/rest/api/content/{id}?expand=body.storage,version
 → body.storage.value is the XHTML you'll edit;
   version.number is the number you must increment in the PUT
+
+# --- Raw REST API — Server / Data Center ---
+
+# Jira issue description
+GET /rest/api/2/issue/{key}?fields=description,comment
+→ fields.description is the wiki-markup string you'll edit
+
+# Jira comment
+GET /rest/api/2/issue/{key}/comment/{id}
+→ body is the wiki-markup string
+
+# Confluence page (note: no /wiki/ prefix on Server)
+GET /rest/api/content/{id}?expand=body.storage,version
+→ body.storage.value is the XHTML;
+  version.number must be incremented in the PUT
 ```
 
 ```
@@ -137,29 +161,58 @@ source you submitted and the rendered output, compare.
 
 ### Jira issue
 
+**Cloud:**
 ```
 GET /rest/api/3/issue/{key}?expand=renderedFields
 ```
-
 - `fields.description` → the ADF you posted.
 - `renderedFields.description` → the HTML Jira renders.
 
+**Server / DC:**
+```
+GET /rest/api/2/issue/{key}?expand=renderedFields
+```
+- `fields.description` → the wiki-markup string you posted.
+- `renderedFields.description` → the HTML Jira renders.
+
 Sanity check: rendered HTML is non-empty and contains the expected
-shape (headings, lists, code blocks, mentions as `<a class="user-hover">`).
+shape (headings, lists, code blocks, mentions as `<a
+class="user-hover">`).
+
+**Server-specific renderer check.** If the rendered HTML contains
+literal `h2.` text instead of `<h2>` elements, or literal
+`*asterisks*` instead of `<strong>`, the field is configured for
+the **Default Text Renderer** (see
+`references/jira-wiki-server.md` § "The renderer trap"). Your
+wiki markup is correct; the field config is the problem. Either
+ask the operator to flip the renderer scheme, or fall back to
+plain text for that field.
 
 ### Jira comment
 
+**Cloud:**
 ```
 GET /rest/api/3/issue/{key}/comment/{id}?expand=renderedBody
 ```
 
-- `body` → the ADF you posted.
+**Server / DC:**
+```
+GET /rest/api/2/issue/{key}/comment/{id}?expand=renderedBody
+```
+
+- `body` → the body you posted (ADF on Cloud, wiki string on Server).
 - `renderedBody` → the HTML Jira renders.
 
 ### Confluence page
 
+**Cloud:**
 ```
 GET /wiki/rest/api/content/{id}?expand=body.storage,body.view,version
+```
+
+**Server / DC** (no `/wiki/` prefix):
+```
+GET /rest/api/content/{id}?expand=body.storage,body.view,version
 ```
 
 - `body.storage.value` → the storage format you submitted.
@@ -173,9 +226,15 @@ For each created resource, confirm ALL of these:
 ### Mentions
 - [ ] Every `@mention` you intended appears as a mention node /
       linked user in the rendered HTML.
-- [ ] No literal `@username` strings anywhere you meant to mention.
-- [ ] `accountId` resolved to a real display name (not "Unknown
-      user" / greyed-out badge).
+- [ ] No literal `@username` / `[~username]` strings anywhere you
+      meant to mention.
+- [ ] Identifier resolved to a real display name (not "Unknown
+      user" / greyed-out badge / broken-link macro placeholder).
+- [ ] (Cloud) `accountId` resolved correctly.
+- [ ] (Jira Server) `[~username]` matched a real `name` from
+      `/rest/api/2/user/search`.
+- [ ] (Confluence Server) `ri:userkey` / `ri:username` resolved to
+      a real user.
 
 ### Headings
 - [ ] Headings render as headings (`<h1>`–`<h6>` in rendered HTML),
@@ -214,6 +273,9 @@ For each created resource, confirm ALL of these:
 - [ ] No literal `**bold**` / `*italic*` / `_italic_` markdown
       artefacts.
 - [ ] No half-rendered HTML tags (e.g. `<br>` visible in body).
+- [ ] (Jira Server) No literal `h2.` / `*asterisks*` / `||pipes||`
+      in the rendered HTML — that signals the field is on the
+      Default Text Renderer (not a bug in your markup).
 
 ### Hygiene
 - [ ] No API tokens / secrets leaked into body text.
@@ -228,24 +290,32 @@ later" ticket. The repair is cheap.
 
 ### Jira issue description
 
+**Cloud:**
 ```
 PUT /rest/api/3/issue/{key}
-{
-  "fields": {
-    "description": { /* corrected ADF doc */ }
-  }
-}
+{ "fields": { "description": { /* corrected ADF doc */ } } }
+```
+
+**Server / DC:**
+```
+PUT /rest/api/2/issue/{key}
+{ "fields": { "description": "<corrected wiki-markup string>" } }
 ```
 
 ### Jira comment
 
 Jira comments update via:
 
+**Cloud:**
 ```
 PUT /rest/api/3/issue/{key}/comment/{id}
-{
-  "body": { /* corrected ADF doc */ }
-}
+{ "body": { /* corrected ADF doc */ } }
+```
+
+**Server / DC:**
+```
+PUT /rest/api/2/issue/{key}/comment/{id}
+{ "body": "<corrected wiki-markup string>" }
 ```
 
 If the comment is wrong in a minor way (typo), editing is fine.
@@ -255,10 +325,28 @@ the thread about the repost.
 
 ### Confluence page
 
-Page updates require the next version number:
+Page updates require the next version number (Cloud and Server
+behave identically on this — only the endpoint differs).
 
+**Cloud:**
 ```
 PUT /wiki/rest/api/content/{id}
+{
+  "type": "page",
+  "title": "<same or updated>",
+  "version": { "number": <current_version_number + 1> },
+  "body": {
+    "storage": {
+      "value": "<corrected storage xhtml>",
+      "representation": "storage"
+    }
+  }
+}
+```
+
+**Server / DC** (no `/wiki/` prefix):
+```
+PUT /rest/api/content/{id}
 {
   "type": "page",
   "title": "<same or updated>",


### PR DESCRIPTION
Extends the `atlassian-content` skill to cover on-prem deployments: Jira Server/DC wiki markup and Confluence Server storage format. Existing Cloud behaviour is unchanged.