### PR TITLE
Add explicit metadata.author to all agents and skills

### DIFF
--- a/agents/ba/AGENT.md
+++ b/agents/ba/AGENT.md
@@ -7,6 +7,8 @@ group: core
 theme: {color: colour183, icon: "📝", short_name: ba}
 aliases: [alex]
 skills: [issue-tracking, plan-feature, brainstorming, memory]
+metadata:
+  author: "Artem Rozumenko (git: arozumenko)"
 ---
 
 @.agents/memory/ba/snapshot.md

--- a/agents/ios-dev/AGENT.md
+++ b/agents/ios-dev/AGENT.md
@@ -8,6 +8,8 @@ group: dev
 theme: {color: colour214, icon: "📱", short_name: io}
 aliases: [io, ios]
 skills: [tdd, implement-feature, bugfix-workflow, root-cause-analysis, systematic-debugging, code-review, requesting-code-review, receiving-code-review, git-workflow, verification-before-completion, completing-a-task, memory, swiftui-pro, swiftdata-pro, swift-testing-pro, swift-concurrency-pro]
+metadata:
+  author: "Artem Rozumenko (git: arozumenko)"
 ---
 
 @.agents/memory/ios-dev/snapshot.md

--- a/agents/js-dev/AGENT.md
+++ b/agents/js-dev/AGENT.md
@@ -8,6 +8,8 @@ group: dev
 theme: {color: colour220, icon: "⚡", short_name: js}
 aliases: [js, jay]
 skills: [tdd, implement-feature, bugfix-workflow, root-cause-analysis, systematic-debugging, code-review, requesting-code-review, receiving-code-review, git-workflow, verification-before-completion, completing-a-task, memory]
+metadata:
+  author: "Artem Rozumenko (git: arozumenko)"
 ---
 
 @.agents/memory/js-dev/snapshot.md

--- a/agents/personal-assistant/AGENT.md
+++ b/agents/personal-assistant/AGENT.md
@@ -8,6 +8,8 @@ group: core
 theme: {color: colour141, icon: "🟣", short_name: pa}
 aliases: [pa, octo]
 skills: [obsidian-vault, microsoft-365, memory]
+metadata:
+  author: "Artem Rozumenko (git: arozumenko)"
 ---
 
 @.agents/memory/personal-assistant/snapshot.md

--- a/agents/project-manager/AGENT.md
+++ b/agents/project-manager/AGENT.md
@@ -7,6 +7,8 @@ group: core
 theme: {color: colour213, icon: "📋", short_name: pm}
 aliases: [pm, max]
 skills: [issue-tracking, plan-feature, subagent-driven-development, dispatching-parallel-agents, memory]
+metadata:
+  author: "Artem Rozumenko (git: arozumenko)"
 ---
 
 @.agents/memory/project-manager/snapshot.md

--- a/agents/python-dev/AGENT.md
+++ b/agents/python-dev/AGENT.md
@@ -8,6 +8,8 @@ group: dev
 theme: {color: colour117, icon: "🐍", short_name: py}
 aliases: [py]
 skills: [tdd, implement-feature, bugfix-workflow, root-cause-analysis, systematic-debugging, code-review, requesting-code-review, receiving-code-review, git-workflow, verification-before-completion, completing-a-task, memory]
+metadata:
+  author: "Artem Rozumenko (git: arozumenko)"
 ---
 
 @.agents/memory/python-dev/snapshot.md

--- a/agents/qa-engineer/AGENT.md
+++ b/agents/qa-engineer/AGENT.md
@@ -7,6 +7,8 @@ group: qa
 theme: {color: colour156, icon: "🧪", short_name: qa}
 aliases: [qa, sage]
 skills: [playwright-testing, playwright-cli, browser-verify, reproducing-issues, bugfix-workflow, test-case-analysis, systematic-debugging, verification-before-completion, issue-tracking, memory]
+metadata:
+  author: "Artem Rozumenko (git: arozumenko)"
 ---
 
 @.agents/memory/qa-engineer/snapshot.md

--- a/agents/scout/AGENT.md
+++ b/agents/scout/AGENT.md
@@ -8,6 +8,8 @@ required: true
 theme: {color: colour252, icon: "🔍", short_name: scout}
 aliases: [kit]
 skills: [seeding-a-project, memory]
