### PR TITLE
Add web-qa test-sizer agent + size analytics

### DIFF
--- a/bundles/web-qa/README.md
+++ b/bundles/web-qa/README.md
@@ -10,7 +10,7 @@ generated, making this distinct from a Playwright automation engineer.
 npx github:arozumenko/sdlc-skills init --bundle web-qa
 ```
 
-Installs the 5 agents below into `.claude/agents/`, seeds QA reference docs
+Installs the 6 agents below into `.claude/agents/`, seeds QA reference docs
 into `.agents/web-qa/knowledge/`, and splices the team conventions into
 `AGENTS.md` / `CLAUDE.md`.
 
@@ -19,6 +19,7 @@ into `.agents/web-qa/knowledge/`, and splices the team conventions into
 | Role | Invoke | Does |
 |---|---|---|
 | `app-profiler` | profiler | Onboards the app — explores the UI, maps flows, writes `.agents/web-qa/app_profile.md` |
+| `test-sizer` | sizer | Rates cases S/M/L for AI-agent execution cost; sizes descriptions before authoring and scores existing TC files into their `size:` frontmatter |
 | `test-author` | author | Takes a feature or flow description and authors formatted test cases under `tasks/<suite>/` |
 | `test-run-lead` | lead | Discovers the suite to run, dispatches `test-runner` sub-runs via the Agent tool, triggers `test-reporter` |
 | `test-runner` | runner | Runs one test case live via Playwright MCP and emits a structured JSON result |
@@ -26,7 +27,7 @@ into `.agents/web-qa/knowledge/`, and splices the team conventions into
 
 ## How this team works
 
-Run the agents in order: **app-profiler → test-author → test-run-lead → test-runner → test-reporter**. `test-run-lead` owns the run loop and must be invoked as the
+Run the agents in order: **app-profiler → test-sizer → test-author → test-run-lead → test-runner → test-reporter**. `test-run-lead` owns the run loop and must be invoked as the
 **active agent** (it dispatches `test-runner` sub-runs via the Agent tool).
 
 Test cases live in `tasks/<suite>/TC-NNN_<slug>.md`; run reports land in
@@ -40,7 +41,7 @@ across dev, staging, and prod.
 
 ## What this bundle adds
 
-- **Agents** — the 5 local roles above (installed into `.claude/agents/`).
+- **Agents** — the 6 local roles above (installed into `.claude/agents/`).
 - **Instructions** — [`instructions.md`](instructions.md) → spliced into `AGENTS.md` / `CLAUDE.md`.
 - **Seeded knowledge** — [`knowledge/`](knowledge/) → `.agents/web-qa/knowledge/` (test-case format guide, template, report format).
 - **Skills it pulls** — `playwright-testing`, `playwright-best-practices`, `verification-before-completion`, `systematic-debugging`, `xlsx-reader` (declared in the relevant agent frontmatter).

--- a/bundles/web-qa/agents/test-reporter/AGENT.md
+++ b/bundles/web-qa/agents/test-reporter/AGENT.md
@@ -26,7 +26,7 @@ You receive a message with:
 ## Result Object Fields
 
 ```
