### PR TITLE
Hook-based memory/context injection + multi-runtime plugin & install support

### DIFF
--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -1,0 +1,165 @@
+{
+  "name": "sdlc-skills",
+  "owner": {
+    "name": "Artem Rozumenko",
+    "url": "https://github.com/arozumenko"
+  },
+  "plugins": [
+    {
+      "name": "sdlc-skills",
+      "source": "./",
+      "description": "Full SDLC toolkit — role-based agents, workflow skills, and session/subagent hooks (per-role memory + lean .agents/*.md project-context injection).",
+      "version": "0.2.0"
+    },
+    {
+      "name": "atlassian-content",
+      "source": "./skills/atlassian-content",
+      "description": "Create well-formatted Jira issues/comments (ADF, API v3) and Confluence pages (storage format) with accountId-backed mentions and mandatory post-creation re-fetch + repair",
+      "version": "0.2.0"
+    },
+    {
+      "name": "browser-verify",
+      "source": "./skills/browser-verify",
+      "description": "Browser verification via CDP — visual checks, screenshots, accessibility",
+      "version": "0.2.0"
+    },
+    {
+      "name": "bugfix-workflow",
+      "source": "./skills/bugfix-workflow",
+      "description": "End-to-end bugfix workflow — reproduce, test, fix, verify, document",
+      "version": "0.2.0"
+    },
+    {
+      "name": "code-review",
+      "source": "./skills/code-review",
+      "description": "Structured code review — security, quality, conventions",
+      "version": "0.2.0"
+    },
+    {
+      "name": "completing-a-task",
+      "source": "./skills/completing-a-task",
+      "description": "Use after implementing a routed task, when working code needs to be committed, pushed, PR'd, commented on the issue, and handed to a reviewer. The canonical task-handoff protocol; runs standalone or as the final phase of implement-feature.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "deep-research",
+      "source": "./skills/deep-research",
+      "description": "Deep research workflow — trends, topic analysis, fact-checking",
+      "version": "0.2.0"
+    },
+    {
+      "name": "gathering-context",
+      "source": "./skills/gathering-context",
+      "description": "Cross-channel context gathering — email, Teams, local KB",
+      "version": "0.2.0"
+    },
+    {
+      "name": "git-workflow",
+      "source": "./skills/git-workflow",
+      "description": "Git branching, PR creation, and merge workflow",
+      "version": "0.2.0"
+    },
+    {
+      "name": "implement-feature",
+      "source": "./skills/implement-feature",
+      "description": "End-to-end feature implementation workflow — plan, test, build, ship",
+      "version": "0.2.0"
+    },
+    {
+      "name": "issue-tracking",
+      "source": "./skills/issue-tracking",
+      "description": "GitHub issue lifecycle — labelling, commenting, closing",
+      "version": "0.2.0"
+    },
+    {
+      "name": "memory",
+      "source": "./skills/memory",
+      "description": "Persistent file-based memory across conversations",
+      "version": "0.2.0"
+    },
+    {
+      "name": "microsoft-365",
+      "source": "./skills/microsoft-365",
+      "description": "Microsoft Graph (email/calendar/Teams) integration",
+      "version": "0.2.0"
+    },
+    {
+      "name": "obsidian-vault",
+      "source": "./skills/obsidian-vault",
+      "description": "Read/write the user's Obsidian second brain",
+      "version": "0.2.0"
+    },
+    {
+      "name": "plan-feature",
+      "source": "./skills/plan-feature",
+      "description": "Structured feature planning — requirements, feasibility, acceptance criteria",
+      "version": "0.2.0"
+    },
+    {
+      "name": "playwright-testing",
+      "source": "./skills/playwright-testing",
+      "description": "End-to-end browser testing with Playwright",
+      "version": "0.2.0"
+    },
+    {
+      "name": "reproducing-issues",
+      "source": "./skills/reproducing-issues",
+      "description": "Reproduce a vague bug report into precise repeatable steps + evidence, ending in a CONFIRMED/CANNOT-REPRODUCE verdict (reproduction only)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "root-cause-analysis",
+      "source": "./skills/root-cause-analysis",
+      "description": "Trace a confirmed bug to its exact cause — execution path, classification, confidence, impact analysis (investigation only)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "seeding-a-project",
+      "source": "./skills/seeding-a-project",
+      "description": "Generate AGENTS.md, .agents/ content docs, and per-role memory briefings for a new project (used by scout)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "test-automation-workflow",
+      "source": "./skills/test-automation-workflow",
+      "description": "End-to-end test automation workflow — explore, specify (AFS), implement, review. Pluggable TMS adapters (Zephyr Scale, TestRail, Xray, Azure Test Plans, markdown) over HTTP or MCP",
+      "version": "0.2.0"
+    },
+    {
+      "name": "test-case-analysis",
+      "source": "./skills/test-case-analysis",
+      "description": "Execute a TMS test case against the live app, capture stable selectors, flag defects, and emit an Automation-Friendly Spec (AFS). Used by qa-engineer",
+      "version": "0.2.0"
+    },
+    {
+      "name": "tosca-automation",
+      "source": "./skills/tosca-automation",
+      "description": "Tricentis TOSCA Cloud full lifecycle — create/update/run TestCases, Modules (Html + SapEngine), Reusable Blocks, Playlists, Inventory folders, TSU import/export. Bundled `tosca_cli.py` (httpx + typer + rich)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "verifying-outcomes",
+      "source": "./skills/verifying-outcomes",
+      "description": "Goal-backward verification — check outcomes, not task completion",
+      "version": "0.2.0"
+    },
+    {
+      "name": "vividus",
+      "source": "./skills/vividus",
+      "description": "Bootstrap, configure, and author tests for the Vividus BDD framework (JBehave-based, 47+ plugins covering web/Selenium+Playwright, REST, mobile/Appium, DB, messaging, AWS/Azure, visual, accessibility). Config-first `.story` files, suite/profile/environment triple, BOM-pinned versions, MCP-server grounding. Templates in `assets/` for scaffolding",
+      "version": "0.2.0"
+    },
+    {
+      "name": "xlsx-reader",
+      "source": "./skills/xlsx-reader",
+      "description": "Read .xlsx spreadsheets (test cases, checklists) into Markdown for agent ingestion.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "xray-testing",
+      "source": "./skills/xray-testing",
+      "description": "CRUD + results import on Xray entities (Test / Precondition / Test Set / Test Plan / Test Execution / Test Run) across Xray Cloud (GraphQL) and Server/DC (REST). JUnit / Cucumber / Xray JSON import formats",
+      "version": "0.2.0"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "sdlc-skills",
+  "version": "0.2.0",
+  "description": "Role-based SDLC skills with session/subagent hooks that inject per-role memory and lean .agents/*.md project context.",
+  "author": {
+    "name": "Artem Rozumenko",
+    "url": "https://github.com/arozumenko"
+  },
+  "homepage": "https://github.com/arozumenko/sdlc-skills",
+  "repository": "https://github.com/arozumenko/sdlc-skills",
+  "license": "MIT",
+  "keywords": ["sdlc", "skills", "hooks", "memory"],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks-codex.json",
+  "interface": {
+    "displayName": "SDLC Skills",
+    "shortDescription": "SDLC skills + per-role memory/context hooks",
+    "category": "Productivity"
+  }
+}

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,225 @@
+{
+  "name": "sdlc-skills",
+  "owner": {
+    "name": "Artem Rozumenko",
+    "url": "https://github.com/arozumenko"
+  },
+  "plugins": [
+    {
+      "name": "sdlc-skills",
+      "source": "./",
+      "description": "Full SDLC toolkit — role-based agents, workflow skills, and session/subagent hooks (per-role memory + lean .agents/*.md project-context injection).",
+      "version": "0.2.0"
+    },
+    {
+      "name": "ba",
+      "source": "./agents/ba",
+      "description": "Use when user requirements need to be translated into user stories, acceptance criteria, or epics — or when a vague idea needs structuring before developers can act on it. Alex — sharp BA who turns vague ideas into clear requirements and bridges users to developers.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "ios-dev",
+      "source": "./agents/ios-dev",
+      "description": "Use when iOS work needs to be implemented — Swift, SwiftUI features, SwiftData models, or any Apple-platform task requiring TDD and verification before handoff. Io — energetic developer, opinionated about modern Apple APIs, pragmatic about delivery.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "js-dev",
+      "source": "./agents/js-dev",
+      "description": "Use when JavaScript or TypeScript work needs to be implemented — React components, Next.js pages, Node backend services, or any JS/TS task requiring TDD and verification before handoff. Jay — energetic TypeScript developer opinionated about DX, pragmatic about delivery.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "personal-assistant",
+      "source": "./agents/personal-assistant",
+      "description": "Use when the user wants a conversational assistant to answer questions, run errands across their tools (email, calendar, Teams, notes), or quietly maintain a second-brain knowledge base in the background. Octo — the user's personal assistant, engaged and resourceful.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "project-manager",
+      "source": "./agents/project-manager",
+      "description": "Use when tasks need to be routed to developers, when an approved PR needs to be merged, or when team progress needs coordination and status reporting. Max — sharp PM who turns chaos into actionable plans and owns the merge gate.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "python-dev",
+      "source": "./agents/python-dev",
+      "description": "Use when Python work needs to be implemented — FastAPI services, FastMCP servers, scripts, or any Python task requiring TDD and verification before handoff. Py — methodical Python developer who treats readable code as kindness to your future self.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "qa-engineer",
+      "source": "./agents/qa-engineer",
+      "description": "Use when a feature needs verification, a bug needs reproduction with evidence, E2E tests need writing or running via Playwright, or a TMS case needs turning into an automation-ready spec (AFS). Sage — meticulous QA who treats every passing test with suspicion and every failure as a gift.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "scout",
+      "source": "./agents/scout",
+      "description": "Use when an unfamiliar codebase needs to be onboarded — generating CLAUDE.md, AGENTS.md, `.agents/` content docs, and per-role memory briefings from exploration so the rest of the team can hit the ground running. Kit — maps repositories, surfaces patterns, flags risks.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "tech-lead",
+      "source": "./agents/tech-lead",
+      "description": "Use when a user story needs technical decomposition into dependency-ordered tasks with interface contracts, a confirmed bug needs root-cause analysis, or a PR needs a blocking code review before merge. Rio — senior tech lead who turns stories into executable plans and owns architecture decisions.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "test-automation-engineer",
+      "source": "./agents/test-automation-engineer",
+      "description": "Use when an Automation-Friendly Spec (AFS) needs to become a green, framework-resident test. Axel — senior automation engineer who matches the project's existing framework (Playwright/Cypress/pytest/JUnit/…), never masks product defects, and stops at the AFS boundary.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "atlassian-content",
+      "source": "./skills/atlassian-content",
+      "description": "Create well-formatted Jira issues/comments (ADF, API v3) and Confluence pages (storage format) with accountId-backed mentions and mandatory post-creation re-fetch + repair",
+      "version": "0.2.0"
+    },
+    {
+      "name": "browser-verify",
+      "source": "./skills/browser-verify",
+      "description": "Browser verification via CDP — visual checks, screenshots, accessibility",
+      "version": "0.2.0"
+    },
+    {
+      "name": "bugfix-workflow",
+      "source": "./skills/bugfix-workflow",
+      "description": "End-to-end bugfix workflow — reproduce, test, fix, verify, document",
+      "version": "0.2.0"
+    },
+    {
+      "name": "code-review",
+      "source": "./skills/code-review",
+      "description": "Structured code review — security, quality, conventions",
+      "version": "0.2.0"
+    },
+    {
+      "name": "completing-a-task",
+      "source": "./skills/completing-a-task",
+      "description": "Use after implementing a routed task, when working code needs to be committed, pushed, PR'd, commented on the issue, and handed to a reviewer. The canonical task-handoff protocol; runs standalone or as the final phase of implement-feature.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "deep-research",
+      "source": "./skills/deep-research",
+      "description": "Deep research workflow — trends, topic analysis, fact-checking",
+      "version": "0.2.0"
+    },
+    {
+      "name": "gathering-context",
+      "source": "./skills/gathering-context",
+      "description": "Cross-channel context gathering — email, Teams, local KB",
+      "version": "0.2.0"
+    },
+    {
+      "name": "git-workflow",
+      "source": "./skills/git-workflow",
+      "description": "Git branching, PR creation, and merge workflow",
+      "version": "0.2.0"
+    },
+    {
+      "name": "implement-feature",
+      "source": "./skills/implement-feature",
+      "description": "End-to-end feature implementation workflow — plan, test, build, ship",
+      "version": "0.2.0"
+    },
+    {
+      "name": "issue-tracking",
+      "source": "./skills/issue-tracking",
+      "description": "GitHub issue lifecycle — labelling, commenting, closing",
+      "version": "0.2.0"
+    },
+    {
+      "name": "memory",
+      "source": "./skills/memory",
+      "description": "Persistent file-based memory across conversations",
+      "version": "0.2.0"
+    },
+    {
+      "name": "microsoft-365",
+      "source": "./skills/microsoft-365",
+      "description": "Microsoft Graph (email/calendar/Teams) integration",
+      "version": "0.2.0"
+    },
+    {
+      "name": "obsidian-vault",
+      "source": "./skills/obsidian-vault",
+      "description": "Read/write the user's Obsidian second brain",
+      "version": "0.2.0"
+    },
+    {
+      "name": "plan-feature",
+      "source": "./skills/plan-feature",
+      "description": "Structured feature planning — requirements, feasibility, acceptance criteria",
+      "version": "0.2.0"
+    },
+    {
+      "name": "playwright-testing",
+      "source": "./skills/playwright-testing",
+      "description": "End-to-end browser testing with Playwright",
+      "version": "0.2.0"
+    },
+    {
+      "name": "reproducing-issues",
+      "source": "./skills/reproducing-issues",
+      "description": "Reproduce a vague bug report into precise repeatable steps + evidence, ending in a CONFIRMED/CANNOT-REPRODUCE verdict (reproduction only)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "root-cause-analysis",
+      "source": "./skills/root-cause-analysis",
+      "description": "Trace a confirmed bug to its exact cause — execution path, classification, confidence, impact analysis (investigation only)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "seeding-a-project",
+      "source": "./skills/seeding-a-project",
+      "description": "Generate AGENTS.md, .agents/ content docs, and per-role memory briefings for a new project (used by scout)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "test-automation-workflow",
+      "source": "./skills/test-automation-workflow",
+      "description": "End-to-end test automation workflow — explore, specify (AFS), implement, review. Pluggable TMS adapters (Zephyr Scale, TestRail, Xray, Azure Test Plans, markdown) over HTTP or MCP",
+      "version": "0.2.0"
+    },
+    {
+      "name": "test-case-analysis",
+      "source": "./skills/test-case-analysis",
+      "description": "Execute a TMS test case against the live app, capture stable selectors, flag defects, and emit an Automation-Friendly Spec (AFS). Used by qa-engineer",
+      "version": "0.2.0"
+    },
+    {
+      "name": "tosca-automation",
+      "source": "./skills/tosca-automation",
+      "description": "Tricentis TOSCA Cloud full lifecycle — create/update/run TestCases, Modules (Html + SapEngine), Reusable Blocks, Playlists, Inventory folders, TSU import/export. Bundled `tosca_cli.py` (httpx + typer + rich)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "verifying-outcomes",
+      "source": "./skills/verifying-outcomes",
+      "description": "Goal-backward verification — check outcomes, not task completion",
+      "version": "0.2.0"
+    },
+    {
+      "name": "vividus",
+      "source": "./skills/vividus",
+      "description": "Bootstrap, configure, and author tests for the Vividus BDD framework (JBehave-based, 47+ plugins covering web/Selenium+Playwright, REST, mobile/Appium, DB, messaging, AWS/Azure, visual, accessibility). Config-first `.story` files, suite/profile/environment triple, BOM-pinned versions, MCP-server grounding. Templates in `assets/` for scaffolding",
+      "version": "0.2.0"
+    },
+    {
+      "name": "xlsx-reader",
+      "source": "./skills/xlsx-reader",
+      "description": "Read .xlsx spreadsheets (test cases, checklists) into Markdown for agent ingestion.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "xray-testing",
+      "source": "./skills/xray-testing",
+      "description": "CRUD + results import on Xray entities (Test / Precondition / Test Set / Test Plan / Test Execution / Test Run) across Xray Cloud (GraphQL) and Server/DC (REST). JUnit / Cucumber / Xray JSON import formats",
+      "version": "0.2.0"
+    }
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -20,5 +20,6 @@
     "code-review"
   ],
   "skills": "./skills/",
-  "agents": "./agents/"
+  "agents": "./agents/",
+  "hooks": "./hooks/hooks-cursor.json"
 }

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,165 @@
+{
+  "name": "sdlc-skills",
+  "owner": {
+    "name": "Artem Rozumenko",
+    "url": "https://github.com/arozumenko"
+  },
+  "plugins": [
+    {
+      "name": "sdlc-skills",
+      "source": "./",
+      "description": "Full SDLC toolkit — role-based agents, workflow skills, and session/subagent hooks (per-role memory + lean .agents/*.md project-context injection).",
+      "version": "0.2.0"
+    },
+    {
+      "name": "atlassian-content",
+      "source": "./skills/atlassian-content",
+      "description": "Create well-formatted Jira issues/comments (ADF, API v3) and Confluence pages (storage format) with accountId-backed mentions and mandatory post-creation re-fetch + repair",
+      "version": "0.2.0"
+    },
+    {
+      "name": "browser-verify",
+      "source": "./skills/browser-verify",
+      "description": "Browser verification via CDP — visual checks, screenshots, accessibility",
+      "version": "0.2.0"
+    },
+    {
+      "name": "bugfix-workflow",
+      "source": "./skills/bugfix-workflow",
+      "description": "End-to-end bugfix workflow — reproduce, test, fix, verify, document",
+      "version": "0.2.0"
+    },
+    {
+      "name": "code-review",
+      "source": "./skills/code-review",
+      "description": "Structured code review — security, quality, conventions",
+      "version": "0.2.0"
+    },
+    {
+      "name": "completing-a-task",
+      "source": "./skills/completing-a-task",
+      "description": "Use after implementing a routed task, when working code needs to be committed, pushed, PR'd, commented on the issue, and handed to a reviewer. The canonical task-handoff protocol; runs standalone or as the final phase of implement-feature.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "deep-research",
+      "source": "./skills/deep-research",
+      "description": "Deep research workflow — trends, topic analysis, fact-checking",
+      "version": "0.2.0"
+    },
+    {
+      "name": "gathering-context",
+      "source": "./skills/gathering-context",
+      "description": "Cross-channel context gathering — email, Teams, local KB",
+      "version": "0.2.0"
+    },
+    {
+      "name": "git-workflow",
+      "source": "./skills/git-workflow",
+      "description": "Git branching, PR creation, and merge workflow",
+      "version": "0.2.0"
+    },
+    {
+      "name": "implement-feature",
+      "source": "./skills/implement-feature",
+      "description": "End-to-end feature implementation workflow — plan, test, build, ship",
+      "version": "0.2.0"
+    },
+    {
+      "name": "issue-tracking",
+      "source": "./skills/issue-tracking",
+      "description": "GitHub issue lifecycle — labelling, commenting, closing",
+      "version": "0.2.0"
+    },
+    {
+      "name": "memory",
+      "source": "./skills/memory",
+      "description": "Persistent file-based memory across conversations",
+      "version": "0.2.0"
+    },
+    {
+      "name": "microsoft-365",
+      "source": "./skills/microsoft-365",
+      "description": "Microsoft Graph (email/calendar/Teams) integration",
+      "version": "0.2.0"
+    },
+    {
+      "name": "obsidian-vault",
+      "source": "./skills/obsidian-vault",
+      "description": "Read/write the user's Obsidian second brain",
+      "version": "0.2.0"
+    },
+    {
+      "name": "plan-feature",
+      "source": "./skills/plan-feature",
+      "description": "Structured feature planning — requirements, feasibility, acceptance criteria",
+      "version": "0.2.0"
+    },
+    {
+      "name": "playwright-testing",
+      "source": "./skills/playwright-testing",
+      "description": "End-to-end browser testing with Playwright",
+      "version": "0.2.0"
+    },
+    {
+      "name": "reproducing-issues",
+      "source": "./skills/reproducing-issues",
+      "description": "Reproduce a vague bug report into precise repeatable steps + evidence, ending in a CONFIRMED/CANNOT-REPRODUCE verdict (reproduction only)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "root-cause-analysis",
+      "source": "./skills/root-cause-analysis",
+      "description": "Trace a confirmed bug to its exact cause — execution path, classification, confidence, impact analysis (investigation only)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "seeding-a-project",
+      "source": "./skills/seeding-a-project",
+      "description": "Generate AGENTS.md, .agents/ content docs, and per-role memory briefings for a new project (used by scout)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "test-automation-workflow",
+      "source": "./skills/test-automation-workflow",
+      "description": "End-to-end test automation workflow — explore, specify (AFS), implement, review. Pluggable TMS adapters (Zephyr Scale, TestRail, Xray, Azure Test Plans, markdown) over HTTP or MCP",
+      "version": "0.2.0"
+    },
+    {
+      "name": "test-case-analysis",
+      "source": "./skills/test-case-analysis",
+      "description": "Execute a TMS test case against the live app, capture stable selectors, flag defects, and emit an Automation-Friendly Spec (AFS). Used by qa-engineer",
+      "version": "0.2.0"
+    },
+    {
+      "name": "tosca-automation",
+      "source": "./skills/tosca-automation",
+      "description": "Tricentis TOSCA Cloud full lifecycle — create/update/run TestCases, Modules (Html + SapEngine), Reusable Blocks, Playlists, Inventory folders, TSU import/export. Bundled `tosca_cli.py` (httpx + typer + rich)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "verifying-outcomes",
+      "source": "./skills/verifying-outcomes",
+      "description": "Goal-backward verification — check outcomes, not task completion",
+      "version": "0.2.0"
+    },
+    {
+      "name": "vividus",
+      "source": "./skills/vividus",
+      "description": "Bootstrap, configure, and author tests for the Vividus BDD framework (JBehave-based, 47+ plugins covering web/Selenium+Playwright, REST, mobile/Appium, DB, messaging, AWS/Azure, visual, accessibility). Config-first `.story` files, suite/profile/environment triple, BOM-pinned versions, MCP-server grounding. Templates in `assets/` for scaffolding",
+      "version": "0.2.0"
+    },
+    {
+      "name": "xlsx-reader",
+      "source": "./skills/xlsx-reader",
+      "description": "Read .xlsx spreadsheets (test cases, checklists) into Markdown for agent ingestion.",
+      "version": "0.2.0"
+    },
+    {
+      "name": "xray-testing",
+      "source": "./skills/xray-testing",
+      "description": "CRUD + results import on Xray entities (Test / Precondition / Test Set / Test Plan / Test Execution / Test Run) across Xray Cloud (GraphQL) and Server/DC (REST). JUnit / Cucumber / Xray JSON import formats",
+      "version": "0.2.0"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -369,16 +369,24 @@ Windsurf, and Copilot CLI. A BA can draft stories, a tech-lead can
 review a PR, `plan-feature` and `bugfix-workflow` run end-to-end with
 just `git` and `gh`.
 
-**`@import` paths auto-loaded at session start:**
+**Context auto-injected at session start (via the `hooks/` scripts):**
 
-```markdown
-@.agents/memory/<role>/snapshot.md
-```
+- `.agents/memory/<role>/snapshot.md` — each role's persistent memory,
+  injected per dispatch by the `agent-start` hook on Claude Code, Codex,
+  and Copilot CLI (their per-agent start hooks); re-fires on every
+  dispatch, so it survives `/clear` and compaction.
+- `.agents/role-overrides.md`, `profile.md`, `workflow.md`, `testing.md`,
+  `conventions.md`, `team-comms.md` — lean shared project context, injected
+  by the `session-start` hook (parent session) and by `agent-start` (each
+  dispatched subagent, which gets a fresh context), re-injected after
+  `/clear` or compaction. Big manuals (`AGENTS.md`, `docs/`) are not
+  injected — agents read those on demand.
 
-On first session the import resolves to a missing file and the agent
-falls back to reading `.agents/memory/<role>/MEMORY.md` + individual
-entries on demand. Once the memory skill has been used the snapshot
-file exists and is loaded automatically.
+A missing file is skipped (safe on first run). On Cursor (whose
+`subagentStart` is permission-only) and Kiro (whose `agentSpawn` carries
+no agent name), the `session-start` hook adds a roster reminder pointing
+each role at the `memory` skill instead. See
+[`hooks/README.md`](hooks/README.md) for wiring and the portability matrix.
 
 Every agent works as a subagent dispatched by the host IDE. Every
 `skills/<name>/` skill is self-contained. Developer agents work on your

--- a/README.md
+++ b/README.md
@@ -124,8 +124,10 @@ want to be happy).
 ### 1. npx installer (recommended)
 
 One command installs agents, their declared monorepo skills, and their
-external skills together. Works for Claude Code, Cursor, Windsurf, and
-GitHub Copilot (all four IDE targets detected automatically).
+external skills together. Works for Claude Code, Cursor, Windsurf, GitHub
+Copilot, and Codex (IDE targets detected automatically). Agents install in
+each host's native form — directories for Claude/Cursor/Windsurf, flat
+`.agent.md` for Copilot, TOML for Codex.
 
 ```bash
 # A team bundle — the whole team in one shot (agents, their skills,
@@ -365,7 +367,7 @@ catalog.
 ## Using these agents and skills
 
 These agents and skills install cleanly into Claude Code, Cursor,
-Windsurf, and Copilot CLI. A BA can draft stories, a tech-lead can
+Windsurf, Copilot CLI, and Codex. A BA can draft stories, a tech-lead can
 review a PR, `plan-feature` and `bugfix-workflow` run end-to-end with
 just `git` and `gh`.
 

--- a/agents/ba/AGENT.md
+++ b/agents/ba/AGENT.md
@@ -11,8 +11,6 @@ metadata:
   author: "Artem Rozumenko (git: arozumenko)"
 ---
 
-@.agents/memory/ba/snapshot.md
-
 # Business Analyst
 
 ## Identity
@@ -23,14 +21,9 @@ Read `SOUL.md` in this directory for your personality, voice, and values. That's
 
 Load this context before any task — it overrides defaults in this file.
 
-**1. Your memory.** The `@.agents/memory/ba/snapshot.md` import above auto-loads your persistent summary in Claude Code. For deeper recall or non-Claude IDEs, invoke the `memory` skill — it knows where your files live across install contexts.
+Your role memory and this project's `.agents/*.md` digests (team-comms, profile, workflow, …) are prepended to your context at dispatch — use what's there. If they're missing (first run, or a runtime without auto-injection), load memory via the `memory` skill (it knows where your files live across install contexts) and read the `.agents/*.md` files yourself.
 
-**2. Scout's project context** (if scout has onboarded this project):
-- `AGENTS.md` at project root — stack, build/test commands, conventions
-- `CLAUDE.md` at project root — the abbreviated, always-loaded version
-- `docs/` folder — architecture, components, requirements (when present)
-- `.agents/memory/ba/project_briefing.md` — project-specific briefing scout seeded as a `type: project` curated entry (read via the memory skill alongside your other curated entries)
-- `.agents/team-comms.md` — handoff protocol
+**Read on demand** (not injected): `AGENTS.md` for stack, build/test commands, conventions; `CLAUDE.md`; the `docs/` folder for architecture, components, requirements.
 
 If scout hasn't run, ask the user whether to run it first — writing stories without project context produces generic ones.
 

--- a/agents/ba/README.md
+++ b/agents/ba/README.md
@@ -19,13 +19,13 @@ An agent for the [sdlc-skills](../../README.md) toolkit. The agent definition li
 /plugin install ba@sdlc-skills
 ```
 
-### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot)
+### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot, Codex)
 
 ```bash
 npx github:arozumenko/sdlc-skills init --agents ba
 ```
 
-Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot`) to limit IDEs, and `--update` to overwrite.
+Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot` / `codex`) to limit IDEs, and `--update` to overwrite.
 
 ### Manual
 
@@ -33,7 +33,7 @@ Installing an agent **auto-resolves its declared skills**: skills in this repo a
 cp -r agents/ba .claude/agents/ba       # Claude Code / Cursor / Windsurf keep the directory
 ```
 
-For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot` (it writes `.github/agents/ba.agent.md`), or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install.
+For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot` (it writes `.github/agents/ba.agent.md`), or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install. For **Codex**, agents install as `.codex/agents/<name>.toml` — use the CLI with `--target codex` (a plain `cp` won’t work).
 
 ## Skills this agent uses
 

--- a/agents/ios-dev/AGENT.md
+++ b/agents/ios-dev/AGENT.md
@@ -12,8 +12,6 @@ metadata:
   author: "Artem Rozumenko (git: arozumenko)"
 ---
 
-@.agents/memory/ios-dev/snapshot.md
-
 # iOS / Swift Developer
 
 ## Identity
@@ -24,14 +22,9 @@ Read `SOUL.md` in this directory for your personality, voice, and values. That's
 
 Load this context before any task — it overrides defaults in this file.
 
-**1. Your memory.** The `@.agents/memory/ios-dev/snapshot.md` import above auto-loads your persistent summary in Claude Code. For deeper recall or non-Claude IDEs, invoke the `memory` skill.
+Your role memory and this project's `.agents/*.md` digests (conventions, testing, workflow, profile, …) are prepended to your context at dispatch — use what's there. If they're missing (first run, or a runtime without auto-injection), load memory via the `memory` skill and read the `.agents/*.md` files yourself.
 
-**2. Scout's project context** (if scout has onboarded this project):
-- `AGENTS.md` at project root — iOS target, Swift version, pinned dependencies, exact test commands
-- `CLAUDE.md` at project root — the abbreviated, always-loaded version
-- `docs/requirements.md`, `docs/architecture.md`, `docs/components.md` — app structure
-- `.agents/conventions.md`, `.agents/testing.md` — detected patterns
-- `.agents/memory/ios-dev/project_briefing.md` — project-specific briefing scout seeded as a `type: project` curated entry (xcodeproj layout, SwiftUI vs UIKit mix, known gotchas around Info.plist / pbxproj — read via the memory skill)
+**Read on demand** (the large manuals, not injected): `AGENTS.md` for the iOS target, Swift version, pinned dependencies, and exact test commands; `CLAUDE.md`; `docs/requirements.md`, `docs/architecture.md`, `docs/components.md` for app structure.
 
 Scout's findings override defaults. If `AGENTS.md` says iOS 17+ (not 26), target 17. If there's existing UIKit for reasons, don't rewrite it in SwiftUI unprompted.
 

--- a/agents/ios-dev/README.md
+++ b/agents/ios-dev/README.md
@@ -20,13 +20,13 @@ An agent for the [sdlc-skills](../../README.md) toolkit. The agent definition li
 /plugin install ios-dev@sdlc-skills
 ```
 
-### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot)
+### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot, Codex)
 
 ```bash
 npx github:arozumenko/sdlc-skills init --agents ios-dev
 ```
 
-Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot`) to limit IDEs, and `--update` to overwrite.
+Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot` / `codex`) to limit IDEs, and `--update` to overwrite.
 
 ### Manual
 
@@ -34,7 +34,7 @@ Installing an agent **auto-resolves its declared skills**: skills in this repo a
 cp -r agents/ios-dev .claude/agents/ios-dev       # Claude Code / Cursor / Windsurf keep the directory
 ```
 
-For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot` (it writes `.github/agents/ios-dev.agent.md`), or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install.
+For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot` (it writes `.github/agents/ios-dev.agent.md`), or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install. For **Codex**, agents install as `.codex/agents/<name>.toml` — use the CLI with `--target codex` (a plain `cp` won’t work).
 
 ## Skills this agent uses
 

--- a/agents/js-dev/AGENT.md
+++ b/agents/js-dev/AGENT.md
@@ -12,8 +12,6 @@ metadata:
   author: "Artem Rozumenko (git: arozumenko)"
 ---
 
-@.agents/memory/js-dev/snapshot.md
-
 # JS/TS Developer
 
 ## Identity
@@ -24,14 +22,9 @@ Read `SOUL.md` in this directory for your personality, voice, and values. That's
 
 Load this context before any task — it overrides defaults in this file.
 
-**1. Your memory.** The `@.agents/memory/js-dev/snapshot.md` import above auto-loads your persistent summary in Claude Code. For deeper recall or non-Claude IDEs, invoke the `memory` skill.
+Your role memory and this project's `.agents/*.md` digests (conventions, testing, workflow, profile, …) are prepended to your context at dispatch — use what's there. If they're missing (first run, or a runtime without auto-injection), load memory via the `memory` skill and read the `.agents/*.md` files yourself.
 
-**2. Scout's project context** (if scout has onboarded this project):
-- `AGENTS.md` at project root — stack, package manager (npm/pnpm/yarn/bun), exact build/test/lint commands, conventions
-- `CLAUDE.md` at project root — the abbreviated, always-loaded version
-- `docs/architecture.md`, `docs/components.md` — system layout
-- `.agents/conventions.md`, `.agents/testing.md` — detected patterns
-- `.agents/memory/js-dev/project_briefing.md` — project-specific briefing scout seeded as a `type: project` curated entry (framework, tsconfig strictness, known gotchas — read via the memory skill)
+**Read on demand** (the large manuals, not injected): `AGENTS.md` for the package manager (npm/pnpm/yarn/bun), exact build/test/lint commands, and full conventions; `CLAUDE.md`; `docs/architecture.md`, `docs/components.md` for system layout.
 
 Scout's findings override your defaults: if `AGENTS.md` says `pnpm` not `npm`, use `pnpm`. If it pins Node 20, don't suggest features that need 22.
 

--- a/agents/js-dev/README.md
+++ b/agents/js-dev/README.md
@@ -20,13 +20,13 @@ An agent for the [sdlc-skills](../../README.md) toolkit. The agent definition li
 /plugin install js-dev@sdlc-skills
 ```
 
-### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot)
+### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot, Codex)
 
 ```bash
 npx github:arozumenko/sdlc-skills init --agents js-dev
 ```
 
-Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot`) to limit IDEs, and `--update` to overwrite.
+Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot` / `codex`) to limit IDEs, and `--update` to overwrite.
 
 ### Manual
 
@@ -34,7 +34,7 @@ Installing an agent **auto-resolves its declared skills**: skills in this repo a
 cp -r agents/js-dev .claude/agents/js-dev       # Claude Code / Cursor / Windsurf keep the directory
 ```
 
-For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot` (it writes `.github/agents/js-dev.agent.md`), or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install.
+For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot` (it writes `.github/agents/js-dev.agent.md`), or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install. For **Codex**, agents install as `.codex/agents/<name>.toml` — use the CLI with `--target codex` (a plain `cp` won’t work).
 
 ## Skills this agent uses
 

--- a/agents/personal-assistant/AGENT.md
+++ b/agents/personal-assistant/AGENT.md
@@ -12,8 +12,6 @@ metadata:
   author: "Artem Rozumenko (git: arozumenko)"
 ---
 
-@.agents/memory/personal-assistant/snapshot.md
-
 # Personal Assistant — Octo
 
 You are **Octo**, the user's personal assistant. Your primary job is to **help
@@ -114,17 +112,15 @@ Correct:
 3. Persona files live in the agent's own `persona/` directory — load
    from there if present.
 
-**Scout's project context — if running inside a coding project where
-scout has onboarded** (rare but possible when PA is installed alongside
-developer roles):
+**Project context — if running inside a coding project where scout has
+onboarded** (rare but possible when PA is installed alongside developer
+roles): your `project_briefing` is already folded into your injected memory.
+Read `AGENTS.md` / `CLAUDE.md` directly for project stack + conventions when
+a task needs them (not injected).
 
-- `AGENTS.md` / `CLAUDE.md` at project root — project stack + conventions
-- `.agents/memory/personal-assistant/project_briefing.md` — project-specific
-  briefing scout seeded as a `type: project` curated entry (if any)
-
-Memory and recent daily logs are auto-loaded via the `@import` at the top
-of this file — that `@import` is a no-op if the file doesn't exist, so
-it's safe on any install.
+Your memory and recent daily logs are prepended to your context at dispatch
+(a no-op if no snapshot exists yet, so it's safe on any install). If they're not
+there, invoke the `memory` skill to load them.
 
 ## Operational memory (the `memory` skill)
 

--- a/agents/personal-assistant/README.md
+++ b/agents/personal-assistant/README.md
@@ -20,13 +20,13 @@ An agent for the [sdlc-skills](../../README.md) toolkit. The agent definition li
 /plugin install personal-assistant@sdlc-skills
 ```
 
-### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot)
+### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot, Codex)
 
 ```bash
 npx github:arozumenko/sdlc-skills init --agents personal-assistant
 ```
 
-Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot`) to limit IDEs, and `--update` to overwrite.
+Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot` / `codex`) to limit IDEs, and `--update` to overwrite.
 
 ### Manual
 
@@ -34,7 +34,7 @@ Installing an agent **auto-resolves its declared skills**: skills in this repo a
 cp -r agents/personal-assistant .claude/agents/personal-assistant   # Claude Code / Cursor / Windsurf keep the directory
 ```
 
-For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install.
+For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install. For **Codex**, agents install as `.codex/agents/<name>.toml` — use the CLI with `--target codex` (a plain `cp` won’t work).
 
 ## Skills this agent uses
 

--- a/agents/project-manager/AGENT.md
+++ b/agents/project-manager/AGENT.md
@@ -11,9 +11,6 @@ metadata:
   author: "Artem Rozumenko (git: arozumenko)"
 ---
 
-@.agents/memory/project-manager/snapshot.md
-@.agents/role-overrides.md
-
 # Project Manager
 
 ## Identity
@@ -24,18 +21,14 @@ Read `SOUL.md` in this directory for your personality, voice, and values. That's
 
 Load this context before any task — it overrides defaults in this file.
 
-**1. Your memory.** The `@.agents/memory/project-manager/snapshot.md` import above auto-loads your persistent summary in Claude Code. For deeper recall or non-Claude IDEs, invoke the `memory` skill.
+Your role memory and this project's `.agents/*.md` digests (role-overrides, team-comms, workflow, profile, conventions) are prepended to your context at dispatch — use what's there. If they're missing (first run, or a runtime without auto-injection), load memory via the `memory` skill and read the `.agents/*.md` files yourself.
 
-**2. Scout's project context** (if scout has onboarded this project):
-- `AGENTS.md` and `CLAUDE.md` at project root — stack, conventions, team
-- `.agents/team-comms.md` — **required** for routing (see next section)
-- `.agents/workflow.md` — how this team actually works (derived from scout's PR sampling): review cadence, required approvers, who typically authors what, branch/commit conventions, CI gates. Read this before making non-trivial routing decisions so your calls align with how the team actually operates.
-- `.agents/profile.md` — scout outputs. **Read § Automation PR
-  policy** (base branch, merge policy, merge strategy) before you
-  close any merge gate; the full rule lives in *Merging approved
-  PRs* below. `.agents/conventions.md` too when present.
-- `.agents/memory/project-manager/project_briefing.md` — project-specific briefing scout seeded as a `type: project` curated entry (read via the memory skill)
-- `docs/` — architecture and component maps
+**Sources of truth:**
+- `.agents/team-comms.md` — **required** for routing (see *How you communicate* below).
+- `.agents/workflow.md` — how this team actually works (scout-derived from PR sampling): review cadence, required approvers, who typically authors what, branch/commit conventions, CI gates. Consult before any non-trivial routing decision so your calls align with how the team operates.
+- `.agents/profile.md` — **§ Automation PR policy** (base branch, merge policy, merge strategy) governs the merge gate; the full rule lives in *Merging approved PRs* below. `.agents/role-overrides.md` maps substitute agents; `.agents/conventions.md` when present.
+
+**Read on demand** (not injected): `AGENTS.md` for stack, conventions, team; `CLAUDE.md`; `docs/` for architecture and component maps.
 
 **Conditional skill load:** `atlassian-content` — load only when the
 project's issue tracker is Jira or KB is Confluence (see
@@ -44,7 +37,7 @@ GitLab-only projects, stay with `issue-tracking`.
 
 ## How you communicate with the team
 
-**Read `.agents/team-comms.md` before routing any work.** It is the
+**`.agents/team-comms.md` — injected into your context at dispatch — is your routing rulebook.** It is the
 canonical, scout-generated answer to "how do I hand off on this project?"
 — installed roster, exact invocation syntax for this project's host,
 when to delegate, and anti-patterns. If it's missing, the project hasn't
@@ -365,8 +358,8 @@ status gating, handoff prompts, batching rules, and tech-lead
 escalation. This AGENT.md deliberately doesn't restate the flow so
 the two don't drift.
 
-If `.agents/role-overrides.md` exists (auto-imported at the top of
-this file), apply its substitute mappings over the skill's
+If `.agents/role-overrides.md` exists (the `session-start` hook injects it
+when present), apply its substitute mappings over the skill's
 defaults — e.g. a language-matched dev substituting for
 `test-automation-engineer` when the dedicated agent isn't installed.
 Scout writes that file during `seeding-a-project` § Step 6.9.

--- a/agents/project-manager/README.md
+++ b/agents/project-manager/README.md
@@ -19,13 +19,13 @@ An agent for the [sdlc-skills](../../README.md) toolkit. The agent definition li
 /plugin install project-manager@sdlc-skills
 ```
 
-### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot)
+### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot, Codex)
 
 ```bash
 npx github:arozumenko/sdlc-skills init --agents project-manager
 ```
 
-Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot`) to limit IDEs, and `--update` to overwrite.
+Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot` / `codex`) to limit IDEs, and `--update` to overwrite.
 
 ### Manual
 
@@ -33,7 +33,7 @@ Installing an agent **auto-resolves its declared skills**: skills in this repo a
 cp -r agents/project-manager .claude/agents/project-manager   # Claude Code / Cursor / Windsurf keep the directory
 ```
 
-For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install.
+For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install. For **Codex**, agents install as `.codex/agents/<name>.toml` — use the CLI with `--target codex` (a plain `cp` won’t work).
 
 ## Skills this agent uses
 

--- a/agents/python-dev/AGENT.md
+++ b/agents/python-dev/AGENT.md
@@ -12,8 +12,6 @@ metadata:
   author: "Artem Rozumenko (git: arozumenko)"
 ---
 
-@.agents/memory/python-dev/snapshot.md
-
 # Python Developer
 
 ## Identity
@@ -24,14 +22,9 @@ Read `SOUL.md` in this directory for your personality, voice, and values. That's
 
 Load this context before any task — it overrides defaults in this file.
 
-**1. Your memory.** The `@.agents/memory/python-dev/snapshot.md` import above auto-loads your persistent summary in Claude Code. For deeper recall or non-Claude IDEs, invoke the `memory` skill.
+Your role memory and this project's `.agents/*.md` digests (conventions, testing, workflow, profile, …) are prepended to your context at dispatch — use what's there. If they're missing (first run, or a runtime without auto-injection), load memory via the `memory` skill and read the `.agents/*.md` files yourself.
 
-**2. Scout's project context** (if scout has onboarded this project):
-- `AGENTS.md` at project root — stack, exact build/test/lint commands, conventions
-- `CLAUDE.md` at project root — the abbreviated, always-loaded version
-- `docs/architecture.md`, `docs/components.md` — system layout
-- `.agents/conventions.md`, `.agents/testing.md` — detected patterns
-- `.agents/memory/python-dev/project_briefing.md` — project-specific briefing scout seeded as a `type: project` curated entry (preferred tools, project-pinned versions, known gotchas — read via the memory skill)
+**Read on demand** (the large manuals, not injected): `AGENTS.md` for the exact build/test/lint commands and full conventions; `CLAUDE.md`; `docs/architecture.md`, `docs/components.md` for system layout.
 
 Scout's findings override your defaults: if `AGENTS.md` says `ruff` not `pylint`, use `ruff`. If it pins Python 3.11, don't suggest 3.13 syntax.
 

--- a/agents/python-dev/README.md
+++ b/agents/python-dev/README.md
@@ -20,13 +20,13 @@ An agent for the [sdlc-skills](../../README.md) toolkit. The agent definition li
 /plugin install python-dev@sdlc-skills
 ```
 
-### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot)
+### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot, Codex)
 
 ```bash
 npx github:arozumenko/sdlc-skills init --agents python-dev
 ```
 
-Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot`) to limit IDEs, and `--update` to overwrite.
+Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot` / `codex`) to limit IDEs, and `--update` to overwrite.
 
 ### Manual
 
@@ -34,7 +34,7 @@ Installing an agent **auto-resolves its declared skills**: skills in this repo a
 cp -r agents/python-dev .claude/agents/python-dev   # Claude Code / Cursor / Windsurf keep the directory
 ```
 
-For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install.
+For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install. For **Codex**, agents install as `.codex/agents/<name>.toml` — use the CLI with `--target codex` (a plain `cp` won’t work).
 
 ## Skills this agent uses
 

--- a/agents/qa-engineer/AGENT.md
+++ b/agents/qa-engineer/AGENT.md
@@ -11,8 +11,6 @@ metadata:
   author: "Artem Rozumenko (git: arozumenko)"
 ---
 
-@.agents/memory/qa-engineer/snapshot.md
-
 # QA Engineer
 
 ## Identity
@@ -23,16 +21,14 @@ Read `SOUL.md` in this directory for your personality, voice, and values. That's
 
 Load this context before any task — it overrides defaults in this file.
 
-**1. Your memory.** The `@.agents/memory/qa-engineer/snapshot.md` import above auto-loads your persistent summary in Claude Code. For deeper recall or non-Claude IDEs, invoke the `memory` skill.
+Your role memory and this project's `.agents/*.md` digests are prepended to your context at dispatch — use what's there. If they're missing (first run, or a runtime without auto-injection), load memory via the `memory` skill and read the `.agents/*.md` files yourself. Your `project_briefing` (known flaky tests, environments, test-data strategy) rides along in your memory.
 
-**2. Scout's project context** (if scout has onboarded this project):
-- `AGENTS.md` at project root — stack, test framework, exact test commands, environments
-- `.agents/testing.md` — **your primary reference**: fixtures, flaky areas, coverage tools, CI pipeline, test environments, test user accounts, scope boundaries
-- `.agents/profile.md` § Project systems — **authoritative for bug filing**: where defects land (issue tracker type / project key / bug-filing style: github-issue vs story-subtask vs test-case-comment vs separate-ticket). Read this before filing any defect during `test-case-analysis`.
-- `.agents/workflow.md` — how this team actually works (review gates, who authors what kind of tests, commit/branch conventions, test-delivery pattern) — scout derives this from PR sampling
-- `.agents/test-automation.yaml` — TMS adapter + transport (HTTP or MCP) when working on test-automation pilot
-- `docs/requirements.md` — what behavior is supposed to exist (your spec for test generation)
-- `.agents/memory/qa-engineer/project_briefing.md` — project-specific briefing scout seeded as a `type: project` curated entry (known flaky tests, environments, test-data strategy — read via the memory skill)
+**Sources of truth:**
+- `.agents/testing.md` — **your primary reference**: fixtures, flaky areas, coverage tools, CI pipeline, test environments, test user accounts, scope boundaries.
+- `.agents/profile.md` § Project systems — **authoritative for bug filing**: where defects land (issue tracker type / project key / bug-filing style: github-issue vs story-subtask vs test-case-comment vs separate-ticket). Consult before filing any defect during `test-case-analysis`.
+- `.agents/workflow.md` — how this team works (review gates, who authors what kind of tests, commit/branch conventions, test-delivery pattern).
+
+**Read on demand** (large manuals, not injected): `AGENTS.md` for stack, test framework, exact test commands, environments; `.agents/test-automation.yaml` for the TMS adapter + transport (HTTP or MCP) on the test-automation pilot; `docs/requirements.md` for the behavior that should exist (your spec for test generation).
 
 Scout's findings override defaults. If `.agents/testing.md` names the test command, use that exactly — don't guess.
 

--- a/agents/qa-engineer/README.md
+++ b/agents/qa-engineer/README.md
@@ -19,13 +19,13 @@ An agent for the [sdlc-skills](../../README.md) toolkit. The agent definition li
 /plugin install qa-engineer@sdlc-skills
 ```
 
-### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot)
+### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot, Codex)
 
 ```bash
 npx github:arozumenko/sdlc-skills init --agents qa-engineer
 ```
 
-Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot`) to limit IDEs, and `--update` to overwrite.
+Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot` / `codex`) to limit IDEs, and `--update` to overwrite.
 
 ### Manual
 
@@ -33,7 +33,7 @@ Installing an agent **auto-resolves its declared skills**: skills in this repo a
 cp -r agents/qa-engineer .claude/agents/qa-engineer   # Claude Code / Cursor / Windsurf keep the directory
 ```
 
-For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install.
+For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install. For **Codex**, agents install as `.codex/agents/<name>.toml` — use the CLI with `--target codex` (a plain `cp` won’t work).
 
 ## Skills this agent uses
 

--- a/agents/scout/README.md
+++ b/agents/scout/README.md
@@ -19,13 +19,13 @@ An agent for the [sdlc-skills](../../README.md) toolkit. The agent definition li
 /plugin install scout@sdlc-skills
 ```
 
-### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot)
+### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot, Codex)
 
 ```bash
 npx github:arozumenko/sdlc-skills init --agents scout
 ```
 
-Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot`) to limit IDEs, and `--update` to overwrite.
+Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot` / `codex`) to limit IDEs, and `--update` to overwrite.
 
 ### Manual
 
@@ -33,7 +33,7 @@ Installing an agent **auto-resolves its declared skills**: skills in this repo a
 cp -r agents/scout .claude/agents/scout   # Claude Code / Cursor / Windsurf keep the directory
 ```
 
-For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install.
+For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install. For **Codex**, agents install as `.codex/agents/<name>.toml` — use the CLI with `--target codex` (a plain `cp` won’t work).
 
 ## Skills this agent uses
 

--- a/agents/tech-lead/AGENT.md
+++ b/agents/tech-lead/AGENT.md
@@ -11,9 +11,6 @@ metadata:
   author: "Artem Rozumenko (git: arozumenko)"
 ---
 
-@.agents/memory/tech-lead/snapshot.md
-@.agents/role-overrides.md
-
 # Tech Lead
 
 ## Identity
@@ -24,16 +21,11 @@ Read `SOUL.md` in this directory for your personality, voice, and values. That's
 
 Load this context before any task — it overrides defaults in this file.
 
-**1. Your memory.** The `@.agents/memory/tech-lead/snapshot.md` import above auto-loads your persistent summary in Claude Code. For deeper recall or non-Claude IDEs, invoke the `memory` skill — it knows where your files live across install contexts.
+Your role memory and this project's `.agents/*.md` digests (role-overrides, workflow, conventions, team-comms, profile) are prepended to your context at dispatch — use what's there. If they're missing (first run, or a runtime without auto-injection), load memory via the `memory` skill (it knows where your files live across install contexts) and read the `.agents/*.md` files yourself.
 
-**2. Scout's project context** (if scout has onboarded this project):
-- `AGENTS.md` at project root — stack, build/test commands, conventions
-- `CLAUDE.md` at project root — the abbreviated, always-loaded version
-- `docs/architecture.md`, `docs/components.md` — system design (essential for technical decomposition)
-- `.agents/architecture.md`, `.agents/conventions.md` — additional scout outputs when present
-- `.agents/workflow.md` — how this team actually works (scout derives this from PR sampling): review cadence, required approvers, branch/commit conventions, CI gates, framework-evolution patterns. Read before decomposing stories so the tasks you emit match the team's actual ways of working and reviewing.
-- `.agents/memory/tech-lead/project_briefing.md` — project-specific briefing scout seeded as a `type: project` curated entry (read via the memory skill)
-- `.agents/team-comms.md` — handoff protocol
+`.agents/workflow.md` is your guide to how this team works (review cadence, required approvers, branch/commit conventions, CI gates, framework-evolution patterns) — match the tasks you emit to it. `.agents/role-overrides.md` maps substitute agents.
+
+**Read on demand** (not injected): `AGENTS.md` for stack, build/test commands, conventions; `CLAUDE.md`; `docs/architecture.md`, `docs/components.md` + `.agents/architecture.md` for system design (essential for technical decomposition).
 
 **3. Conditional skill loads** (by project systems, not on every session):
 - **`atlassian-content`** — load when the project's issue tracker is

--- a/agents/tech-lead/README.md
+++ b/agents/tech-lead/README.md
@@ -19,13 +19,13 @@ An agent for the [sdlc-skills](../../README.md) toolkit. The agent definition li
 /plugin install tech-lead@sdlc-skills
 ```
 
-### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot)
+### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot, Codex)
 
 ```bash
 npx github:arozumenko/sdlc-skills init --agents tech-lead
 ```
 
-Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot`) to limit IDEs, and `--update` to overwrite.
+Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot` / `codex`) to limit IDEs, and `--update` to overwrite.
 
 ### Manual
 
@@ -33,7 +33,7 @@ Installing an agent **auto-resolves its declared skills**: skills in this repo a
 cp -r agents/tech-lead .claude/agents/tech-lead   # Claude Code / Cursor / Windsurf keep the directory
 ```
 
-For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install.
+For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install. For **Codex**, agents install as `.codex/agents/<name>.toml` — use the CLI with `--target codex` (a plain `cp` won’t work).
 
 ## Skills this agent uses
 

--- a/agents/test-automation-engineer/AGENT.md
+++ b/agents/test-automation-engineer/AGENT.md
@@ -12,8 +12,6 @@ metadata:
   author: "Alexander Bychinkii (git: bermudas)"
 ---
 
-@.agents/memory/test-automation-engineer/snapshot.md
-
 # Test Automation Engineer
 
 ## Identity
@@ -24,19 +22,14 @@ Read `SOUL.md` in this directory for your personality, voice, and values. That's
 
 Load this context before any task — it overrides defaults in this file.
 
-**1. Your memory.** The `@.agents/memory/test-automation-engineer/snapshot.md` import above auto-loads your persistent summary in Claude Code. For deeper recall or non-Claude IDEs, invoke the `memory` skill.
+Your role memory and this project's `.agents/*.md` digests are prepended to your context at dispatch — use what's there. If they're missing (first run, or a runtime without auto-injection), load memory via the `memory` skill and read the `.agents/*.md` files yourself. Your `project_briefing` (framework conventions, common pitfalls, CI quirks) rides along in your memory.
 
-**2. Scout's project context** (if scout has onboarded this project):
-- `AGENTS.md` at project root — stack, test framework, exact build/test/CI commands
-- `CLAUDE.md` at project root — the abbreviated, always-loaded version
-- `docs/architecture.md`, `docs/components.md` — system layout (so your tests touch the right surfaces)
-- `.agents/testing.md` — **your primary reference**: framework name + version, page-object location, fixture patterns, step logger / reporter, exact CI command
-- `.agents/test-automation.yaml` — TMS adapter + transport, plus the framework block (language, runner, paths, env file)
-- `.agents/workflow.md` — how this team actually works (review gates, branch/commit conventions, whether tests ship with features or separately, typical PR size) — scout derives this from PR sampling; look here when deciding how to structure your PR
-- `.agents/conventions.md` — detected coding patterns
-- `.agents/architecture.md` — system surfaces your tests will touch
-- `.agents/memory/test-automation-engineer/project_briefing.md` — project-specific briefing scout seeded (framework conventions, common pitfalls, CI quirks — read via the memory skill)
-- `.agents/team-comms.md` — handoff protocol
+**Sources of truth:**
+- `.agents/testing.md` — **your primary reference**: framework name + version, page-object location, fixture patterns, step logger / reporter, exact CI command.
+- `.agents/workflow.md` — how this team works (review gates, branch/commit conventions, whether tests ship with features or separately, typical PR size); consult when structuring your PR.
+- `.agents/conventions.md` — detected coding patterns. `.agents/team-comms.md` — handoff protocol.
+
+**Read on demand** (not injected): `AGENTS.md` for stack, test framework, exact build/test/CI commands; `CLAUDE.md`; `.agents/test-automation.yaml` for the TMS adapter + transport and framework block (language, runner, paths, env file); `.agents/architecture.md` + `docs/architecture.md`, `docs/components.md` for the surfaces your tests touch.
 
 Scout's findings override defaults. Match `.agents/testing.md` exactly — framework version, naming, page-object style, run commands. Before writing a line, read three neighboring tests.
 

--- a/agents/test-automation-engineer/README.md
+++ b/agents/test-automation-engineer/README.md
@@ -20,13 +20,13 @@ An agent for the [sdlc-skills](../../README.md) toolkit. The agent definition li
 /plugin install test-automation-engineer@sdlc-skills
 ```
 
-### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot)
+### npx CLI (Claude Code, Cursor, Windsurf, GitHub Copilot, Codex)
 
 ```bash
 npx github:arozumenko/sdlc-skills init --agents test-automation-engineer
 ```
 
-Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot`) to limit IDEs, and `--update` to overwrite.
+Installing an agent **auto-resolves its declared skills**: skills in this repo are copied in; external ones are fetched from `skills.json` (or surfaced as pending if not yet available). Add `--target claude` (or `cursor` / `windsurf` / `copilot` / `codex`) to limit IDEs, and `--update` to overwrite.
 
 ### Manual
 
@@ -34,7 +34,7 @@ Installing an agent **auto-resolves its declared skills**: skills in this repo a
 cp -r agents/test-automation-engineer .claude/agents/test-automation-engineer   # Claude Code / Cursor / Windsurf keep the directory
 ```
 
-For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install.
+For **GitHub Copilot**, agents must be flat files — use the CLI with `--target copilot`, or run `npx github:arozumenko/sdlc-skills init fix-copilot` to convert an existing install. For **Codex**, agents install as `.codex/agents/<name>.toml` — use the CLI with `--target codex` (a plain `cp` won’t work).
 
 ## Skills this agent uses
 

--- a/bin/gen-marketplaces.mjs
+++ b/bin/gen-marketplaces.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * Generate per-runtime plugin marketplace manifests from the catalog so they
+ * never drift from the agents/, skills/, and skills.json sources.
+ *
+ * Each marketplace lists an umbrella "full toolkit" entry plus individual
+ * agent/skill entries, filtered by what that runtime's plugin system can ship:
+ *
+ *   Cursor  -> agents (dir-structured, kept as-is) + skills + hooks
+ *   Codex   -> skills + hooks            (no documented plugin `agents` field)
+ *   Copilot -> skills + hooks            (plugin agents must be flat .agent.md;
+ *                                         our agents install via the npx CLI)
+ *
+ * Claude Code's .claude-plugin/marketplace.json is hand-curated and left alone.
+ *
+ *   node bin/gen-marketplaces.mjs            # write the files
+ *   node bin/gen-marketplaces.mjs --check    # fail if any file is stale (CI)
+ */
+
+import { existsSync, readFileSync, readdirSync, writeFileSync, statSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const VERSION = JSON.parse(readFileSync(join(PKG_ROOT, "package.json"), "utf8")).version || "0.0.0";
+const OWNER = { name: "Artem Rozumenko", url: "https://github.com/arozumenko" };
+
+const UMBRELLA = {
+  name: "sdlc-skills",
+  source: "./",
+  description:
+    "Full SDLC toolkit — role-based agents, workflow skills, and session/subagent hooks (per-role memory + lean .agents/*.md project-context injection).",
+  version: VERSION,
+};
+
+const RUNTIMES = [
+  { id: "cursor", out: ".cursor-plugin/marketplace.json", agents: true, skills: true },
+  { id: "codex", out: ".codex-plugin/marketplace.json", agents: false, skills: true },
+  { id: "copilot", out: ".github/plugin/marketplace.json", agents: false, skills: true },
+];
+
+function listDirs(parent) {
+  const root = join(PKG_ROOT, parent);
+  if (!existsSync(root)) return [];
+  return readdirSync(root)
+    .filter((n) => !n.startsWith(".") && n !== "README.md")
+    .filter((n) => {
+      try {
+        return statSync(join(root, n)).isDirectory();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+function frontmatterField(file, field) {
+  if (!existsSync(file)) return null;
+  const fm = readFileSync(file, "utf8").match(/^---\s*\n([\s\S]*?)\n---/m);
+  if (!fm) return null;
+  const m = fm[1].match(new RegExp(`^${field}:\\s*(.+)$`, "m"));
+  return m ? m[1].trim().replace(/^["']|["']$/g, "") : null;
+}
+
+function skillDescriptions() {
+  const out = {};
+  const reg = join(PKG_ROOT, "skills.json");
+  if (existsSync(reg)) {
+    try {
+      for (const s of JSON.parse(readFileSync(reg, "utf8")).skills || [])
+        if (s.id && s.description) out[s.id] = s.description;
+    } catch {
+      /* ignore */
+    }
+  }
+  return out;
+}
+
+function buildPlugins(rt, agents, skills, skillDescs) {
+  const plugins = [UMBRELLA];
+  if (rt.agents) {
+    for (const a of agents) {
+      plugins.push({
+        name: a,
+        source: `./agents/${a}`,
+        description: frontmatterField(join(PKG_ROOT, "agents", a, "AGENT.md"), "description") || `${a} agent`,
+        version: VERSION,
+      });
+    }
+  }
+  if (rt.skills) {
+    for (const s of skills) {
+      plugins.push({
+        name: s,
+        source: `./skills/${s}`,
+        description:
+          skillDescs[s] || frontmatterField(join(PKG_ROOT, "skills", s, "SKILL.md"), "description") || `${s} skill`,
+        version: VERSION,
+      });
+    }
+  }
+  return plugins;
+}
+
+function main() {
+  const check = process.argv.includes("--check");
+  const agents = listDirs("agents");
+  const skills = listDirs("skills");
+  const skillDescs = skillDescriptions();
+
+  let stale = 0;
+  for (const rt of RUNTIMES) {
+    const manifest = { name: "sdlc-skills", owner: OWNER, plugins: buildPlugins(rt, agents, skills, skillDescs) };
+    const text = JSON.stringify(manifest, null, 2) + "\n";
+    const path = join(PKG_ROOT, rt.out);
+    const current = existsSync(path) ? readFileSync(path, "utf8") : null;
+    if (current === text) {
+      console.log(`  = ${rt.out} (${manifest.plugins.length} entries, up to date)`);
+      continue;
+    }
+    if (check) {
+      console.error(`  ! ${rt.out} is stale — run: node bin/gen-marketplaces.mjs`);
+      stale++;
+      continue;
+    }
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, text);
+    console.log(`  ✓ ${rt.out} (${manifest.plugins.length} entries)`);
+  }
+  if (check && stale) process.exit(1);
+}
+
+main();

--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -36,6 +36,11 @@
  *
  * This installer only covers modes 1 and 2. The plugin marketplace path
  * is handled natively by Claude Code and does not invoke this script.
+ *
+ * Every CLI install also wires the core hooks/ scripts (per-role memory +
+ * lean .agents/*.md project-context injection) into each target's native hook
+ * config — Claude .claude/settings.json, Cursor .cursor/hooks.json, Copilot
+ * .github/hooks/sdlc-skills.json. See installCoreHooks() and hooks/README.md.
  */
 
 import {
@@ -425,6 +430,145 @@ function mergeClaudeSettingsHooks(settingsPath, hookSpec, bundleId) {
   mkdirSync(dirname(settingsPath), { recursive: true });
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n");
   return true;
+}
+
+// ---------------------------------------------------------------------------
+// Core hooks — the repo-root hooks/ scripts that inject per-role memory and the
+// lean .agents/*.md project context at session/subagent start (these replaced
+// the old @-imports; see hooks/README.md). Installed on every CLI install, per
+// target, in each runtime's native hook format:
+//   Claude Code -> .claude/settings.json          (SessionStart + SubagentStart)
+//   Cursor      -> .cursor/hooks.json             (sessionStart only — its
+//                  subagentStart is permission-only and can't inject context)
+//   Copilot CLI -> .github/hooks/sdlc-skills.json (sessionStart + subagentStart)
+//   Windsurf    -> skipped (no documented hook API)
+// The Claude *plugin* path needs none of this — it auto-discovers
+// hooks/hooks.json at the plugin root. Codex/Kiro aren't CLI targets; we point
+// at the shipped hooks/hooks-codex.json / hooks-kiro.json templates instead.
+// ---------------------------------------------------------------------------
+
+const CORE_HOOK_FILES = ["run-hook.cmd", "session-start", "agent-start", "lib.sh"];
+const CORE_HOOK_EXE = ["run-hook.cmd", "session-start", "agent-start"];
+
+// Copy the four hook files into destDir together (they reference each other by
+// SCRIPT_DIR-relative path, so they must live side by side) and mark the
+// executables +x.
+function copyHookScripts(destDir) {
+  const srcDir = join(PKG_ROOT, "hooks");
+  if (!existsSync(srcDir)) return false;
+  mkdirSync(destDir, { recursive: true });
+  for (const f of CORE_HOOK_FILES) {
+    const s = join(srcDir, f);
+    if (existsSync(s)) cpSync(s, join(destDir, f), { force: true });
+  }
+  for (const f of CORE_HOOK_EXE) {
+    try {
+      chmodSync(join(destDir, f), 0o755);
+    } catch {
+      /* best-effort (Windows) */
+    }
+  }
+  return true;
+}
+
+// Merge our entries into a version-1 hooks.json (Cursor / SDK shape),
+// replacing only the entries that reference our scripts dir (idempotent) and
+// leaving the user's other hooks intact. Backs up before writing.
+function mergeVersionedHooks(path, spec, markerSubstr) {
+  let cfg = { version: 1, hooks: {} };
+  if (existsSync(path)) {
+    const raw = readFileSync(path, "utf8");
+    try {
+      cfg = JSON.parse(raw);
+    } catch (err) {
+      console.log(`      ! ${basename(path)} parse failed; left untouched: ${err.message}`);
+      return false;
+    }
+    writeFileSync(path + ".bak", raw);
+    if (!cfg.hooks || typeof cfg.hooks !== "object") cfg.hooks = {};
+    if (!cfg.version) cfg.version = 1;
+  }
+  for (const [event, entries] of Object.entries(spec)) {
+    const existing = Array.isArray(cfg.hooks[event]) ? cfg.hooks[event] : [];
+    const kept = existing.filter(
+      (e) => !(e && typeof e.command === "string" && e.command.includes(markerSubstr))
+    );
+    cfg.hooks[event] = [...kept, ...entries];
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");
+  return true;
+}
+
+function installCoreHooks(targets) {
+  const srcDir = join(PKG_ROOT, "hooks");
+  if (!existsSync(srcDir)) return;
+
+  for (const t of targets) {
+    if (t.id === "claude") {
+      const rel = ".claude/hooks/sdlc-skills";
+      copyHookScripts(join(CWD, rel));
+      const cmd = `"\${CLAUDE_PROJECT_DIR}/${rel}/run-hook.cmd"`;
+      const spec = {
+        SessionStart: [
+          {
+            matcher: "startup|clear|compact|resume",
+            hooks: [{ type: "command", command: `${cmd} session-start`, async: false }],
+          },
+        ],
+        SubagentStart: [
+          {
+            matcher: "*",
+            hooks: [{ type: "command", command: `${cmd} agent-start`, async: false }],
+          },
+        ],
+      };
+      if (mergeClaudeSettingsHooks(join(CWD, ".claude", "settings.json"), spec, "sdlc-core"))
+        console.log(`      ✓ hooks Claude Code (.claude/settings.json)`);
+    } else if (t.id === "cursor") {
+      const rel = ".cursor/hooks/sdlc-skills";
+      copyHookScripts(join(CWD, rel));
+      // Cursor's subagentStart is permission-only (no context injection) — wire
+      // sessionStart only; per-role memory falls back to the `memory` skill.
+      const spec = { sessionStart: [{ command: `./${rel}/run-hook.cmd session-start` }] };
+      if (mergeVersionedHooks(join(CWD, ".cursor", "hooks.json"), spec, rel))
+        console.log(`      ✓ hooks Cursor (.cursor/hooks.json)`);
+    } else if (t.id === "copilot") {
+      const rel = ".github/hooks/sdlc-skills";
+      copyHookScripts(join(CWD, rel));
+      const entry = (verb) => ({
+        type: "command",
+        bash: `"./${rel}/run-hook.cmd" ${verb}`,
+        powershell: `& "./${rel}/run-hook.cmd" ${verb}`,
+        env: { COPILOT_CLI: "1" },
+        timeoutSec: 10,
+      });
+      // .github/hooks/<name>.json is an sdlc-owned file — write it wholesale.
+      const spec = {
+        version: 1,
+        hooks: {
+          sessionStart: [entry("session-start")],
+          subagentStart: [entry("agent-start")],
+        },
+      };
+      mkdirSync(join(CWD, ".github", "hooks"), { recursive: true });
+      writeFileSync(
+        join(CWD, ".github", "hooks", "sdlc-skills.json"),
+        JSON.stringify(spec, null, 2) + "\n"
+      );
+      console.log(`      ✓ hooks GitHub Copilot (.github/hooks/sdlc-skills.json)`);
+    } else if (t.id === "windsurf") {
+      console.log(`      — hooks Windsurf (no documented hook API; skipped)`);
+    }
+  }
+
+  // Codex / Kiro aren't CLI install targets, but flag them when their config
+  // dir is present so the user knows how to finish wiring.
+  if (existsSync(join(CWD, ".codex"))) {
+    console.log(
+      `      → Codex: copy hooks/hooks-codex.json → .codex/hooks.json and the hooks/ scripts beside it (see hooks/README.md)`
+    );
+  }
 }
 
 // Ensure .agents/memory/<role>/MEMORY.md carries an index line pointing at
@@ -1440,6 +1584,13 @@ async function main() {
         console.log(`      ! skill  ${entry.id} (external fetch failed)`);
       }
     }
+  }
+
+  // Core hooks (per-role memory + lean .agents/*.md context injection) land in
+  // each selected runtime's native hook format. Every install, not just bundles.
+  if (existsSync(join(PKG_ROOT, "hooks"))) {
+    console.log(`\n  → hooks (memory + project-context injection)`);
+    installCoreHooks(targets);
   }
 
   // Briefing overlays land once in .agents/ (IDE-neutral), not per target.

--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -8,8 +8,10 @@
  *        /plugin marketplace add arozumenko/sdlc-skills
  *        /plugin install sdlc-skills@sdlc-skills
  *
- *   2. This CLI (works for Claude Code, Cursor, Windsurf, GitHub Copilot —
- *      copies agents and skills directly into the IDE dirs):
+ *   2. This CLI (works for Claude Code, Cursor, Windsurf, GitHub Copilot,
+ *      Codex — installs agents and skills in each host's native form:
+ *      directories (Claude/Cursor/Windsurf), flat .agent.md (Copilot), or
+ *      .codex/agents/<name>.toml (Codex)):
  *        npx github:arozumenko/sdlc-skills init
  *        npx github:arozumenko/sdlc-skills init --all
  *        npx github:arozumenko/sdlc-skills init --agents ba,tech-lead,pm
@@ -72,7 +74,17 @@ const TARGETS = [
   { id: "cursor", dir: ".cursor", label: "Cursor" },
   { id: "windsurf", dir: ".windsurf", label: "Windsurf" },
   { id: "copilot", dir: ".github", label: "GitHub Copilot" },
+  { id: "codex", dir: ".codex", label: "Codex" },
 ];
+
+// Claude Code / agentskills.io short-form model aliases → Anthropic's canonical
+// dashed model IDs. Hosts that need a concrete provider id (Copilot CLI, Codex)
+// can't resolve a bare `sonnet`. Keep in lockstep with the current model family.
+const MODEL_ALIASES = {
+  sonnet: "claude-sonnet-4-6",
+  opus: "claude-opus-4-7",
+  haiku: "claude-haiku-4-5",
+};
 
 // ---------------------------------------------------------------------------
 // Catalog discovery — read the agents/ and skills/ dirs at the repo root so
@@ -557,17 +569,30 @@ function installCoreHooks(targets) {
         JSON.stringify(spec, null, 2) + "\n"
       );
       console.log(`      ✓ hooks GitHub Copilot (.github/hooks/sdlc-skills.json)`);
+    } else if (t.id === "codex") {
+      const rel = ".codex/hooks/sdlc-skills";
+      copyHookScripts(join(CWD, rel));
+      // Codex uses Claude's nested SessionStart/SubagentStart shape. For a CLI
+      // (non-plugin) project install PLUGIN_ROOT isn't set, so the command sets
+      // CODEX_HOOK=1 to select the hookSpecificOutput emit shape. (Unix sh form;
+      // Codex hooks run via shell.)
+      const cmd = `CODEX_HOOK=1 "./${rel}/run-hook.cmd"`;
+      const spec = {
+        SessionStart: [
+          {
+            matcher: "startup|clear|compact|resume",
+            hooks: [{ type: "command", command: `${cmd} session-start` }],
+          },
+        ],
+        SubagentStart: [
+          { matcher: "*", hooks: [{ type: "command", command: `${cmd} agent-start` }] },
+        ],
+      };
+      if (mergeClaudeSettingsHooks(join(CWD, ".codex", "hooks.json"), spec, "sdlc-core"))
+        console.log(`      ✓ hooks Codex (.codex/hooks.json)`);
     } else if (t.id === "windsurf") {
       console.log(`      — hooks Windsurf (no documented hook API; skipped)`);
     }
-  }
-
-  // Codex / Kiro aren't CLI install targets, but flag them when their config
-  // dir is present so the user knows how to finish wiring.
-  if (existsSync(join(CWD, ".codex"))) {
-    console.log(
-      `      → Codex: copy hooks/hooks-codex.json → .codex/hooks.json and the hooks/ scripts beside it (see hooks/README.md)`
-    );
   }
 }
 
@@ -845,6 +870,11 @@ function copyItem(kind, name, target, update, registry, srcRoot = PKG_ROOT) {
     return flattenAgentForCopilot(src, name, target.dir, update, registry);
   }
 
+  // Codex custom agents are TOML files under .codex/agents/, not directories.
+  if (kind === "agents" && target.id === "codex") {
+    return writeCodexAgent(src, name, target.dir, update);
+  }
+
   const dest = join(CWD, target.dir, kind, name);
   if (existsSync(dest) && !update) return { status: "exists", dest };
   mkdirSync(dirname(dest), { recursive: true });
@@ -1074,20 +1104,11 @@ function transformAgentForCopilot(
   }
 
   if (normalizeModel) {
-    // Map agentskills.io / Claude Code's short-form model aliases to
-    // Anthropic's canonical model IDs (dashed form, matching the SDK).
-    // Copilot CLI requires a concrete ID — shipping `model: sonnet`
-    // leaves Copilot unable to resolve a provider. Keep this map in
-    // lockstep with the current Claude model family; one-line edit on
-    // a family bump.
-    const COPILOT_MODEL_MAP = {
-      sonnet: "claude-sonnet-4-6",
-      opus: "claude-opus-4-7",
-      haiku: "claude-haiku-4-5",
-    };
+    // Copilot CLI requires a concrete provider id — shipping `model: sonnet`
+    // leaves it unable to resolve. Map to the canonical dashed id (MODEL_ALIASES).
     agent = agent.replace(
       /^model:\s*(sonnet|opus|haiku)\s*$/m,
-      (_, alias) => `model: ${COPILOT_MODEL_MAP[alias]}`,
+      (_, alias) => `model: ${MODEL_ALIASES[alias]}`,
     );
   }
 
@@ -1132,6 +1153,89 @@ function flattenAgentForCopilot(src, name, targetDir, update, registry) {
   return { status: "installed", dest };
 }
 
+// ---------------------------------------------------------------------------
+// Codex agent transform — Codex custom agents are TOML files under
+// .codex/agents/<name>.toml, NOT markdown (see
+// https://developers.openai.com/codex/subagents). Mirror the Copilot path: a
+// pure text→TOML function (reusable/testable) plus a writer. The AGENT.md body
+// (+ SOUL.md inlined as a persona) becomes `developer_instructions`; declared
+// monorepo skills become [[skills.config]] entries pointing at the SKILL.md
+// files installed under .codex/skills/.
+// ---------------------------------------------------------------------------
+
+function tomlBasicString(s) {
+  return (
+    '"' +
+    String(s)
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, "\\n")
+      .replace(/\t/g, "\\t") +
+    '"'
+  );
+}
+
+function tomlMultiline(s) {
+  // Literal triple-quote keeps markdown intact (no escaping). Fall back to a
+  // basic triple-quote with escaping only if the body itself contains '''.
+  const body = s.replace(/\r/g, "");
+  if (!body.includes("'''")) return "'''\n" + body + "\n'''";
+  return '"""\n' + body.replace(/\\/g, "\\\\").replace(/"""/g, '\\"\\"\\"') + '\n"""';
+}
+
+function transformAgentForCodex(agentText, soulText, name, { normalizeModel = true } = {}) {
+  const fm = agentText.match(/^---\s*\n([\s\S]*?)\n---\s*\n?/m);
+  const frontmatter = fm ? fm[1] : "";
+  let body = fm ? agentText.slice(fm.index + fm[0].length) : agentText;
+
+  const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+  const description = descMatch ? descMatch[1].trim().replace(/^["']|["']$/g, "") : `${name} agent`;
+  const modelMatch = frontmatter.match(/^model:\s*(.+)$/m);
+  let model = modelMatch ? modelMatch[1].trim() : null;
+  if (model && normalizeModel && MODEL_ALIASES[model]) model = MODEL_ALIASES[model];
+
+  // Inline SOUL.md as a persona section (Codex has no sibling-file mechanism),
+  // mirroring Copilot's inline soul mode; drop the now-stale "Read SOUL.md in
+  // this directory" pointer since there's no sibling file in a TOML agent.
+  if (soulText) {
+    const soulBody = soulText.replace(/^#\s+[^\n]*\n+/, "").trimStart();
+    body = body.replace(
+      /Read `SOUL\.md` in this directory for your personality, voice, and values\. That's who you are\.\s*/,
+      ""
+    );
+    body = body.replace(/\s+$/, "") + "\n\n---\n\n## Persona\n\n" + soulBody;
+  }
+
+  const lines = [`name = ${tomlBasicString(name)}`, `description = ${tomlBasicString(description)}`];
+  if (model) lines.push(`model = ${tomlBasicString(model)}`);
+  lines.push("", `developer_instructions = ${tomlMultiline(body.trim())}`);
+
+  const skills = parseSkillsFromFrontmatter(agentText).filter((id) =>
+    existsSync(join(PKG_ROOT, "skills", id))
+  );
+  for (const id of skills) {
+    lines.push("", "[[skills.config]]", `path = ${tomlBasicString(`.codex/skills/${id}/SKILL.md`)}`, "enabled = true");
+  }
+  return lines.join("\n") + "\n";
+}
+
+function writeCodexAgent(src, name, targetDir, update) {
+  const agentFile = join(src, "AGENT.md");
+  if (!existsSync(agentFile)) return { status: "missing" };
+  const dest = join(CWD, targetDir, "agents", `${name}.toml`);
+  if (existsSync(dest) && !update) return { status: "exists", dest };
+  const soulFile = join(src, "SOUL.md");
+  const toml = transformAgentForCodex(
+    readFileSync(agentFile, "utf8"),
+    existsSync(soulFile) ? readFileSync(soulFile, "utf8") : null,
+    name,
+    { normalizeModel: true }
+  );
+  mkdirSync(dirname(dest), { recursive: true });
+  writeFileSync(dest, toml);
+  return { status: "installed", dest };
+}
+
 function ask(rl, q) {
   return new Promise((resolve) => rl.question(q, resolve));
 }
@@ -1141,6 +1245,11 @@ async function interactivePick(catalog, args) {
   let targets;
   if (args.targets) {
     targets = TARGETS.filter((t) => args.targets.includes(t.id));
+    if (args.targets.includes("kiro")) {
+      console.log(
+        "  Note: Kiro isn't a CLI target — its hooks attach per custom-agent config;\n  see hooks/hooks-kiro.json and hooks/README.md to wire them."
+      );
+    }
     if (targets.length === 0) {
       console.error(`  ! No valid --target values: ${args.targets.join(", ")}`);
       process.exit(1);

--- a/bundles/test-automation/agents/test-automation-lead/AGENT.md
+++ b/bundles/test-automation/agents/test-automation-lead/AGENT.md
@@ -11,12 +11,6 @@ metadata:
   author: "Alexander Bychinkii (git: bermudas)"
 ---
 
-@.agents/memory/test-automation-lead/snapshot.md
-@.agents/profile.md
-@.agents/workflow.md
-@.agents/testing.md
-@.agents/team-comms.md
-
 # Test Automation Lead
 
 ## Identity
@@ -27,15 +21,15 @@ Read `SOUL.md` in this directory for your personality, voice, and values. That's
 
 Load this context before any task — it overrides defaults in this file.
 
-**1. Your memory.** The `@.agents/memory/test-automation-lead/snapshot.md` import above auto-loads your persistent memory in Claude Code — an auto-generated digest that inlines your memory index, the curated entry bodies (including `project_briefing.md`), and recent daily logs. For non-Claude IDEs, invoke the `memory` skill.
+**1. Your memory.** Your persistent memory — an auto-generated digest inlining your memory index, the curated entry bodies (including `project_briefing.md`), and recent daily logs — is prepended to your context at dispatch. If it's not there, invoke the `memory` skill.
 
-**2. Scout's project context** auto-imported above:
+**2. Project context** — these `.agents/*.md` digests are prepended to your context at dispatch (if absent, read them directly):
 - `.agents/profile.md` — project systems map (issue tracker, TMS, base branch, merge policy)
 - `.agents/workflow.md` — branch/PR conventions, EPIC pattern, sub-task filing rules
 - `.agents/testing.md` — framework, run commands, fixture/POM conventions, locator strategy
 - `.agents/team-comms.md` — host, dispatch syntax, installed roster
 
-A missing file resolves to a non-fatal `@`-import warning — that's fine. Proceed if at least one is present; consume what scout produced and treat the rest as "to-be-filled" gaps to flag in your status updates. **Pause and ask the operator to run scout only when NONE of these files exist** — that's the signal the project hasn't been seeded at all, and your dispatches would go out blind.
+A missing file is simply skipped — that's fine. Proceed if at least one is present; consume what scout produced and treat the rest as "to-be-filled" gaps to flag in your status updates. **Pause and ask the operator to run scout only when NONE of these files exist** — that's the signal the project hasn't been seeded at all, and your dispatches would go out blind.
 
 **3. The pipeline skill.** Your frontmatter preloads `test-automation-workflow` — it carries the IC-facing process (analyst six-phase loop, implementer six-phase loop, AFS quality bar, no-defect-masking rules, run-report template). You don't need to load it on demand; it's already in context.
 
@@ -186,7 +180,7 @@ Use these verbatim, substituting `{PLACEHOLDER}` fields.
 ```
 You are the **analyst slot** for {TMS_ID}.
 
-Project context (read at session start; auto-imported via @-blocks):
+Project context (injected at session start by the `session-start` hook):
 - .agents/profile.md — project systems, base URL, credentials matrix
 - .agents/workflow.md — branch/PR rules and EPIC pattern
 - .agents/testing.md — framework, run commands, locator strategy

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -112,13 +112,16 @@ Two install paths:
     user's other hooks (`subagentStart` is permission-only, so it's not wired).
   - **Copilot CLI** → writes `.github/hooks/sdlc-skills.json` (`sessionStart` +
     `subagentStart`, `COPILOT_CLI=1`).
+  - **Codex** → writes `.codex/hooks.json` (Claude-shaped SessionStart +
+    SubagentStart; the command sets `CODEX_HOOK=1` so the script emits the
+    `hookSpecificOutput` shape for a non-plugin project install). Codex agents
+    install as `.codex/agents/<name>.toml`; skills to `.codex/skills/`.
   - **Windsurf** → skipped (no documented hook API).
 
-**Codex / Kiro** aren't CLI install targets, so wire them manually: copy
-`hooks-codex.json` → `~/.codex/hooks.json` or `<repo>/.codex/hooks.json` with the
-scripts beside it (Codex exports `PLUGIN_ROOT`, which the script keys off — no env
-injection needed); paste the `hooks-kiro.json` snippet into each Kiro custom-agent
-config's `hooks` field.
+**Kiro** isn't a CLI install target — paste the `hooks-kiro.json` snippet into
+each Kiro custom-agent config's `hooks` field (its `agentSpawn` carries no agent
+name, so each agent passes its role explicitly). The plugin path for Codex uses
+`${PLUGIN_ROOT}` instead of `CODEX_HOOK`; see `hooks-codex.json`.
 
 ## Testing locally
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,137 @@
+# Hooks
+
+These hooks replace the per-agent `@.agents/...` imports that used to sit at the
+top of each `AGENT.md`. `@import` is a Claude Code `CLAUDE.md` feature — it is
+**not** processed in subagent definition files, and it does **not** exist in
+Cursor, Copilot CLI, Codex, or Kiro. It also does not survive `/clear` or context
+compaction, because inlined text is summarised away. Hooks fix both problems:
+they re-fire on `clear`/`compact`/`resume`, and they run on every runtime.
+
+## What gets injected
+
+| Content | Hook | Scope |
+|---|---|---|
+| `.agents/memory/<role>/snapshot.md` | `agent-start` | per agent, every dispatch |
+| Lean shared docs: `role-overrides.md`, `profile.md`, `workflow.md`, `testing.md`, `conventions.md`, `team-comms.md` | `session-start` (parent session) **and** `agent-start` (each subagent) | per session / per dispatch; re-injected on clear/compact |
+| Roster reminder → `memory` skill | `session-start` | only on Cursor & Kiro (no context-injecting per-agent hook) |
+
+A dispatched subagent gets a fresh context that does **not** inherit the parent's
+`SessionStart` injection, so `agent-start` delivers the shared docs to each
+subagent too. Big manuals (`AGENTS.md`, `docs/`, `.agents/architecture.md`) are
+deliberately **not** injected — they stay as on-demand reads in the agent prompts.
+
+A missing file is skipped — same no-op-on-missing behaviour the old `@import`
+relied on, so the hooks are safe on an unseeded project.
+
+## Files
+
+- `run-hook.cmd` — polyglot cmd/bash wrapper (Windows finds Git Bash; Unix execs
+  bash). Extensionless target names dodge Claude Code's Windows `.sh`
+  auto-detection. Borrowed from the superpowers project.
+- `session-start` — injects shared `.agents/*.md` context + (off Claude Code) the
+  roster reminder. Platform-detects the output shape.
+- `agent-start` — injects the spawning role's `snapshot.md`.
+- `lib.sh` — shared helpers: JSON escaping, jq-free field extraction, platform
+  detection, and the two `emit_*` formatters.
+- `hooks.json` — Claude Code config (auto-discovered at plugin root).
+- `hooks-codex.json`, `hooks-cursor.json`, `hooks-copilot.json`, `hooks-kiro.json`
+  — reference templates. The `npx … init` CLI generates the live per-target
+  configs from these (with project-relative paths); they're also the manual
+  wiring path for Codex/Kiro. See *Wiring* below. Cursor's `subagentStart` is
+  permission-only, so its config wires `sessionStart` only (per-agent memory
+  falls back to the roster reminder).
+
+## Portability matrix
+
+| Runtime | Per-agent memory | Shared project context | Survives clear/compact | Hook config location |
+|---|---|---|---|---|
+| **Claude Code** | ✅ `SubagentStart` (`agent_name`) → `agent-start` | ✅ `SessionStart` → `session-start` | ✅ (`startup\|clear\|compact\|resume`) | auto: `hooks/hooks.json` at plugin root |
+| **Codex** | ✅ `SubagentStart` (`agent_type`), same shape as CC | ✅ `SessionStart` | ✅ (`startup\|resume\|clear\|compact`) | `~/.codex/hooks.json` or `<repo>/.codex/hooks.json` |
+| **Copilot CLI** | ✅ `subagentStart` (`agentName`) → `agent-start` | ✅ `sessionStart` (v1.0.11+ honours `additionalContext`) | ✅ on resume | `.github/hooks/*.json` or `~/.copilot/hooks/` |
+| **Cursor** | ❌ `subagentStart` is permission-only (no context inject; generic `subagent_type`) → roster reminder + `memory` skill | ✅ `sessionStart` | ✅ (`sessionStart` re-fires; `preCompact` exists) | `.cursor/hooks.json` |
+| **Kiro** | ⚠️ `agentSpawn` carries no agent name → per-agent config passes the role explicitly | ✅ via `agentSpawn` (raw stdout) | n/a (per-spawn) | inside each custom-agent config `hooks` field |
+
+**Bottom line:** per-agent memory auto-load works on **Claude Code, Codex, and
+Copilot CLI** (all three have a context-injecting per-agent start hook that names
+the agent). **Cursor** has the event but it's permission-only, and **Kiro**'s
+lacks the agent name — both fall back to the session-start roster reminder + the
+`memory` skill. Shared project context and durability across `clear`/`compact`
+hold on every runtime — the thing `@import` never had.
+
+## Platform detection
+
+`session-start` chooses its output shape from environment variables (the same
+scheme superpowers uses), so one script serves every runtime:
+
+- `SDLC_HOOK_RAW=1` → plain text on stdout (Kiro `agentSpawn` appends stdout to context)
+- `CURSOR_PLUGIN_ROOT` set → `{ "additional_context": ... }`
+- `PLUGIN_ROOT` set or `CODEX_HOOK=1` → `{ "hookSpecificOutput": { "hookEventName": ..., "additionalContext": ... } }` (Codex; same shape as CC)
+- `CLAUDE_PLUGIN_ROOT` set and `COPILOT_CLI` unset → `{ "hookSpecificOutput": ... }` (Claude Code)
+- `COPILOT_CLI=1` → `{ "additionalContext": ... }` (SDK standard)
+
+`agent-start` emits the `SubagentStart`/`hookSpecificOutput` variant on Claude
+Code and Codex, the top-level `additionalContext` variant on Copilot CLI, and raw
+stdout when called directly with a role argument (the Kiro path).
+
+> **Note on `SubagentStart`:** Claude Code's payload schema is underdocumented
+> (see [anthropics/claude-code#19170](https://github.com/anthropics/claude-code/issues/19170)).
+> `agent-start` parses the agent name defensively, trying `agentName` (Copilot),
+> `agent_name` (CC proposed), `subagent_type` (Cursor), `agent_type` (Codex),
+> `agentType`, then `name`. If a runtime settles on a different field, add it to
+> that list in `agent-start`.
+
+## Wiring
+
+Two install paths:
+
+- **Plugin marketplace** (all four runtimes): each runtime's plugin manifest
+  points at its correctly-shaped hooks file, auto-loaded at the plugin root.
+  - Claude Code — auto-discovers `hooks/hooks.json` (no manifest entry needed);
+    `${CLAUDE_PLUGIN_ROOT}` in the commands.
+  - Codex — `.codex-plugin/plugin.json` `"hooks": "./hooks/hooks-codex.json"`;
+    `${PLUGIN_ROOT}` in the commands.
+  - Cursor — `.cursor-plugin/plugin.json` `"hooks": "./hooks/hooks-cursor.json"`;
+    plugin-root-relative `./hooks/…` commands.
+  - Copilot CLI — root `plugin.json` `"hooks": "./hooks/hooks-copilot.json"`;
+    plugin-root-relative `./hooks/…` commands.
+
+  The per-runtime `marketplace.json` files (`.cursor-plugin/`, `.codex-plugin/`,
+  `.github/plugin/`) are generated from the catalog by
+  `bin/gen-marketplaces.mjs` (`npm run gen:marketplaces`; `npm run validate`
+  fails if stale). They list an umbrella "full toolkit" entry plus individual
+  agent/skill entries — agents only where the runtime's plugins support them
+  (Claude, Cursor); Codex/Copilot ship skills + hooks, and their agents install
+  via the CLI below (Copilot needs flat `.agent.md` files).
+- **`npx … init` CLI** (`bin/init.mjs`): every install runs `installCoreHooks()`,
+  which copies the four scripts into `<target>/hooks/sdlc-skills/` and writes each
+  selected runtime's native config with project-relative paths:
+  - **Claude** → merges `SessionStart` + `SubagentStart` into
+    `.claude/settings.json` (tagged `_bundle: "sdlc-core"`, replaced in place on
+    re-run; uses `${CLAUDE_PROJECT_DIR}`).
+  - **Cursor** → merges `sessionStart` into `.cursor/hooks.json`, preserving the
+    user's other hooks (`subagentStart` is permission-only, so it's not wired).
+  - **Copilot CLI** → writes `.github/hooks/sdlc-skills.json` (`sessionStart` +
+    `subagentStart`, `COPILOT_CLI=1`).
+  - **Windsurf** → skipped (no documented hook API).
+
+**Codex / Kiro** aren't CLI install targets, so wire them manually: copy
+`hooks-codex.json` → `~/.codex/hooks.json` or `<repo>/.codex/hooks.json` with the
+scripts beside it (Codex exports `PLUGIN_ROOT`, which the script keys off — no env
+injection needed); paste the `hooks-kiro.json` snippet into each Kiro custom-agent
+config's `hooks` field.
+
+## Testing locally
+
+```sh
+TMP=$(mktemp -d); mkdir -p "$TMP/.agents/memory/project-manager"
+echo '## snapshot' > "$TMP/.agents/memory/project-manager/snapshot.md"
+echo '# overrides' > "$TMP/.agents/role-overrides.md"
+
+# Claude Code SessionStart
+CLAUDE_PLUGIN_ROOT=/x CLAUDE_PROJECT_DIR="$TMP" bash hooks/session-start
+# Claude Code SubagentStart
+CLAUDE_PLUGIN_ROOT=/x CLAUDE_PROJECT_DIR="$TMP" \
+  bash hooks/agent-start <<<'{"agent_name":"project-manager"}'
+# Cursor (note the roster reminder)
+CURSOR_PLUGIN_ROOT=/x CLAUDE_PROJECT_DIR="$TMP" bash hooks/session-start
+```

--- a/hooks/agent-start
+++ b/hooks/agent-start
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Per-agent start hook for sdlc-skills — injects, for the spawning role, its
+# persistent memory snapshot (.agents/memory/<role>/snapshot.md) PLUS the lean
+# shared project docs (role-overrides/profile/workflow/testing/team-comms).
+# A dispatched subagent gets a fresh context that does NOT inherit the parent's
+# SessionStart injection, so it needs the project docs delivered here too.
+# Replaces the per-agent `@.agents/...` imports, and re-runs on every dispatch so
+# the context survives compaction within a long session.
+#
+# Copilot CLI (subagentStart): agent name arrives on stdin as `agentName`.
+# Codex (SubagentStart): name on stdin as `agent_type`.
+# Claude Code (SubagentStart): name on stdin, field underdocumented (issue
+#   #19170 proposes `agent_name`); we try several.
+# Kiro (agentSpawn): provides no agent name, so a Kiro per-agent config calls
+#   this script with the role as $1 and SDLC_HOOK_RAW=1 to consume raw stdout.
+# (Cursor also has subagentStart, but it is permission-only — no context
+#  injection — so Cursor is served by the session-start roster reminder.)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+
+# Role from explicit arg (Kiro) or parsed from the SubagentStart payload (CC).
+agent="${1:-}"
+if [ -z "$agent" ]; then
+  payload="$(cat 2>/dev/null || true)"
+  for key in agentName agent_name subagent_type agent_type agentType name; do
+    agent="$(json_string_field "$payload" "$key")"
+    [ -n "$agent" ] && break
+  done
+fi
+[ -n "$agent" ] || exit 0
+
+context=""
+
+# Role memory snapshot (if present).
+snap="${PROJECT_DIR}/.agents/memory/${agent}/snapshot.md"
+if [ -f "$snap" ]; then
+  context="# Your persistent memory — .agents/memory/${agent}/snapshot.md"$'\n\n'"$(cat "$snap")"
+fi
+
+# Lean shared project docs, so the dispatched worker is self-sufficient.
+context="${context}$(collect_shared_context "${PROJECT_DIR}/.agents")"
+
+# Nothing to inject (unseeded project, no memory yet) — exit quietly.
+if [ -z "${context//[$'\n\t ']/}" ]; then
+  exit 0
+fi
+
+emit_subagent_context "$context"
+exit 0

--- a/hooks/hooks-codex.json
+++ b/hooks/hooks-codex.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "statusMessage": "Loading sdlc-skills project context"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${PLUGIN_ROOT}/hooks/run-hook.cmd\" agent-start",
+            "statusMessage": "Loading role memory"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/hooks-copilot.json
+++ b/hooks/hooks-copilot.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "\"./hooks/run-hook.cmd\" session-start",
+        "powershell": "& \"./hooks/run-hook.cmd\" session-start",
+        "env": { "COPILOT_CLI": "1" },
+        "timeoutSec": 10
+      }
+    ],
+    "subagentStart": [
+      {
+        "type": "command",
+        "bash": "\"./hooks/run-hook.cmd\" agent-start",
+        "powershell": "& \"./hooks/run-hook.cmd\" agent-start",
+        "env": { "COPILOT_CLI": "1" },
+        "timeoutSec": 10
+      }
+    ]
+  }
+}

--- a/hooks/hooks-cursor.json
+++ b/hooks/hooks-cursor.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "./hooks/run-hook.cmd session-start"
+      }
+    ]
+  }
+}

--- a/hooks/hooks-kiro.json
+++ b/hooks/hooks-kiro.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Kiro defines hooks inside each custom-agent config file (see kiro.dev/docs/cli/custom-agents/configuration-reference#hooks-field), not a standalone hooks.json. This file is an illustrative snippet to paste into a Kiro agent config's `hooks` field. Kiro's agentSpawn event carries NO agent name, so each agent passes its own role explicitly and consumes raw stdout (SDLC_HOOK_RAW=1).",
+  "hooks": {
+    "agentSpawn": [
+      {
+        "command": "\"$SDLC_SKILLS_ROOT/hooks/run-hook.cmd\" agent-start project-manager",
+        "env": { "SDLC_HOOK_RAW": "1" }
+      },
+      {
+        "command": "\"$SDLC_SKILLS_ROOT/hooks/run-hook.cmd\" session-start",
+        "env": { "SDLC_HOOK_RAW": "1" }
+      }
+    ]
+  }
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "async": false
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" agent-start",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/lib.sh
+++ b/hooks/lib.sh
@@ -1,0 +1,99 @@
+# Shared helpers for sdlc-skills hooks. Sourced by session-start / agent-start.
+# No shebang and no `set` here — this file is sourced, not executed.
+
+# Escape a string for embedding inside a JSON string literal. Each
+# substitution is a single C-level pass — fast, and avoids a per-char loop.
+# Same approach as superpowers' session-start hook.
+escape_for_json() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+# Extract a top-level JSON string field without requiring jq (which we can't
+# assume is installed). Usage: json_string_field "$json" "agent_name"
+json_string_field() {
+  local json="$1" key="$2"
+  printf '%s' "$json" \
+    | sed -n "s/.*\"${key}\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" \
+    | head -n1
+}
+
+# Concatenate the lean shared project docs (scout outputs + role overrides) that
+# exist under $1 (an .agents dir), each under a markdown header. Echoes the
+# combined string (empty if none). This is the per-dispatch "must-read" project
+# context — kept lean on purpose; the full AGENTS.md manual is NOT injected, it
+# stays an on-demand reference.
+collect_shared_context() {
+  local agents_dir="$1" out="" name f
+  for name in role-overrides profile workflow testing conventions team-comms; do
+    f="${agents_dir}/${name}.md"
+    if [ -f "$f" ]; then
+      out="${out}"$'\n\n'"# .agents/${name}.md"$'\n\n'"$(cat "$f")"
+    fi
+  done
+  printf '%s' "$out"
+}
+
+# True only under plain Claude Code. Mirrors the branching in the emit_* helpers.
+is_claude_code() {
+  [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ] && [ -z "${CURSOR_PLUGIN_ROOT:-}" ]
+}
+
+# True under Codex, which exports PLUGIN_ROOT (a Codex-specific extension) and
+# uses the same hookSpecificOutput shape as Claude Code. CODEX_HOOK is an
+# optional explicit override for installers that prefer to set it.
+is_codex() {
+  [ -n "${CODEX_HOOK:-}" ] || [ -n "${PLUGIN_ROOT:-}" ]
+}
+
+# True on runtimes whose per-agent start hook can BOTH name the agent AND
+# inject context: Claude Code (SubagentStart), Codex (SubagentStart), Copilot
+# CLI (subagentStart). These load per-role memory via agent-start, so
+# session-start skips the roster reminder for them.
+#
+# Cursor is deliberately excluded: it has subagentStart, but that event is
+# permission-only (allow/deny) — it cannot return additionalContext — and its
+# identifier is a generic type (generalPurpose/explore/shell), not our role
+# names. So Cursor falls back to the sessionStart roster reminder.
+has_subagent_hook() {
+  is_claude_code || [ -n "${COPILOT_CLI:-}" ] || is_codex
+}
+
+# Emit session-level context in the shape the current runtime consumes.
+#   Cursor            -> additional_context (top-level, snake_case)
+#   Claude Code/Codex -> hookSpecificOutput.additionalContext (SessionStart)
+#   Copilot / SDK     -> additionalContext (top-level)
+#   Kiro / raw        -> plain text on stdout (agentSpawn appends stdout)
+# Set SDLC_HOOK_RAW=1 (Kiro) for raw; CODEX_HOOK=1 selects the Codex shape.
+emit_session_context() {
+  if [ -n "${SDLC_HOOK_RAW:-}" ]; then printf '%s\n' "$1"; return; fi
+  local ctx; ctx="$(escape_for_json "$1")"
+  if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
+    printf '{\n  "additional_context": "%s"\n}\n' "$ctx"
+  elif is_codex || { [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; }; then
+    printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$ctx"
+  else
+    printf '{\n  "additionalContext": "%s"\n}\n' "$ctx"
+  fi
+}
+
+# Emit per-agent start context in the shape the current runtime consumes.
+#   Copilot CLI       -> additionalContext (top-level; subagentStart prepends it)
+#   Claude Code/Codex -> hookSpecificOutput.additionalContext (SubagentStart)
+#   Kiro / raw        -> plain stdout (a per-agent config calls agent-start direct)
+emit_subagent_context() {
+  if [ -n "${SDLC_HOOK_RAW:-}" ]; then printf '%s\n' "$1"; return; fi
+  local ctx; ctx="$(escape_for_json "$1")"
+  if [ -n "${COPILOT_CLI:-}" ]; then
+    printf '{\n  "additionalContext": "%s"\n}\n' "$ctx"
+  elif is_codex || is_claude_code; then
+    printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SubagentStart",\n    "additionalContext": "%s"\n  }\n}\n' "$ctx"
+  else
+    printf '%s\n' "$1"
+  fi
+}

--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -1,0 +1,46 @@
+: << 'CMDBLOCK'
+@echo off
+REM Cross-platform polyglot wrapper for hook scripts.
+REM On Windows: cmd.exe runs the batch portion, which finds and calls bash.
+REM On Unix: the shell interprets this as a script (: is a no-op in bash).
+REM
+REM Hook scripts use extensionless filenames (e.g. "session-start" not
+REM "session-start.sh") so Claude Code's Windows auto-detection -- which
+REM prepends "bash" to any command containing .sh -- doesn't interfere.
+REM
+REM Usage: run-hook.cmd <script-name> [args...]
+
+if "%~1"=="" (
+    echo run-hook.cmd: missing script name >&2
+    exit /b 1
+)
+
+set "HOOK_DIR=%~dp0"
+
+REM Try Git for Windows bash in standard locations
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin)
+where bash >nul 2>nul
+if %ERRORLEVEL% equ 0 (
+    bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM No bash found - exit silently rather than error
+REM (plugin still works, just without hook context injection)
+exit /b 0
+CMDBLOCK
+
+# Unix: run the named script directly
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$1"
+shift
+exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"

--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -16,21 +16,34 @@ if "%~1"=="" (
 )
 
 set "HOOK_DIR=%~dp0"
+set "SCRIPT=%~1"
+
+REM Collect every remaining arg (no 8-arg %2..%9 cap), each re-quoted so
+REM values with spaces survive. %* ignores shift in cmd, so build the list
+REM by hand. (Note: SHIFT must come after capturing %~1 above.)
+shift
+set "ARGS="
+:collect_args
+if "%~1"=="" goto args_done
+set "ARGS=%ARGS% "%~1""
+shift
+goto collect_args
+:args_done
 
 REM Try Git for Windows bash in standard locations
 if exist "C:\Program Files\Git\bin\bash.exe" (
-    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%SCRIPT%" %ARGS%
     exit /b %ERRORLEVEL%
 )
 if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
-    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%SCRIPT%" %ARGS%
     exit /b %ERRORLEVEL%
 )
 
 REM Try bash on PATH (e.g. user-installed Git Bash, MSYS2, Cygwin)
 where bash >nul 2>nul
 if %ERRORLEVEL% equ 0 (
-    bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    bash "%HOOK_DIR%%SCRIPT%" %ARGS%
     exit /b %ERRORLEVEL%
 )
 

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SessionStart hook for sdlc-skills.
+#
+# Injects shared, project-scoped context (the .agents/*.md files scout
+# produces, plus role overrides) that used to be @-imported per agent. On
+# runtimes without a per-agent start hook it also injects a roster reminder so
+# each role knows to pull its own memory via the `memory` skill.
+#
+# Fires on startup|clear|compact|resume, so the context is re-injected after a
+# /clear or a compaction — which a static @import cannot survive.
+#
+# Uses printf (not heredocs) to dodge the bash 5.3+ heredoc hang.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+AGENTS_DIR="${PROJECT_DIR}/.agents"
+
+# Shared project context for the parent/orchestrator session. A missing file is
+# skipped — same no-op-on-missing behaviour the old @import relied on. (Dispatched
+# subagents get their own copy via agent-start, since SessionStart context does
+# not propagate into a subagent's fresh context.)
+context="$(collect_shared_context "$AGENTS_DIR")"
+
+# Per-role memory: runtimes whose per-agent start hook can inject context
+# (Claude Code, Codex, Copilot CLI) load it per dispatch via agent-start, so
+# they do NOT need the reminder. Cursor (subagentStart is permission-only) and
+# Kiro (agentSpawn carries no agent name) get a roster pointing at the memory
+# skill instead.
+if ! has_subagent_hook; then
+  roster=""
+  if [ -d "${AGENTS_DIR}/memory" ]; then
+    for d in "${AGENTS_DIR}/memory"/*/; do
+      [ -d "$d" ] || continue
+      roster="${roster}$(basename "$d"), "
+    done
+  fi
+  roster="${roster%, }"
+  [ -n "$roster" ] || roster="ba, tech-lead, project-manager, python-dev, js-dev, ios-dev, qa-engineer, test-automation-engineer, personal-assistant, scout"
+  context="${context}"$'\n\n'"<role-memory-reminder>
+Each role in this project has persistent memory at .agents/memory/<role>/snapshot.md.
+When you act as one of these roles, invoke the \`memory\` skill to load your snapshot before starting work.
+Roles: ${roster}.
+</role-memory-reminder>"
+fi
+
+# Nothing to inject (unseeded project on Claude Code) — exit quietly.
+if [ -z "${context//[$'\n\t ']/}" ]; then
+  exit 0
+fi
+
+emit_session_context "$context"
+exit 0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc-skills",
   "version": "0.2.0",
-  "description": "SDLC agents and skills for Claude Code, Cursor, Windsurf, and GitHub Copilot. Installable via Claude plugin marketplace or npx for direct install into .claude/agents.",
+  "description": "SDLC agents and skills for Claude Code, Cursor, Windsurf, GitHub Copilot, and Codex. Installable via plugin marketplace or npx (per-host native agent format: dirs, flat .agent.md, or Codex TOML).",
   "type": "module",
   "bin": {
     "init": "./bin/init.mjs"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "scripts": {
     "validate:bundles": "node bin/validate-bundles.mjs",
-    "validate": "npm run validate:bundles"
+    "validate:marketplaces": "node bin/gen-marketplaces.mjs --check",
+    "validate": "npm run validate:bundles && npm run validate:marketplaces",
+    "gen:marketplaces": "node bin/gen-marketplaces.mjs"
   },
   "repository": {
     "type": "git",

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "sdlc-skills",
+  "version": "0.2.0",
+  "description": "Workflow skills and session/subagent hooks (per-role memory + lean .agents/*.md project-context injection) for software delivery. Agents install via the npx CLI (Copilot needs flat .agent.md files).",
+  "author": {
+    "name": "Artem Rozumenko",
+    "email": "artyom.rozumenko@gmail.com"
+  },
+  "homepage": "https://github.com/arozumenko/sdlc-skills",
+  "repository": "https://github.com/arozumenko/sdlc-skills",
+  "license": "MIT",
+  "keywords": ["sdlc", "skills", "hooks", "memory"],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks-copilot.json"
+}


### PR DESCRIPTION
## Summary

Replaces the per-agent `@.agents/…` imports — which were Claude Code-only and wiped by `/clear` and compaction — with **lifecycle hooks** that inject per-role memory and lean `.agents/*.md` project context, re-firing on `startup|clear|compact|resume`. Extends agent/skill/hook distribution across **Claude Code, Cursor, Windsurf, Copilot CLI, and Codex** via both plugin marketplaces and the `npx … init` CLI.

## What's in it

**`hooks/`** — `session-start` (shared project context + roster reminder where no per-agent hook), `agent-start` (per-role memory snapshot + lean docs, since a dispatched subagent gets a fresh context), `lib.sh` (jq-free parse, platform detection, per-runtime emitters), polyglot `run-hook.cmd`, and per-runtime config templates. Per-agent memory auto-loads on Claude Code / Codex / Copilot CLI (context-injecting per-agent start hooks); Cursor (permission-only `subagentStart`) and Kiro (no agent name) fall back to the `memory` skill.

**Agent prompts** — dropped the `@import` lines; each "Session Start" section rewritten from a read-checklist into durable knowledge + a runtime-agnostic fallback + on-demand pointers for the big manuals (`AGENTS.md`, `docs/`). Prompts no longer narrate what's already injected.

**Installer (`bin/init.mjs`)** — `installCoreHooks()` writes each target's native hook config on every install (Claude `settings.json`, Cursor `hooks.json`, Copilot `.github/hooks/`, Codex `.codex/hooks.json`; Windsurf skipped), idempotent and preserving the user's own hooks. New **Codex target**: `transformAgentForCodex()` generates `.codex/agents/<name>.toml` (`developer_instructions` = body + inlined persona, normalized model, `[[skills.config]]`) — mirroring the Copilot flatten transform.

**Plugin distribution** — `.codex-plugin/plugin.json`, root `plugin.json` (Copilot), `hooks` wired into `.cursor-plugin/plugin.json`, and `bin/gen-marketplaces.mjs` generates per-runtime `marketplace.json` (umbrella + individual entries; agents only where the host's plugins support them). `npm run validate` guards staleness.

**Docs** — README, init header, `hooks/README.md`, `package.json`, and all 10 per-agent READMEs updated for the five targets and per-host native agent forms (dirs / flat `.agent.md` / Codex TOML).

## Testing

79/79 install-matrix assertions across **claude / cursor / windsurf / copilot / codex** — agent format per host, hooks per target, idempotence (+ hook de-dup), selection logic (auto-detect / invalid / kiro pointer), bundle install, installed-hook emit shapes, and the generators/validators. Network-free by design.

## Needs real-host validation (flagged, non-blocking)

- Claude `SubagentStart` payload field name (#19170 — parsed defensively).
- Codex `skills.config` path form (relative vs absolute) and `developer_instructions` size.
- Granular marketplace `source` entries, Codex marketplace file location, Copilot plugin discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)