+metadata:
+  author: "Artem Rozumenko (git: arozumenko)"
 ---
 
 # Scout

--- a/agents/tech-lead/AGENT.md
+++ b/agents/tech-lead/AGENT.md
@@ -7,6 +7,8 @@ group: core
 theme: {color: colour209, icon: "🏗️", short_name: tl}
 aliases: [tl, rio]
 skills: [code-review, root-cause-analysis, plan-feature, git-workflow, writing-skills, memory]
+metadata:
+  author: "Artem Rozumenko (git: arozumenko)"
 ---
 
 @.agents/memory/tech-lead/snapshot.md

--- a/agents/test-automation-engineer/AGENT.md
+++ b/agents/test-automation-engineer/AGENT.md
@@ -8,6 +8,8 @@ group: qa
 theme: {color: colour208, icon: "🤖", short_name: tae}
 aliases: [test-automation-engineer, axel, automation]
 skills: [test-automation-workflow, playwright-testing, playwright-cli, browser-verify, tdd, code-review, bugfix-workflow, systematic-debugging, verification-before-completion, requesting-code-review, receiving-code-review, git-workflow, completing-a-task, memory]
+metadata:
+  author: "Alexander Bychinkii (git: bermudas)"
 ---
 
 @.agents/memory/test-automation-engineer/snapshot.md

--- a/bundles/test-automation/agents/test-automation-lead/AGENT.md
+++ b/bundles/test-automation/agents/test-automation-lead/AGENT.md
@@ -7,6 +7,8 @@ group: qa
 theme: {color: colour51, icon: "🎯", short_name: tal}
 aliases: [tal, ta-lead, automation-lead]
 skills: [test-automation-workflow, test-case-analysis, code-review, issue-tracking, atlassian-content, completing-a-task, git-workflow, plan-feature, memory]
+metadata:
+  author: "Alexander Bychinkii (git: bermudas)"
 ---
 
 @.agents/memory/test-automation-lead/MEMORY.md

--- a/bundles/web-qa/agents/executor/AGENT.md
+++ b/bundles/web-qa/agents/executor/AGENT.md
@@ -8,6 +8,8 @@ theme: {color: colour196, icon: "▶️", short_name: exec}
 aliases: [executor]
 tools: Read, Write, mcp__playwright__browser_navigate, mcp__playwright__browser_click, mcp__playwright__browser_fill_form, mcp__playwright__browser_type, mcp__playwright__browser_select_option, mcp__playwright__browser_hover, mcp__playwright__browser_press_key, mcp__playwright__browser_snapshot, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_wait_for, mcp__playwright__browser_handle_dialog, mcp__playwright__browser_evaluate, mcp__playwright__browser_navigate_back, mcp__playwright__browser_console_messages
 skills: [playwright-testing, playwright-best-practices, verification-before-completion, systematic-debugging]
+metadata:
+  author: "Olha Stetsenko (git: olexis-st)"
 ---
 
 You are a QA Executor Agent. Your sole responsibility: execute one test case precisely using Playwright MCP tools and report the result.

--- a/bundles/web-qa/agents/orchestrator/AGENT.md
+++ b/bundles/web-qa/agents/orchestrator/AGENT.md
@@ -8,6 +8,8 @@ theme: {color: colour156, icon: "🎯", short_name: orch}
 aliases: [orchestrator, orch]
 tools: Glob, Read, Write, Agent
 skills: [verification-before-completion, systematic-debugging]
+metadata:
+  author: "Olha Stetsenko (git: olexis-st)"
 ---
 
 You are a QA Orchestrator Agent. You manage a complete test run from discovery to final report.

--- a/bundles/web-qa/agents/reporter/AGENT.md
+++ b/bundles/web-qa/agents/reporter/AGENT.md
@@ -8,6 +8,8 @@ theme: {color: colour33, icon: "📊", short_name: rep}
 aliases: [reporter]
 tools: Read, Write
 skills: []
+metadata:
+  author: "Olha Stetsenko (git: olexis-st)"
 ---
 
 You are a QA Reporter Agent. Turn an array of executor results into a clean Markdown report.