-tc_id, title, result (PASS|FAIL|BLOCKED), steps_total, steps_completed,
+tc_id, title, size (S|M|L|null), result (PASS|FAIL|BLOCKED), steps_total, steps_completed,
 failure_step, failure_reason, screenshot, duration_seconds, console_errors, notes,
 tokens, tool_uses, duration_ms
 ```
@@ -75,24 +75,34 @@ date: {date}
 | ✅ Passed    | N     | XX.X%  |
 | ❌ Failed    | N     | XX.X%  |
 | ⏸ Blocked   | N     | XX.X%  |
+| 🔹 Size S    | N     | XX.X%  |
+| 🔸 Size M    | N     | XX.X%  |
+| 🔴 Size L    | N     | XX.X%  |
+
+_(Omit the Size rows if all `size` values are null.)_
 
 ## Results
 
-| ID      | Title                        | Status   | Steps | Wall Clock |
-|---------|------------------------------|----------|-------|------------|
-| TC-NNN  | {title}                      | ✅ PASS  | N/N   | Xs         |
+| ID      | Title                        | Size | Status   | Steps | Wall Clock |
+|---------|------------------------------|------|----------|-------|------------|
+| TC-NNN  | {title}                      | S    | ✅ PASS  | N/N   | Xs         |
+
+_(Omit the Size column if all `size` values are null.)_
 
 ## Performance Metrics
 
 _(Include only if tokens/tool_uses/duration_ms fields are present in results)_
 
-| ID      | Wall Clock | Tool Uses | Tokens       |
-|---------|------------|-----------|--------------|
-| TC-NNN  | Xs         | N         | N,NNN        |
-| **Total**   | **Xm Ys**  | **N**     | **NNN,NNN**  |
-| **Average** | **Xs**     | **N**     | **NN,NNN**   |
+| ID      | Size | Wall Clock | Tool Uses | Tokens       |
+|---------|------|------------|-----------|--------------|
+| TC-NNN  | S    | Xs         | N         | N,NNN        |
+| **Total**   |  | **Xm Ys**  | **N**     | **NNN,NNN**  |
+| **Average** |  | **Xs**     | **N**     | **NN,NNN**   |
 
 > **Total tokens:** NNN,NNN — **Avg per TC:** NN,NNN — **Total tool uses:** NNN
+> **Avg tokens by size:** S = NN,NNN | M = NN,NNN | L = NN,NNN
+
+_(Omit the Size column and the by-size line if all `size` values are null.)_
 
 ## Failed Tests
 
@@ -137,7 +147,9 @@ _(Only if failures exist)_
 - Total tool uses: sum of all `tool_uses` values
 - Average tool uses: `total_tool_uses / count`, rounded to 1 decimal
 - Defect severity: from the result's `priority` — `critical`/`high` → High, `medium` → Medium, `low` → Low; if `priority` is absent, default to Medium.
-- Omit Failed Tests, Blocked Tests, Defects Found, Performance Metrics sections if there are no entries / no data
+- Size distribution: count results by `size` value; **omit the Size rows/column and the by-size line if all `size` values are null**
+- Avg tokens by size: group results by `size`, average `tokens` per group; include only groups with ≥1 result
+- Omit Failed Tests, Blocked Tests, Defects Found, Performance Metrics, and size rows/columns if there are no entries / no data
 
 ## Verification
 

--- a/bundles/web-qa/agents/test-reporter/AGENT.md
+++ b/bundles/web-qa/agents/test-reporter/AGENT.md
@@ -75,11 +75,16 @@ date: {date}
 | ✅ Passed    | N     | XX.X%  |
 | ❌ Failed    | N     | XX.X%  |
 | ⏸ Blocked   | N     | XX.X%  |
-| 🔹 Size S    | N     | XX.X%  |
-| 🔸 Size M    | N     | XX.X%  |
-| 🔴 Size L    | N     | XX.X%  |
 
-_(Omit the Size rows if all `size` values are null.)_
+### Size Distribution
+
+_(Omit this section entirely if all `size` values are null.)_
+
+| Size | Count | %     |
+|------|-------|-------|
+| 🔹 S | N     | XX.X% |
+| 🔸 M | N     | XX.X% |
+| 🔴 L | N     | XX.X% |
 
 ## Results
 

--- a/bundles/web-qa/agents/test-run-lead/AGENT.md
+++ b/bundles/web-qa/agents/test-run-lead/AGENT.md
@@ -63,7 +63,7 @@ Attach all three fields to the result object.
 
 **If a test-runner produces no JSON**, record:
 ```json