--- a/bundles/web-qa/agents/setup/AGENT.md
+++ b/bundles/web-qa/agents/setup/AGENT.md
@@ -8,6 +8,8 @@ theme: {color: colour156, icon: "🔍", short_name: setup}
 aliases: [setup]
 tools: Read, Write, Bash, mcp__playwright__browser_navigate, mcp__playwright__browser_snapshot, mcp__playwright__browser_click, mcp__playwright__browser_fill_form, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_wait_for, mcp__playwright__browser_evaluate, mcp__playwright__browser_network_requests, mcp__playwright__browser_console_messages
 skills: [playwright-testing, playwright-best-practices, systematic-debugging, xlsx-reader]
+metadata:
+  author: "Olha Stetsenko (git: olexis-st)"
 ---
 
 You are a QA Setup Agent. Learn a new web application through conversation and hands-on exploration, then write `.agents/web-qa/app_profile.md` so all other agents have accurate context.

--- a/bundles/web-qa/agents/tc-writer/AGENT.md
+++ b/bundles/web-qa/agents/tc-writer/AGENT.md
@@ -8,6 +8,8 @@ theme: {color: colour156, icon: "✍️", short_name: tcw}
 aliases: [tc-writer, tcw]
 tools: Read, Write, Glob
 skills: []
+metadata:
+  author: "Olha Stetsenko (git: olexis-st)"
 ---
 
 You are a QA Test Case Writer. Transform rough ideas into precise, executable test cases.

--- a/skills/atlassian-content/SKILL.md
+++ b/skills/atlassian-content/SKILL.md
@@ -3,7 +3,7 @@ name: atlassian-content
 description: Create well-formatted Jira issues/comments and Confluence pages on both Cloud and Server/Data Center, with mandatory post-creation re-fetch + repair. Load for "file a bug", "comment on JIRA-123", "write up a decision page", or any authored Atlassian content.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Alexander Bychinkii (git: bermudas)"
   version: "0.2.0"
 ---
 

--- a/skills/browser-verify/SKILL.md
+++ b/skills/browser-verify/SKILL.md
@@ -4,7 +4,7 @@ description: Use when you need to run arbitrary JS in a page, inspect cookies/lo
 license: Apache-2.0
 compatibility: Requires Chrome/Chromium and Node 22+. No npm install needed.
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/bugfix-workflow/SKILL.md
+++ b/skills/bugfix-workflow/SKILL.md
@@ -3,7 +3,7 @@ name: bugfix-workflow
 description: End-to-end bugfix workflow — reproduce, test-first, RCA, fix, verify, document. Use when the user says "fix bug", "investigate issue", "fix #NNN", or whenever you hit a failing test or reproducible defect, before you start patching.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -4,7 +4,7 @@ description: Review code for correctness, security, performance, and maintainabi
 license: Apache-2.0
 compatibility: Requires git CLI. Optional gh CLI for PR reviews.
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/completing-a-task/SKILL.md
+++ b/skills/completing-a-task/SKILL.md
@@ -3,7 +3,7 @@ name: completing-a-task
 description: Use when you've finished implementing a routed task and need to commit, push, open a PR, comment on the issue, and notify your reviewer. The five-step protocol that marks a task truly "done" — writing code is step 1, handoff is step 5.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -4,7 +4,7 @@ description: Disk-first, checkpointed research workflow with three modes — tre
 license: Apache-2.0
 compatibility: Requires tavily_search/extract tools; Context7 (resolve-library-id, query-docs) optional for technical topics
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/gathering-context/SKILL.md
+++ b/skills/gathering-context/SKILL.md
@@ -4,7 +4,7 @@ description: Gather cross-channel context (local KB, email, Teams, optional web)
 license: Apache-2.0
 compatibility: Requires MS Graph tools (search-query, list-mail-messages, get-mail-message, find-chat, list-chat-messages). Web search optional.
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires git CLI and gh CLI for GitHub operations
 allowed-tools: Bash(git:*) Bash(gh:*)
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/implement-feature/SKILL.md
+++ b/skills/implement-feature/SKILL.md
@@ -3,7 +3,7 @@ name: implement-feature
 description: End-to-end feature implementation — plan review, test-first, build, verify, deliver. Use when the user says "implement", "build feature", "work on task", or once a plan or story is approved and you're about to start building.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/issue-tracking/SKILL.md
+++ b/skills/issue-tracking/SKILL.md
@@ -5,7 +5,7 @@ license: Apache-2.0
 compatibility: Requires gh CLI for GitHub, or linear/glab CLI for other trackers
 allowed-tools: Bash(gh:*) Bash(linear:*) Bash(glab:*)
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/memory/SKILL.md
+++ b/skills/memory/SKILL.md
@@ -3,7 +3,7 @@ name: memory
 description: Per-role persistent memory — durable facts, preferences, decisions, and a daily log, as plain markdown. Use when the user says "remember this" or "log this", asks "what did you learn yesterday", or whenever you discover something worth keeping across sessions.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.3.0"
 ---
 

--- a/skills/microsoft-365/SKILL.md
+++ b/skills/microsoft-365/SKILL.md
@@ -4,7 +4,7 @@ description: Microsoft 365 (Graph) access to email, Teams, calendar, and SharePo
 license: Apache-2.0
 compatibility: Requires Python 3.10+. Dependencies and Azure AD app are auto-configured on first run.
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.2.0"
 ---
 

--- a/skills/obsidian-vault/SKILL.md
+++ b/skills/obsidian-vault/SKILL.md
@@ -4,7 +4,7 @@ description: Headless, file-system Obsidian vault operations (no Obsidian app ne
 license: Apache-2.0
 compatibility: Requires Python 3.10+ (stdlib only). Vault path via $OBSIDIAN_VAULT_PATH (or legacy $OCTOBOTS_VAULT_PATH). ripgrep recommended (falls back to grep).
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/plan-feature/SKILL.md
+++ b/skills/plan-feature/SKILL.md
@@ -3,7 +3,7 @@ name: plan-feature
 description: Structured feature planning — requirements, feasibility, and an implementation plan. Use when the user says "plan a feature", "design this", "how should we build", or before writing code for any non-trivial feature — plan first, build second.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/playwright-testing/SKILL.md
+++ b/skills/playwright-testing/SKILL.md
@@ -4,7 +4,7 @@ description: UI/E2E test automation with Playwright MCP. Use when the user asks 
 license: Apache-2.0
 compatibility: Requires Node.js 18+. MCP server installed via setup.yaml.
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/reproducing-issues/SKILL.md
+++ b/skills/reproducing-issues/SKILL.md
@@ -3,7 +3,7 @@ name: reproducing-issues
 description: Turn a vague bug report into precise, repeatable steps with evidence and a CONFIRMED / CANNOT-REPRODUCE / PARTIAL verdict. Use when a bug is unclear or unconfirmed and needs reproduction before RCA or any fix. Reproduction and documentation only — does not fix code.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/root-cause-analysis/SKILL.md
+++ b/skills/root-cause-analysis/SKILL.md
@@ -3,7 +3,7 @@ name: root-cause-analysis
 description: Trace a confirmed bug to its exact cause — execution-path tracing, root-cause classification, confidence, and impact/regression analysis, reported on the ticket. Use after a bug is reproduced, before proposing a fix. Investigation only — does not edit code.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/seeding-a-project/SKILL.md
+++ b/skills/seeding-a-project/SKILL.md
@@ -4,7 +4,7 @@ description: Generate AGENTS.md and .octobots/ configuration files for a new pro
 license: Apache-2.0
 compatibility: Requires project root write access. No external dependencies.
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/test-automation-workflow/SKILL.md
+++ b/skills/test-automation-workflow/SKILL.md
@@ -3,7 +3,7 @@ name: test-automation-workflow
 description: End-to-end test automation workflow — Explore, Specify, Implement, Review — over a pluggable TMS (Zephyr/TestRail/Xray/Azure/markdown). Load for "automate TC-NNN", "convert this case to Playwright", or any flow from a manual test case to green framework tests.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Alexander Bychinkii (git: bermudas)"
   version: "0.1.0"
 ---
 

--- a/skills/test-case-analysis/SKILL.md
+++ b/skills/test-case-analysis/SKILL.md
@@ -3,7 +3,7 @@ name: test-case-analysis
 description: Execute a TMS test case end-to-end, capture stable selectors, flag defects, and emit an Automation-Friendly Spec (AFS). Load for "analyse SCRUM-T101 for automation", "run this case and emit an AFS", or any TMS-case exploration before automation. Does not write test code.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Alexander Bychinkii (git: bermudas)"
   version: "0.1.0"
 ---
 

--- a/skills/tosca-automation/SKILL.md
+++ b/skills/tosca-automation/SKILL.md
@@ -3,7 +3,7 @@ name: tosca-automation
 description: Tricentis TOSCA Cloud automation via the bundled tosca_cli.py — create/update/run TestCases, Modules, Reusable Blocks, Playlists, folders, and TSU import/export. Use when the user asks to create a TOSCA test case, run a playlist, organize cases, or any TOSCA Cloud REST/CLI operation.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Alexander Bychinkii (git: bermudas)"
   version: "0.1.0"
   upstream: https://github.com/bermudas/toscacloud_cli
 ---

--- a/skills/verifying-outcomes/SKILL.md
+++ b/skills/verifying-outcomes/SKILL.md
@@ -4,7 +4,7 @@ description: Goal-backward verification — checks whether the desired outcome w
 license: Apache-2.0
 compatibility: Works in any repo. Uses Read, Grep, Glob, Bash.
 metadata:
-  author: octobots
+  author: "Artem Rozumenko (git: arozumenko)"
   version: "0.1.0"
 ---
 

--- a/skills/vividus/SKILL.md
+++ b/skills/vividus/SKILL.md
@@ -3,7 +3,7 @@ name: vividus
 description: Bootstrap, configure, and author tests for the Vividus BDD framework — JBehave-based, config-first .story files spanning web/REST/mobile/DB via 47+ plugins. Use when the user mentions Vividus, .story files, vividus-bom/-starter, backtick-parameter BDD, or ./gradlew runStories.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Alexander Bychinkii (git: bermudas)"
   version: "1.0.0"
   framework: vividus
   framework-version: "0.6.x"

--- a/skills/xlsx-reader/SKILL.md
+++ b/skills/xlsx-reader/SKILL.md
@@ -4,7 +4,7 @@ description: Read .xlsx/.xls spreadsheets (test cases, checklists, requirement m
 license: Apache-2.0
 compatibility: Requires Node.js 18+ and the xlsx npm package (npm i xlsx).
 metadata:
-  author: octobots
+  author: "Olha Stetsenko (git: olexis-st)"
   version: "0.1.0"
 ---
 

--- a/skills/xray-testing/SKILL.md
+++ b/skills/xray-testing/SKILL.md
@@ -3,7 +3,7 @@ name: xray-testing
 description: CRUD + results import on Xray entities (Test, Precondition, Test Set/Plan/Execution/Run) across Cloud (GraphQL) and Server/DC (REST). Load for "pull test PROJ-T42", "create Xray test from this AFS", "upload JUnit to test plan", or any Xray CRUD.
 license: Apache-2.0
 metadata:
-  author: octobots
+  author: "Alexander Bychinkii (git: bermudas)"
   version: "0.1.0"
 ---
 


### PR DESCRIPTION
## Summary

Adds an explicit `metadata.author` to **every agent and skill** so contributors are cited directly in the frontmatter. Skills previously carried a placeholder `author: octobots`; that's replaced with the real author. Agents had no author field — a `metadata:` block is added to each.

41 files, frontmatter-only changes:

- **Olha Stetsenko (git: olexis-st)** — web-qa agents (`setup`, `tc-writer`, `orchestrator`, `executor`, `reporter`) + the `xlsx-reader` skill
- **Alexander Bychinkii (git: bermudas)** — `test-automation-engineer` + `test-automation-lead` (Tal) agents; `atlassian-content`, `test-case-analysis`, `test-automation-workflow`, `tosca-automation`, `vividus`, `xray-testing` skills
- **Artem Rozumenko (git: arozumenko)** — all remaining agents and skills

Values are quoted (`"Name (git: handle)"`) because the `git:` substring would otherwise be ambiguous YAML. No tooling reads these fields (the installer and validator ignore them), so this is documentation-only and behavior-preserving.

## Test Plan
- [x] No `author: octobots` remains anywhere.
- [x] Author counts: bermudas 8, arozumenko 27, olexis-st 6 (= 41).
- [x] All agent frontmatter delimiters intact (each AGENT.md still has its closing `---`); metadata block inserted just before it.
- [x] `npm run validate` passes — all 4 bundles valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)