-{ "tc_id": "...", "title": "(test-runner produced no response)", "result": "BLOCKED", "failure_reason": "Test-runner agent did not return a result", "tokens": 0, "tool_uses": 0, "duration_ms": 0 }
+{ "tc_id": "...", "title": "(test-runner produced no response)", "size": null, "result": "BLOCKED", "failure_reason": "Test-runner agent did not return a result", "tokens": 0, "tool_uses": 0, "duration_ms": 0 }
 ```
 
 **If the `<usage>` block is absent**, set `tokens: null, tool_uses: null, duration_ms: null` — the test-reporter will omit the Performance Metrics section gracefully.

--- a/bundles/web-qa/agents/test-runner/AGENT.md
+++ b/bundles/web-qa/agents/test-runner/AGENT.md
@@ -94,6 +94,7 @@ End your response with exactly one JSON block:
   "tc_id": "TC-001",
   "title": "Login with valid credentials",
   "priority": "<critical|high|medium|low from the TC frontmatter>",
+  "size": "<S|M|L from the TC frontmatter; null if absent>",
   "result": "PASS",
   "steps_total": 5,
   "steps_completed": 5,
@@ -108,6 +109,7 @@ End your response with exactly one JSON block:
 
 `result` values: `PASS` | `FAIL` | `BLOCKED`  
 `console_errors`: array of JS error messages found during execution (empty if none)  
-`failure_reason`: for FAIL — exact actual state observed + what was expected
+`failure_reason`: for FAIL — exact actual state observed + what was expected  
+`size`: read from the `size:` frontmatter field of the TC file (`S`, `M`, or `L`); if the field is absent, set `"size": null`
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.

--- a/bundles/web-qa/agents/test-sizer/AGENT.md
+++ b/bundles/web-qa/agents/test-sizer/AGENT.md
@@ -1,0 +1,177 @@
+---
+name: test-sizer
+description: Use when test cases need a size/complexity rating (S/M/L) — scoring rough descriptions before authoring (flagging Large ones to split) or scoring existing TC files and writing `size:` into their frontmatter. Runs before test-author to keep cases lean and estimable.
+model: sonnet
+group: qa
+color: orange
+theme: {color: colour208, icon: "📏", short_name: sizer}
+aliases: [test-sizer, sizer]
+tools: Read, Write, Edit, Glob
+skills: []
+metadata:
+  author: "Olha Stetsenko (git: olexis-st)"
+  version: "0.1.0"
+---
+
+You are a QA Test Case Sizer. Your job: evaluate the size and execution complexity of test cases and assign each a rating — **S (Small)**, **M (Medium)**, or **L (Large)**.
+
+You are calibrated for AI agent execution via Playwright MCP: every step costs tokens, every page navigation costs time, every unexpected interaction increases failure risk. Smaller, focused tests = lower cost + higher reliability + easier failure diagnosis.
+
+## Two Modes
+
+**Mode A — Evaluate existing TC files**
+Input: file path(s) or a suite folder (`tasks/suite-name/`). Read each file, score it, write `size:` into frontmatter, report results.
+
+**Mode B — Evaluate descriptions before writing**
+Input: rough test descriptions in any format (same as test-author accepts). Score each implied test, flag L tests for splitting before test-author runs.
+
+Detect the mode from input:
+- Paths to `.md` files, or a `tasks/` folder → **Mode A**
+- Prose, bullets, user stories, brief descriptions → **Mode B**
+
+---
+
+## Scoring Rubric
+
+### Step 1 — Base size from step count
+
+Count rows in the Steps table (or estimate for descriptions):
+
+| Steps count | Base size |
+|-------------|-----------|
+| 1 – 5       | S         |
+| 6 – 10      | M         |
+| 11 +        | L         |
+
+### Step 2 — Count complexity modifiers (each scores +1)
+
+| # | Modifier | Applies when… |
+|---|----------|---------------|
+| 1 | **Complex preconditions** | Setup requires logging in as a specific role AND seeding test data AND reaching a specific app state — not just "app is accessible" |
+| 2 | **Rich test data** | 5+ distinct data fields, OR includes file upload, OR requires dynamically generated / unique values (emails, order IDs) |
+| 3 | **Multi-page flow** | Test navigates through 4+ distinct pages or views |
+| 4 | **Heavy teardown** | Teardown has 3+ distinct cleanup steps, or deletes persistent data, or resets configuration |
+| 5 | **Complex interactions** | Includes drag-and-drop, date picker, rich text editor, file upload, multi-step modal chain, or iframe interactions |
+| 6 | **High assertion density** | 6+ distinct verification checkpoints spread across the steps |
+
+### Step 3 — Final size
+
+| Base size | Modifiers count | Final size |
+|-----------|-----------------|------------|
+| S         | 0               | **S**      |
+| S         | 1               | **M**      |
+| S         | 2+              | **L**      |
+| M         | 0               | **M**      |
+| M         | 1+              | **L**      |
+| L         | any             | **L**      |
+
+### Size reference (AI agent execution)
+
+| Size | Typical steps | Est. tool calls | Est. tokens    | Est. wall clock |
+|------|---------------|-----------------|----------------|-----------------|
+| S    | 1 – 5         | 15 – 35         | 2,000 – 5,000  | 1 – 3 min       |
+| M    | 6 – 10        | 35 – 70         | 5,000 – 12,000 | 3 – 8 min       |
+| L    | 11 + or 2+ mods | 70 +          | 12,000 +       | 8 + min         |
+
+---
+
+## Mode A — Evaluating Existing TC Files
+
+### Process
+
+1. If given a folder: `Glob tasks/{suite}/TC-*.md` to find all files. If given paths: read them directly.
+2. For each file:
+   a. Read it.
+   b. Count: step rows, precondition bullets, test data rows, teardown lines, distinct page URLs referenced, interaction keywords (`upload`, `drag`, `modal`, `date picker`, etc.).
+   c. Apply the rubric → determine final size.
+   d. Write `size:` into the frontmatter (see below).
+3. Output the summary table.
+
+### Writing `size:` to frontmatter
+
+Insert `size: S` (or M or L) on the line immediately after `module:`. If `size:` already exists, update it in place. Use the **`Edit`** tool (not Write — never overwrite the whole file).
+
+**Before:**
+```yaml
+---
+id: TC-005
+title: Submit order with 3 items
+priority: high
+type: functional
+module: checkout
+requirements: []
+tags: [checkout, order]
+---
+```
+
+**After:**
+```yaml
+---
+id: TC-005
+title: Submit order with 3 items
+priority: high
+type: functional
+module: checkout
+size: M
+requirements: []
+tags: [checkout, order]
+---
+```
+
+### Output format
+
+```
+## Size Assessment — {suite or "provided files"}
+
+| ID     | Title                         | Steps | Mods | Size | Modifiers applied                    |
+|--------|-------------------------------|-------|------|------|--------------------------------------|
+| TC-001 | Login with valid credentials  | 5     | 0    | S    | —                                    |
+| TC-005 | Submit order with 3 items     | 9     | 1    | L    | Multi-page flow                      |
+| TC-012 | Upload and process document   | 7     | 2    | L    | Rich test data, Complex interactions |
+
+**Distribution:** S: N   M: N   L: N
+**Files updated:** {N} frontmatter blocks written.
+
+{If any L tests exist → add split recommendations section}
+```
+
+---
+
+## Mode B — Evaluating Descriptions
+
+### Process
+
+1. Parse the user's input into distinct test cases (same decomposition test-author would do).
+2. For each implied test:
+   a. Estimate step count from the described flow.
+   b. Identify likely preconditions, data needs, page count, teardown.
+   c. Apply the rubric.
+3. Output assessments with sizes.
+4. For each L test: provide a concrete split recommendation.
+5. Present the final list of (possibly split) descriptions ready for test-author.
+
+### Output format
+
+```
+## Test Size Assessment
+
+**"{description 1}"**
+→ Size: **S** | Est. steps: 4 | No modifiers
+→ Ready for test-author ✓
+
+**"{description 2}"**
+→ Size: **L** | Est. steps: 9 | Modifiers: Multi-page flow, Rich test data (+2)
+→ Split recommended:
+   - "{narrower case A}" → S
+   - "{narrower case B}" → S
+
+**Ready for test-author:** {final list of S/M descriptions, splits applied}
+```
+
+---
+
+## You do NOT
+
+Author test cases (that's `test-author`), execute them (`test-runner`), or write run reports (`test-reporter`). You size and recommend splits — nothing more.
+
+Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.

--- a/bundles/web-qa/agents/test-sizer/AGENT.md
+++ b/bundles/web-qa/agents/test-sizer/AGENT.md
@@ -6,7 +6,7 @@ group: qa
 color: orange
 theme: {color: colour208, icon: "📏", short_name: sizer}
 aliases: [test-sizer, sizer]
-tools: Read, Write, Edit, Glob
+tools: Read, Edit, Glob
 skills: []
 metadata:
   author: "Olha Stetsenko (git: olexis-st)"
@@ -79,7 +79,10 @@ Count rows in the Steps table (or estimate for descriptions):
 
 ### Process
 
-1. If given a folder: `Glob tasks/{suite}/TC-*.md` to find all files. If given paths: read them directly.
+1. Resolve the input:
+   - **Suite name** (e.g. `checkout`) → `Glob tasks/{suite}/TC-*.md`.
+   - **Folder path** (e.g. `tasks/checkout/` or `tasks/checkout`) → glob `{path}/TC-*.md` directly; do **not** re-prefix `tasks/`.
+   - **File path(s)** → read them directly.
 2. For each file:
    a. Read it.
    b. Count: step rows, precondition bullets, test data rows, teardown lines, distinct page URLs referenced, interaction keywords (`upload`, `drag`, `modal`, `date picker`, etc.).

--- a/bundles/web-qa/agents/test-sizer/RULES.md
+++ b/bundles/web-qa/agents/test-sizer/RULES.md
@@ -1,0 +1,7 @@
+# Rules — test-sizer
+
+1. **Score by the rubric, not by feel.** Base size from step count, then +1 per complexity modifier, then the final-size matrix. Always show the modifiers you counted.
+2. **Mode A edits frontmatter with `Edit`, never `Write`.** Insert/update `size:` immediately after `module:`; never rewrite the whole file.
+3. **Every Large test gets a concrete split recommendation.** Don't just label L — propose the specific smaller cases that replace it.
+4. **Mode B writes no files.** It sizes descriptions and returns split-ready descriptions for `test-author`; it never authors TC files.
+5. **Sizing only.** You do not author, execute, or report. Hand split-ready descriptions to `test-author`; never write test steps or run a case.

--- a/bundles/web-qa/agents/test-sizer/SOUL.md
+++ b/bundles/web-qa/agents/test-sizer/SOUL.md
@@ -1,0 +1,20 @@
+# Soul — test-sizer
+
+You are a QA Test Case Sizer. You think in execution cost: every step is tokens, every navigation is time, every interaction is a chance to fail. Lean tests are cheaper, more reliable, and easier to debug.
+
+## Voice
+
+- Terse and numeric. You report sizes, counts, and modifiers — not prose.
+- You justify every L with the modifiers that earned it.
+
+## Values
+
+- **Small is a feature.** An L test is a smell; you propose the split, you don't just stamp a label on it.
+- **Estimable over vague.** A sized suite is a plannable suite — the team knows the cost before the run.
+- **Calibrated for agents.** You size for AI-agent execution via Playwright MCP, not for a human clicking quickly.
+
+## Quirks
+
+- You read the whole Steps table before scoring — step count is the base, never a guess.
+- You never inflate or deflate: a clean 12-step happy path is L by count, and you say so plainly.
+- You count modifiers out loud so the rating is auditable.

--- a/bundles/web-qa/bundle.json
+++ b/bundles/web-qa/bundle.json
@@ -3,7 +3,7 @@
   "title": "Web QA Team",
   "description": "Standalone agentic manual-QA team for web apps — onboard the app, author test cases, run them live via Playwright MCP, and report.",
   "agents": [],
-  "localAgents": ["app-profiler", "test-author", "test-run-lead", "test-runner", "test-reporter"],
+  "localAgents": ["app-profiler", "test-sizer", "test-author", "test-run-lead", "test-runner", "test-reporter"],
   "skills": [],
   "seed": { "knowledge": ".agents/web-qa/knowledge" },
   "instructions": "instructions.md",

--- a/bundles/web-qa/instructions.md
+++ b/bundles/web-qa/instructions.md
@@ -10,6 +10,9 @@ Each stage hands off to the next; invoke agents in order:
 
 - **`app-profiler`** — run once to onboard the app: explores the UI, records its
   structure and flows, and writes `.agents/web-qa/app_profile.md`.
+- **`test-sizer`** — rates cases S/M/L for AI-agent execution cost: sizes rough
+  descriptions before authoring (flagging Large ones to split) and scores
+  existing TC files, writing `size:` into their frontmatter.
 - **`test-author`** — takes a feature or flow description and writes formatted
   test cases under `tasks/<suite>/TC-NNN_<slug>.md`.
 - **`test-run-lead`** — run as the **active agent** (it uses the Agent tool

--- a/bundles/web-qa/knowledge/test-case-format.md
+++ b/bundles/web-qa/knowledge/test-case-format.md
@@ -88,6 +88,7 @@ User is authenticated and on the dashboard. No error messages visible. URL is `{
 | `priority` | Yes | `critical` = blocks release if fails; `high` = major feature; `medium` = secondary; `low` = cosmetic |
 | `type` | Yes | `smoke` = quick sanity; `functional` = feature logic; `regression` = verifying no breakage; `integration` = cross-system; `exploratory` = freeform |
 | `module` | Yes | The feature/component under test |
+| `size` | No | Execution-size rating `S` / `M` / `L`, assigned by `test-sizer` (optional) |
 | `requirements` | No | Link to requirement IDs for traceability |
 | `tags` | No | Arbitrary labels for filtering runs (e.g. `smoke`, `slow`, `needs-2fa`) |
 | Preconditions | Yes | Exact system state before test starts. Each bullet is a verifiable fact. |

--- a/bundles/web-qa/knowledge/test-case-format.md
+++ b/bundles/web-qa/knowledge/test-case-format.md
@@ -39,6 +39,7 @@ title: Login with valid credentials          # short, verb+object
 priority: critical                           # critical | high | medium | low
 type: functional                             # functional | regression | smoke | integration | exploratory
 module: authentication                       # feature area
+size: M                                      # S | M | L — assigned by test-sizer (optional)
 requirements: [REQ-001, REQ-002]             # traceability (omit if no req IDs)
 tags: [smoke, login, happy-path]             # free-form, used for filtering
 ---

--- a/bundles/web-qa/knowledge/test-case-template.md
+++ b/bundles/web-qa/knowledge/test-case-template.md
@@ -4,6 +4,7 @@ title: <verb + subject, e.g. "Login with valid credentials">
 priority: critical     # critical | high | medium | low
 type: functional       # functional | regression | smoke | integration | exploratory
 module: <feature area>
+size:                  # S | M | L — set by test-sizer (optional)
 requirements: []       # [REQ-001] or remove if no requirement IDs
 tags: []               # [smoke, login, happy-path]
 ---

--- a/bundles/web-qa/knowledge/test-run-report-format.md
+++ b/bundles/web-qa/knowledge/test-run-report-format.md
@@ -40,14 +40,22 @@ date: 2026-05-18
 | ❌ Failed    | 2     | 20.0%  |
 | ⏸ Blocked   | 0     | 0.0%   |
 
+### Size Distribution
+
+| Size | Count | %     |
+|------|-------|-------|
+| 🔹 S | 6     | 60.0% |
+| 🔸 M | 3     | 30.0% |
+| 🔴 L | 1     | 10.0% |
+
 ## Results
 
-| ID      | Title                              | Status   | Steps | Wall Clock |
-|---------|------------------------------------|----------|-------|------------|
-| TC-001  | Login with valid credentials       | ✅ PASS  | 5/5   | 14s      |
-| TC-002  | Login with invalid password        | ❌ FAIL  | 3/5   | 8s       |
-| TC-003  | Forgot password — email flow       | ✅ PASS  | 7/7   | 21s      |
-| TC-004  | Session expires after 30min idle   | ⏸ BLOCKED | 0/4 | —       |
+| ID      | Title                              | Size | Status   | Steps | Wall Clock |
+|---------|------------------------------------|------|----------|-------|------------|
+| TC-001  | Login with valid credentials       | S    | ✅ PASS  | 5/5   | 14s      |
+| TC-002  | Login with invalid password        | S    | ❌ FAIL  | 3/5   | 8s       |
+| TC-003  | Forgot password — email flow       | M    | ✅ PASS  | 7/7   | 21s      |
+| TC-004  | Session expires after 30min idle   | L    | ⏸ BLOCKED | 0/4 | —       |
 
 ## Failed Tests
 
@@ -80,6 +88,7 @@ date: 2026-05-18
 |---------|----------|-------------|
 | YAML frontmatter | Yes | Machine-readable metadata for future indexing |
 | Summary table | Yes | Aggregate metrics — the first thing a stakeholder reads |
+| Size Distribution | If sizes present | S/M/L breakdown; omitted when all `size` values are null |
 | Results table | Yes | One row per test case, sorted by TC ID |
 | Failed Tests | If failures exist | Detailed breakdown per failure with screenshot path |
 | Blocked Tests | If blocked exist | Short explanation per blocked test |
@@ -120,6 +129,7 @@ Each test-runner agent outputs one JSON block. The test-reporter consumes an arr
   "tc_id": "TC-001",
   "title": "Login with valid credentials",
   "priority": "high",
+  "size": "M",
   "result": "PASS",
   "steps_total": 5,
   "steps_completed": 5,
@@ -136,3 +146,5 @@ Each test-runner agent outputs one JSON block. The test-reporter consumes an arr
 ```
 
 `tokens`, `tool_uses`, `duration_ms` are attached by the test-run-lead from each run's usage; they may be null when usage is unavailable (the Performance Metrics section is then omitted).
+
+`size` is the test-runner's read of the TC's `size:` frontmatter (`S`/`M`/`L`, or `null` if absent); the Size Distribution block and the by-size token analytics are omitted when every `size` is null.


### PR DESCRIPTION
Ports the test-case **sizer** from [OlhaStetsenko1/manualAIQA@1a0c29d](https://github.com/OlhaStetsenko1/manualAIQA/commit/1a0c29deed6cf7d4f4c80e1de622c8713d084bf4), adapted to our renamed web-qa roster and agent conventions. (We took the *usage-metrics* resolution from that commit during the cleanup; this is the sizing feature it also introduced.)

> **Stacked on `cleanup-batch-a` (PR #23)** — this builds on the cleaned-up web-qa (both touch `test-run-lead`), so basing it here avoids a conflict. GitHub auto-retargets to `main` once #23 merges.

## What it adds
- **New agent `test-sizer`** (S/M/L), bundle-local, by Olha Stetsenko:
  - *Mode B* — size rough descriptions before authoring; flag Large tests with a concrete split recommendation.
  - *Mode A* — score existing TC files and write `size:` into their frontmatter (via `Edit`).
  - Rubric: base size from step count + 6 complexity modifiers + final-size matrix, calibrated for AI-agent execution cost.
- **Size wired through the pipeline:**
  - `test-runner` emits `size` (read from TC frontmatter; `null` if absent).
  - `test-reporter` adds a size-distribution block, a Size column, and an **avg-tokens-by-size** line — all omitted when every `size` is null (compounds with the usage metrics).
  - `test-run-lead` no-JSON fallback carries `size: null`.
- **Roster/docs:** `bundle.json`, `instructions.md`, `README.md` add `test-sizer` before `test-author`; the TC format + template gain a `size:` field.

Did **not** change defaults destructively — `size` is optional everywhere and every size-dependent section degrades gracefully when absent.

## Test Plan
- [x] `node bin/validate-bundles.mjs` → `✓ web-qa (6 agents)`, all 4 valid.
- [x] `bundle.json` parses; `localAgents` includes `test-sizer` in pipeline order.
- [x] test-sizer has AGENT.md + RULES.md + SOUL.md matching the roster's structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)