### PR TITLE
Add session-retrospective skill — assisted reinforcement from past sessions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -162,6 +162,12 @@
       "version": "0.2.0"
     },
     {
+      "name": "session-retrospective",
+      "source": "./skills/session-retrospective",
+      "description": "Distill past Claude Code sessions (main + sub-agent) into evidenced, ack-gated memory and workflow improvements (used by scout).",
+      "version": "0.2.0"
+    },
+    {
       "name": "completing-a-task",
       "source": "./skills/completing-a-task",
       "description": "Five-step task handoff protocol: commit → push → PR → comment → notify.",

--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -120,6 +120,12 @@
       "version": "0.2.0"
     },
     {
+      "name": "session-retrospective",
+      "source": "./skills/session-retrospective",
+      "description": "Distill past Claude Code sessions (main + sub-agent) into evidenced, ack-gated memory and workflow improvements (used by scout)",
+      "version": "0.2.0"
+    },
+    {
       "name": "test-automation-workflow",
       "source": "./skills/test-automation-workflow",
       "description": "End-to-end test automation workflow — explore, specify (AFS), implement, review. Pluggable TMS adapters (Zephyr Scale, TestRail, Xray, Azure Test Plans, markdown) over HTTP or MCP",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -180,6 +180,12 @@
       "version": "0.2.0"
     },
     {
+      "name": "session-retrospective",
+      "source": "./skills/session-retrospective",
+      "description": "Distill past Claude Code sessions (main + sub-agent) into evidenced, ack-gated memory and workflow improvements (used by scout)",
+      "version": "0.2.0"
+    },
+    {
       "name": "test-automation-workflow",
       "source": "./skills/test-automation-workflow",
       "description": "End-to-end test automation workflow — explore, specify (AFS), implement, review. Pluggable TMS adapters (Zephyr Scale, TestRail, Xray, Azure Test Plans, markdown) over HTTP or MCP",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -120,6 +120,12 @@
       "version": "0.2.0"
     },
     {
+      "name": "session-retrospective",
+      "source": "./skills/session-retrospective",
+      "description": "Distill past Claude Code sessions (main + sub-agent) into evidenced, ack-gated memory and workflow improvements (used by scout)",
+      "version": "0.2.0"
+    },
+    {
       "name": "test-automation-workflow",
       "source": "./skills/test-automation-workflow",
       "description": "End-to-end test automation workflow — explore, specify (AFS), implement, review. Pluggable TMS adapters (Zephyr Scale, TestRail, Xray, Azure Test Plans, markdown) over HTTP or MCP",

--- a/agents/scout/AGENT.md
+++ b/agents/scout/AGENT.md
@@ -7,7 +7,7 @@ group: core
 required: true
 theme: {color: colour252, icon: "🔍", short_name: scout}
 aliases: [kit]
-skills: [seeding-a-project, memory]
+skills: [seeding-a-project, memory, session-retrospective]
 metadata:
   author: "Artem Rozumenko (git: arozumenko)"
 ---

--- a/bundles/team-ios/README.md
+++ b/bundles/team-ios/README.md
@@ -15,6 +15,85 @@ Testing / Swift Concurrency skills via `ios-dev`), seeds per-role stack
 briefings into `.agents/memory/<role>/`, and splices the team conventions
 into `AGENTS.md` / `CLAUDE.md`.
 
+The team runs in **three phases**. You launch only two agents yourself —
+`scout`, then `project-manager`; the hooks and the orchestrator handle the
+rest.
+
+**Install (once)** — `npx github:arozumenko/sdlc-skills init --bundle team-ios`.
+Drops the agents into `.claude/`, pulls their skills (including the SwiftUI /
+SwiftData / Swift Testing / Swift Concurrency skills), wires the
+memory/context hooks, and splices `instructions.md` into `AGENTS.md`.
+
+**Phase 1 — Inception (`scout`, once per repo).** Launch scout: _"Use the
+scout agent to onboard this repo."_ It asks you what it can't infer, finds
+the workspace, dependency manager, build/test schemes, and release path
+(sampling PR history to learn how the team actually works), then generates
+the project config — `CLAUDE.md`, `AGENTS.md`, and the `.agents/` set
+(`profile.md`, `workflow.md`, `team-comms.md`, `conventions.md`,
+`testing.md`) plus a per-role briefing under `.agents/memory/<role>/`.
+**Why it's first:** every other agent boots from these files; without them
+the team has no shared context. Re-run after big structural changes.
+
+**Phase 2 — Usage (`project-manager` + the team).** Hand Max a feature or
+ticket: _"Use the project-manager agent to implement …"_. Max sequences the
+work and dispatches `ba` → `tech-lead` → `ios-dev` → `qa-engineer`, then
+owns the merge gate. **The logic:** each subagent starts in a *fresh*
+context, but at dispatch the `agent-start` hook injects the shared
+`.agents/*` docs **and** that role's own memory — so a subagent already
+knows the stack, concurrency model, and routing without you re-explaining.
+You talk only to Max.
+
+**Phase 3 — Reinforcement (assisted; owned by `scout`, not the PM).** Two
+moving parts, and only one is automatic:
+- **Replay is automatic.** The hooks re-inject each role's memory snapshot
+  and the shared `.agents/*` docs at every dispatch (survives `/clear`,
+  compaction, resume). This only replays what's already been written.
+- **Capture is assisted.** Agents jot durable facts to
+  `.agents/memory/<role>/` when they hit something worth keeping (or when
+  you say "remember this"), and you periodically **re-run `scout`** to
+  refresh the shared config and per-role briefings — scout re-reads the
+  **code, PR history, and (via the `session-retrospective` skill) past agent
+  sessions**, proposes the delta, and **waits for your ack**
+  before writing. The PM only routes work; scout owns the durable project
+  lens, so reinforcement is a scout job.
+
+**Note:** there is no automatic mining of past chat or sub-agent transcripts
+— refinement comes from re-running scout against the codebase and from
+agent-curated memory, not from replaying conversation logs.
+
+### How it flows
+
+```mermaid
+flowchart TD
+    install(["npx … init --bundle team-ios"]) --> scout
+
+    subgraph p1["Phase 1 — Inception · you launch scout (once per repo)"]
+        scout["scout (kit) — interview + explore,<br/>sample PR history"]
+        brief[/"project config:<br/>CLAUDE.md + AGENTS.md +<br/>.agents/ (profile, workflow, team-comms,<br/>conventions, per-role briefings)"/]
+        scout --> brief
+    end
+
+    subgraph p2["Phase 2 — Usage · you launch project-manager"]
+        pm["project-manager (max) —<br/>orchestrate + merge gate"]
+        ba["ba — requirements"]
+        tl["tech-lead — app architecture +<br/>concurrency model"]
+        ios["ios-dev — Swift / SwiftUI"]
+        qa["qa-engineer — simulator + XCUITest"]
+        pm --> ba --> tl --> ios --> qa
+    end
+
+    brief -->|"agents boot from this"| pm
+
+    subgraph p3["Phase 3 — Reinforcement · assisted (you re-run scout)"]
+        mem[(".agents/memory/&lt;role&gt;/<br/>briefings · curated entries · daily log")]
+    end
+
+    pm -. "jot learnings (assisted)" .-> mem
+    qa -. "jot learnings (assisted)" .-> mem
+    scout -. "re-run scout to refresh —<br/>proposes delta, waits for ack" .-> mem
+    mem == "auto-replayed at every dispatch<br/>(survives /clear · compact · resume)" ==> pm
+```
+
 ## Roster
 
 | Role | Alias | Group | Does |

--- a/bundles/team-ios/README.md
+++ b/bundles/team-ios/README.md
@@ -57,9 +57,10 @@ moving parts, and only one is automatic:
   before writing. The PM only routes work; scout owns the durable project
   lens, so reinforcement is a scout job.
 
-**Note:** there is no automatic mining of past chat or sub-agent transcripts
-— refinement comes from re-running scout against the codebase and from
-agent-curated memory, not from replaying conversation logs.
+**Note:** mining past sessions is **on-demand, not automatic** — it happens
+only when you run scout's `session-retrospective`, which proposes deltas you
+must ack. The automatic half of reinforcement is just the hooks replaying
+already-written `.agents/memory/` content at dispatch.
 
 ### How it flows
 

--- a/bundles/team-web/README.md
+++ b/bundles/team-web/README.md
@@ -15,6 +15,91 @@ each agent's skills, seeds per-role stack briefings into
 `.agents/memory/<role>/`, and splices the team conventions into
 `AGENTS.md` / `CLAUDE.md`.
 
+The team runs in **three phases**. You launch only two agents yourself —
+`scout`, then `project-manager`; the hooks and the orchestrator handle the
+rest.
+
+**Install (once)** — `npx github:arozumenko/sdlc-skills init --bundle team-web`.
+Drops the agents into `.claude/`, pulls their skills, wires the
+memory/context hooks, and splices `instructions.md` into `AGENTS.md`.
+
+**Phase 1 — Inception (`scout`, once per repo).** Launch scout: _"Use the
+scout agent to onboard this repo."_ It asks you what it can't infer,
+explores the codebase (sampling PR history to learn how the team actually
+works), then generates the project config — `CLAUDE.md`, `AGENTS.md`, and
+the `.agents/` set (`profile.md`, `workflow.md`, `team-comms.md`,
+`conventions.md`, `testing.md`) plus a per-role briefing under
+`.agents/memory/<role>/`. **Why it's first:** every other agent boots from
+these files; without them the team has no shared context. Re-run after big
+structural changes.
+
+**Phase 2 — Usage (`project-manager` + the team).** Hand Max a feature or
+ticket: _"Use the project-manager agent to implement …"_. Max sequences the
+work and dispatches `ba` → `tech-lead` → `python-dev` / `js-dev` →
+`qa-engineer` → `test-automation-engineer`, then owns the merge gate. **The
+logic:** each subagent starts in a *fresh* context, but at dispatch the
+`agent-start` hook injects the shared `.agents/*` docs **and** that role's
+own memory — so a subagent already knows the stack, conventions, and
+routing without you re-explaining. You talk only to Max.
+
+**Phase 3 — Reinforcement (assisted; owned by `scout`, not the PM).** Two
+moving parts, and only one is automatic:
+- **Replay is automatic.** The hooks re-inject each role's memory snapshot
+  and the shared `.agents/*` docs at every dispatch (survives `/clear`,
+  compaction, resume). This only replays what's already been written.
+- **Capture is assisted.** Agents jot durable facts to
+  `.agents/memory/<role>/` when they hit something worth keeping (or when
+  you say "remember this"), and you periodically **re-run `scout`** to
+  refresh the shared config and per-role briefings — scout re-reads the
+  **code, PR history, and (via the `session-retrospective` skill) past agent
+  sessions**, proposes the delta, and **waits for your ack**
+  before writing. The PM only routes work; scout owns the durable project
+  lens, so reinforcement is a scout job.
+
+**Note:** there is no automatic mining of past chat or sub-agent transcripts
+— refinement comes from re-running scout against the codebase and from
+agent-curated memory, not from replaying conversation logs.
+
+### How it flows
+
+```mermaid
+flowchart TD
+    install(["npx … init --bundle team-web"]) --> scout
+
+    subgraph p1["Phase 1 — Inception · you launch scout (once per repo)"]
+        scout["scout (kit) — interview + explore,<br/>sample PR history"]
+        brief[/"project config:<br/>CLAUDE.md + AGENTS.md +<br/>.agents/ (profile, workflow, team-comms,<br/>conventions, per-role briefings)"/]
+        scout --> brief
+    end
+
+    subgraph p2["Phase 2 — Usage · you launch project-manager"]
+        pm["project-manager (max) —<br/>orchestrate + merge gate"]
+        ba["ba — requirements"]
+        tl["tech-lead — architecture + API contract"]
+        py["python-dev — FastAPI / FastMCP backend"]
+        js["js-dev — JS/TS frontend"]
+        qa["qa-engineer — live test + AFS"]
+        tae["test-automation-engineer — Playwright e2e"]
+        pm --> ba --> tl
+        tl --> py
+        tl --> js
+        py --> qa
+        js --> qa
+        qa --> tae
+    end
+
+    brief -->|"agents boot from this"| pm
+
+    subgraph p3["Phase 3 — Reinforcement · assisted (you re-run scout)"]
+        mem[(".agents/memory/&lt;role&gt;/<br/>briefings · curated entries · daily log")]
+    end
+
+    pm -. "jot learnings (assisted)" .-> mem
+    tae -. "jot learnings (assisted)" .-> mem
+    scout -. "re-run scout to refresh —<br/>proposes delta, waits for ack" .-> mem
+    mem == "auto-replayed at every dispatch<br/>(survives /clear · compact · resume)" ==> pm
+```
+
 ## Roster
 
 | Role | Alias | Group | Does |

--- a/bundles/team-web/README.md
+++ b/bundles/team-web/README.md
@@ -56,9 +56,10 @@ moving parts, and only one is automatic:
   before writing. The PM only routes work; scout owns the durable project
   lens, so reinforcement is a scout job.
 
-**Note:** there is no automatic mining of past chat or sub-agent transcripts
-— refinement comes from re-running scout against the codebase and from
-agent-curated memory, not from replaying conversation logs.
+**Note:** mining past sessions is **on-demand, not automatic** — it happens
+only when you run scout's `session-retrospective`, which proposes deltas you
+must ack. The automatic half of reinforcement is just the hooks replaying
+already-written `.agents/memory/` content at dispatch.
 
 ### How it flows
 

--- a/bundles/test-automation/README.md
+++ b/bundles/test-automation/README.md
@@ -11,6 +11,91 @@ merge gate.
 npx github:arozumenko/sdlc-skills init --bundle test-automation
 ```
 
+The pipeline runs in **three phases**. You launch `scout` once, then drive
+**Tal** directly for every automation task; Tal dispatches the analyst →
+implementer → reviewer pipeline as subagents.
+
+**Install (once)** — `npx github:arozumenko/sdlc-skills init --bundle test-automation`.
+Drops the four agents into `.claude/`, pulls their skills (incl.
+`test-automation-workflow` + `test-case-analysis`), wires the memory/context
+hooks, and splices `instructions.md` into `AGENTS.md`.
+
+**Phase 1 — Inception (`scout`, once per repo).** Launch scout: _"Use the
+scout agent to onboard this repo."_ It asks you what it can't infer,
+explores the repo, then generates the project config — `AGENTS.md` plus the
+`.agents/` set, recording the test framework, TMS adapter, base branch,
+merge policy, and credential matrix into `profile.md` / `workflow.md`, and
+seeding a per-role briefing under `.agents/memory/<role>/`. **Why it's
+first:** if the project isn't seeded, Tal pauses and asks for a scout run
+before doing anything else — the whole pipeline reads this config.
+
+**Phase 2 — Usage (Tal runs the pipeline).** Drop a TMS case on Tal: _"Use
+the test-automation-lead agent to automate TC-1234."_ He routes it through
+the **analyst** (`qa-engineer` writes the AFS) → the
+**`ready-for-automation` gate** → the **implementer**
+(`test-automation-engineer` opens a PR + Run Report) → the **reviewer**
+(`qa-engineer`, fresh session), then merges, files follow-ups, back-writes
+the TMS, and reports to you. **The logic:** each subagent boots from a fresh
+context that the `agent-start` hook seeds with the shared `.agents/*` config
+and its own memory — so the analyst, implementer, and reviewer already know
+the framework, merge policy, and TMS adapter.
+
+**Phase 3 — Reinforcement (assisted; owned by `scout`, not Tal).** Two
+moving parts, and only one is automatic:
+- **Replay is automatic.** The hooks re-inject each role's memory snapshot
+  and the shared `.agents/*` config at every dispatch (survives `/clear`,
+  compaction, resume) — it only replays what's already written.
+- **Capture is assisted.** The pipeline agents jot durable facts (framework
+  quirks, recurring flake causes, review patterns) into
+  `.agents/memory/<role>/` when worth keeping, and you periodically **re-run
+  `scout`** to refresh the shared config + briefings — scout re-reads the
+  **code, PR history, and (via the `session-retrospective` skill) past agent
+  sessions**, proposes the delta, and **waits for your ack**.
+  Tal orchestrates the pipeline; scout owns the durable project lens, so the
+  refresh is a scout job.
+
+**Note:** there is no automatic mining of past chat or sub-agent transcripts
+— refinement comes from re-running scout against the codebase and from
+agent-curated memory, not from replaying conversation logs.
+
+### How it flows
+
+```mermaid
+flowchart TD
+    install(["npx … init --bundle test-automation"]) --> scout
+
+    subgraph p1["Phase 1 — Inception · you launch scout (once per repo)"]
+        scout["scout (kit) — interview + explore"]
+        seed[/"project config: AGENTS.md + .agents/<br/>(framework, TMS, base branch,<br/>merge policy, per-role briefings)"/]
+        scout --> seed
+    end
+
+    subgraph p2["Phase 2 — Usage · you launch Tal per case"]
+        tal["test-automation-lead (Tal)<br/>orchestrator — routes + merge gate"]
+        analyst["qa-engineer (analyst) — writes the AFS"]
+        gate{"AFS status =<br/>ready-for-automation?"}
+        impl["test-automation-engineer<br/>PR + Run Report"]
+        review["qa-engineer (reviewer, fresh)<br/>APPROVED / CHANGES_REQUESTED"]
+        merge(["Tal merges, back-writes TMS, reports"])
+        stop(["handled, never forwarded"])
+        tal --> analyst --> gate
+        gate -->|"yes"| impl --> review --> merge
+        gate -->|"blocked / defect / un-automatable"| stop
+    end
+
+    seed -->|"pipeline boots from this"| tal
+    case[/"a TMS case"/] --> tal
+
+    subgraph p3["Phase 3 — Reinforcement · assisted (you re-run scout)"]
+        mem[(".agents/memory/&lt;role&gt;/<br/>briefings · curated entries · daily log")]
+    end
+
+    tal -. "jot learnings (assisted)" .-> mem
+    review -. "jot learnings (assisted)" .-> mem
+    scout -. "re-run scout to refresh —<br/>proposes delta, waits for ack" .-> mem
+    mem == "auto-replayed at every dispatch<br/>(survives /clear · compact · resume)" ==> tal
+```
+
 ## Roster
 
 | Role | Agent | Source | Job |

--- a/bundles/test-automation/README.md
+++ b/bundles/test-automation/README.md
@@ -54,9 +54,10 @@ moving parts, and only one is automatic:
   Tal orchestrates the pipeline; scout owns the durable project lens, so the
   refresh is a scout job.
 
-**Note:** there is no automatic mining of past chat or sub-agent transcripts
-— refinement comes from re-running scout against the codebase and from
-agent-curated memory, not from replaying conversation logs.
+**Note:** mining past sessions is **on-demand, not automatic** — it happens
+only when you run scout's `session-retrospective`, which proposes deltas you
+must ack. The automatic half of reinforcement is just the hooks replaying
+already-written `.agents/memory/` content at dispatch.
 
 ### How it flows
 

--- a/bundles/web-qa/README.md
+++ b/bundles/web-qa/README.md
@@ -14,6 +14,79 @@ Installs the 6 agents below into `.claude/agents/`, seeds QA reference docs
 into `.agents/web-qa/knowledge/`, and splices the team conventions into
 `AGENTS.md` / `CLAUDE.md`.
 
+The team runs in **three phases**. Unlike the other bundles there is no
+`scout` and no single orchestrator: `app-profiler` onboards, then you run
+the authoring/running agents **in order**.
+
+**Install (once)** — `npx github:arozumenko/sdlc-skills init --bundle web-qa`.
+Installs the 6 agents into `.claude/agents/`, seeds reference docs into
+`.agents/web-qa/knowledge/`, wires the context hooks, and splices
+`instructions.md` into `AGENTS.md`.
+
+**Phase 1 — Inception (`app-profiler`, once per app).** _"Use the
+app-profiler agent to onboard this app."_ It **interviews you** (base URL,
+what the app does, auth + test credentials, the 3–5 key flows, user roles,
+external-service flows), then explores the running app live via Playwright
+MCP and writes `.agents/web-qa/app_profile.md` (URLs, auth, key pages,
+reliable selectors, fragile areas). **Why it's first:** there's no scout
+here — `app-profiler` is the onboarding agent, and every other web-qa agent
+reads this profile before acting.
+
+**Phase 2 — Usage (size → author → run).**
+- **`test-sizer`** (optional) rates cases S/M/L for agent-execution cost.
+- **`test-author`** turns a feature/flow description into
+  `tasks/<suite>/TC-NNN_<slug>.md` (URLs as `{{base_url}}/path`).
+- **`test-run-lead`** — launch as the **active agent** with a `base_url`. It
+  discovers the suite, dispatches one `test-runner` per case (each runs live
+  via Playwright MCP and must capture a confirming snapshot to record PASS),
+  then triggers `test-reporter` to write `reports/RUN-YYYY-MM-DD-NNN.md`.
+  Don't invoke `test-runner` / `test-reporter` by hand during a led run.
+  **The logic:** every agent reads `app_profile.md` for selectors and auth,
+  so cases and runs stay grounded in the real app.
+
+**Phase 3 — Reinforcement (assisted; you curate — there's no scout here).**
+The project's knowledge lives in durable, growing artifacts that every agent
+re-reads on each run: `.agents/web-qa/app_profile.md` (**re-run
+`app-profiler`** after UI changes to refresh selectors and flows), the
+`tasks/` suite (a living regression set), and the `reports/` history. None
+of this is automatic — you decide when to re-profile and which cases to
+keep. **The payoff:** runs get more reliable as the profile sharpens and the
+suite grows — the team builds a lasting QA memory of *this* app rather than a
+one-off pass. There is no mining of past chat or sub-agent transcripts;
+refinement comes from re-profiling the live app and curating the suite.
+
+### How it flows
+
+```mermaid
+flowchart TD
+    install(["npx … init --bundle web-qa"]) --> profiler
+
+    subgraph p1["Phase 1 — Inception · you launch app-profiler (once per app)"]
+        profiler["app-profiler — interview +<br/>explore live app"]
+        profile[/"app_profile.md<br/>URLs · auth · selectors · fragile areas"/]
+        profiler --> profile
+    end
+
+    subgraph p2["Phase 2 — Usage · you launch these in order"]
+        sizer["test-sizer — rate S/M/L (optional)"]
+        author["test-author — write TC-NNN files"]
+        lead["test-run-lead — active agent,<br/>owns the run loop"]
+        runner["test-runner — run one case<br/>live via Playwright MCP"]
+        reporter["test-reporter — write run report"]
+        sizer --> author --> lead
+        lead -->|dispatches| runner --> reporter
+    end
+
+    profile -->|"every agent reads it"| sizer
+
+    subgraph p3["Phase 3 — Reinforcement · assisted (you curate)"]
+        artifacts[(".agents/web-qa/app_profile.md<br/>tasks/ suite · reports/ history")]
+    end
+
+    reporter -. "runs accrue" .-> artifacts
+    artifacts -. "re-run app-profiler after UI changes;<br/>profile + suite ground the next run" .-> profiler
+```
+
 ## Roster
 
 | Role | Invoke | Does |

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "init": "./bin/init.mjs"
   },
   "scripts": {
+    "test": "node --test",
     "validate:bundles": "node bin/validate-bundles.mjs",
     "validate:marketplaces": "node bin/gen-marketplaces.mjs --check",
     "validate": "npm run validate:bundles && npm run validate:marketplaces",

--- a/skills.json
+++ b/skills.json
@@ -26,6 +26,7 @@
     {"id": "implement-feature",  "monorepo": "sdlc-skills", "name": "implement-feature",  "description": "End-to-end feature implementation workflow — plan, test, build, ship"},
     {"id": "plan-feature",       "monorepo": "sdlc-skills", "name": "plan-feature",       "description": "Structured feature planning — requirements, feasibility, acceptance criteria"},
     {"id": "seeding-a-project",     "monorepo": "sdlc-skills", "name": "seeding-a-project",     "description": "Generate AGENTS.md, .agents/ content docs, and per-role memory briefings for a new project (used by scout)"},
+    {"id": "session-retrospective", "monorepo": "sdlc-skills", "name": "session-retrospective", "description": "Distill past Claude Code sessions (main + sub-agent) into evidenced, ack-gated memory and workflow improvements (used by scout)"},
     {"id": "deep-research",      "monorepo": "sdlc-skills", "name": "deep-research",      "description": "Deep research workflow — trends, topic analysis, fact-checking"},
     {"id": "gathering-context",   "monorepo": "sdlc-skills", "name": "gathering-context",   "description": "Cross-channel context gathering — email, Teams, local KB"},
     {"id": "verifying-outcomes",      "monorepo": "sdlc-skills", "name": "verifying-outcomes",      "description": "Goal-backward verification — check outcomes, not task completion"},

--- a/skills/session-retrospective/SKILL.md
+++ b/skills/session-retrospective/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: session-retrospective
+description: Use when asked to run a retrospective, mine past sessions, or improve the team from what already happened — turning prior Claude Code conversations and sub-agent sessions into proposed memory and workflow updates. Used by scout.
+license: Apache-2.0
+metadata:
+  author: "Artem Rozumenko (git: arozumenko)"
+  version: "0.1.0"
+---
+
+# Session Retrospective
+
+Distill past sessions for this project into **evidenced, ack-gated**
+improvements to the team's memory and shared docs. Efficiency-led: process
+waste first, durable facts second. You (scout) run this manually when asked.
+
+**Read-only analysis, assisted writes.** The parser only reads transcripts.
+*You* propose every change and write nothing until the user acks.
+
+## When to use
+
+- The user says "run a retrospective", "mine past sessions", "what slowed us
+  down", or "improve the team from recent work".
+- Periodically, to fold lessons from recent sessions into `.agents/`.
+
+Not for: onboarding a fresh repo (that's `seeding-a-project`), or refreshing
+config from code/PR changes (that's scout's normal update flow).
+
+## Procedure
+
+1. **Distill.** Run the parser from the project root:
+
+   ```
+   node {skill}/scripts/distill-sessions.mjs
+   ```
+
+   It reads `~/.claude/projects/<this-project>/` transcripts newer than the
+   watermark (`.agents/memory/scout/.last-retrospective`), plus each session's
+   `subagents/`, and prints a bounded markdown digest. Add `--all` to ignore
+   the watermark, `--exclude-session <id>` to skip the active session, or
+   `--out <path>` to save the digest. Exit code 3 = no transcripts found →
+   use the Fallback below.
+
+2. **Read the digest** (it fits in context — never read raw `.jsonl`).
+
+3. **Interpret** — see `references/signal-taxonomy.md`. Separate:
+   - **Efficiency findings** — repeated corrections, retry loops, file churn,
+     tool errors, ignored conventions.
+   - **Durable facts** — gotchas, decisions, "X doesn't work, use Y".
+   Every finding MUST cite the session id it came from. Drop anything you
+   cannot evidence from the digest.
+
+4. **Map findings to targets** — see `references/finding-to-target.md`:
+   role-specific → that role's `.agents/memory/<role>/`; team-wide process →
+   `.agents/workflow.md` / `.agents/conventions.md`; durable fact → a curated
+   entry (via the `memory` skill).
+
+5. **Propose, then wait.** Present each proposed change as a diff plus a
+   one-line rationale with its session-id evidence. **Stop and wait for the
+   user's ack.** Do not write yet.
+
+6. **On ack, write:**
+   - Memory deltas via the `memory` skill (curated entries + `MEMORY.md`
+     index lines; `project_briefing.md` updates).
+   - Surgical edits to `.agents/workflow.md` / `conventions.md`.
+   - A dated report `.agents/retrospectives/YYYY-MM-DD.md`: sessions analyzed,
+     findings, what was applied, what was deferred and why.
+   - Advance the watermark: write `.agents/memory/scout/.last-retrospective`
+     as `{"lastRun":"<ISO>","analyzed":[<session ids you just covered>]}`,
+     merging with any existing ids. **Only after writing — never on a decline.**
+
+## Fallback (non–Claude Code hosts)
+
+If the parser exits with code 3, transcripts aren't accessible here. Ask the
+user to paste a session transcript or summary, then run steps 3–6 on that text
+(skip the watermark; note in the report that it was a pasted-transcript run).
+
+## Anti-memory-poisoning rules
+
+- Never write without an explicit ack.
+- Every durable fact cites a session id. No inventing.
+- Record corrections as one-line lessons, not raw quotes.
+- Bounded recall — reason over the digest, never raw `.jsonl`.
+
+## Common mistakes
+
+- Writing before ack — forbidden; always propose-then-wait.
+- Advancing the watermark on a dry run or a decline — only after writing.
+- Treating a candidate correction as a fact without judgment — the digest
+  flags candidates; you decide.
+- Reading raw transcripts into context — use the digest.
+
+## References
+
+- `references/transcript-schema.md` — Claude Code JSONL + sub-agent layout.
+- `references/digest-format.md` — the digest the parser emits.
+- `references/signal-taxonomy.md` — signal definitions + thresholds.
+- `references/finding-to-target.md` — finding→target mapping + safeguards.

--- a/skills/session-retrospective/SKILL.md
+++ b/skills/session-retrospective/SKILL.md
@@ -38,7 +38,9 @@ config from code/PR changes (that's scout's normal update flow).
    `subagents/`, and prints a bounded markdown digest. Add `--all` to ignore
    the watermark, `--exclude-session <id>` to skip the active session, or
    `--out <path>` to save the digest. Exit code 3 = no transcripts found →
-   use the Fallback below.
+   use the Fallback below. The newest session is usually the one you're
+   running in — pass `--exclude-session <its id>` so the retrospective
+   doesn't analyze itself.
 
 2. **Read the digest** (it fits in context — never read raw `.jsonl`).
 
@@ -52,7 +54,9 @@ config from code/PR changes (that's scout's normal update flow).
 4. **Map findings to targets** — see `references/finding-to-target.md`:
    role-specific → that role's `.agents/memory/<role>/`; team-wide process →
    `.agents/workflow.md` / `.agents/conventions.md`; durable fact → a curated
-   entry (via the `memory` skill).
+   entry (via the `memory` skill). If `.agents/` doesn't exist, the project
+   isn't seeded — a retrospective refines an existing lens, it doesn't create
+   one; run `seeding-a-project` first.
 
 5. **Propose, then wait.** Present each proposed change as a diff plus a
    one-line rationale with its session-id evidence. **Stop and wait for the

--- a/skills/session-retrospective/references/digest-format.md
+++ b/skills/session-retrospective/references/digest-format.md
@@ -1,0 +1,23 @@
+# Digest format
+
+The parser emits markdown, one section per analyzed session:
+
+```
+## Session <id> — <date>  (branch: <b>, <Nu> user / <Na> assistant turns, ~<min> min)
+Skills/plugins seen: <comma-separated attribution set>
+
+### Sub-agents
+- <agentType> — "<task description>" — <turns> turns, <errors> errors, ended: ok|with errors
+
+### Signals
+- Tool errors: <Tool>: error ×<count>
+- Retry/loop: <Tool> on <target> ×<count>
+- File churn: <path> edited ×<count>
+- Candidate corrections:
+  - "<short quoted user turn>" (turn <n>)
+```
+
+A session with none of the above shows `- (no notable signals)`. The digest is
+bounded: quotes truncated to 200 chars, max 12 corrections/session, file churn
+only listed at ≥4 edits. Signals are **extracted, not interpreted** — judgment
+is the agent's job.

--- a/skills/session-retrospective/references/finding-to-target.md
+++ b/skills/session-retrospective/references/finding-to-target.md
@@ -5,6 +5,7 @@
 | Lesson specific to one role | `.agents/memory/<role>/project_briefing.md` or a new curated entry | `memory` skill (curated-entry write) |
 | Team-wide process improvement | `.agents/workflow.md` | surgical edit |
 | Coding-standard correction | `.agents/conventions.md` | surgical edit |
+| Project tooling / build-script knowledge (no single role owns it) | `.agents/conventions.md` or `AGENTS.md` | surgical edit |
 | Durable project fact / gotcha | curated entry in the most relevant role's memory | `memory` skill |
 | Every run | `.agents/retrospectives/YYYY-MM-DD.md` | new report: analyzed / applied / deferred |
 

--- a/skills/session-retrospective/references/finding-to-target.md
+++ b/skills/session-retrospective/references/finding-to-target.md
@@ -1,0 +1,22 @@
+# Finding → write-target mapping
+
+| Finding kind | Target | How |
+|---|---|---|
+| Lesson specific to one role | `.agents/memory/<role>/project_briefing.md` or a new curated entry | `memory` skill (curated-entry write) |
+| Team-wide process improvement | `.agents/workflow.md` | surgical edit |
+| Coding-standard correction | `.agents/conventions.md` | surgical edit |
+| Durable project fact / gotcha | curated entry in the most relevant role's memory | `memory` skill |
+| Every run | `.agents/retrospectives/YYYY-MM-DD.md` | new report: analyzed / applied / deferred |
+
+## Rules
+
+- **Ack first.** Present diffs + per-item rationale with session-id evidence;
+  write nothing until the user approves. Mirrors scout's "surface the delta,
+  wait for ack" rule.
+- **Evidence required.** Each durable fact cites the session id it came from.
+- **Surgical edits.** For shared docs, change only the affected lines; don't
+  reformat working prose.
+- **Defer, don't drop.** Findings the user declines go in the report's
+  "deferred" section with the reason.
+- **Watermark last.** Advance `.agents/memory/scout/.last-retrospective` only
+  after a successful write.

--- a/skills/session-retrospective/references/signal-taxonomy.md
+++ b/skills/session-retrospective/references/signal-taxonomy.md
@@ -1,0 +1,22 @@
+# Signal taxonomy
+
+What the parser extracts (thresholds in `distill-sessions.mjs` constants):
+
+| Signal | Definition | Threshold |
+|---|---|---|
+| Tool error | a `tool_result` with `is_error`, name-correlated via `tool_use_id` | any |
+| Retry/loop | same tool + same primary target within a 6-call window | ≥1 repeat |
+| File churn | one `file_path` edited via Edit/Write/NotebookEdit | ≥4 edits |
+| Candidate correction | short user turn after assistant activity matching the correction regex (no/don't/actually/revert/…) | ≤12/session |
+
+## How to read them
+
+- **Tool errors / retries** → friction or a missing convention. Ask: would a
+  note in a role briefing or `workflow.md` have prevented the loop?
+- **File churn** → thrash. Often a sign the role lacked context the briefing
+  could carry.
+- **Candidate corrections** → the richest source of durable lessons, but
+  noisy. A correction is only a finding if it generalizes beyond the one turn.
+
+Signals are evidence, not findings. Promote a signal to a finding only when it
+recurs or clearly generalizes, and always keep its session id as evidence.

--- a/skills/session-retrospective/references/transcript-schema.md
+++ b/skills/session-retrospective/references/transcript-schema.md
@@ -1,0 +1,30 @@
+# Claude Code transcript layout
+
+Per project, under `~/.claude/projects/<encoded-cwd>/`, where `<encoded-cwd>`
+is the absolute project path with `/` and `.` replaced by `-`
+(e.g. `/Users/x/dev/app` → `-Users-x-dev-app`). If the encoded dir is absent,
+the parser falls back to scanning project dirs and matching the `cwd` field
+inside transcripts.
+
+```
+<encoded-cwd>/
+├── <session-id>.jsonl            main session (one JSON record per line)
+└── <session-id>/
+    └── subagents/
+        ├── agent-<id>.jsonl      a sub-agent session
+        └── agent-<id>.meta.json  { agentType, description, toolUseId }
+```
+
+## Record fields the parser uses
+
+- `type`: `user` | `assistant` | `system` | `file-history-snapshot` | …
+- `message`: `{ role, content }`. `content` is a string or an array of blocks.
+  - assistant blocks: `{ type: "tool_use", id, name, input }`
+  - user blocks: `{ type: "tool_result", tool_use_id, is_error }` or `{ type: "text", text }`
+- `timestamp` (ISO), `gitBranch`, `cwd`, `sessionId`
+- `attributionSkill`, `attributionPlugin` — which skill/plugin was active
+- `toolUseResult` — top-level tool result payload (may carry `is_error`)
+
+The schema can drift between Claude Code versions. The parser is defensive
+(skips unparseable lines, tolerates missing fields); re-calibrate the unit
+tests if fields change.

--- a/skills/session-retrospective/scripts/distill-sessions.mjs
+++ b/skills/session-retrospective/scripts/distill-sessions.mjs
@@ -17,7 +17,9 @@ const EDIT_TOOLS = ['Edit', 'Write', 'NotebookEdit'];
 function safeParse(line) { try { return JSON.parse(line); } catch { return null; } }
 
 export function encodeProjectPath(cwd) {
-  // Claude Code names the project dir by replacing path separators and dots.
+  // Claude Code names the project dir by replacing path separators and dots
+  // with dashes. Paths with spaces or other special characters may not match
+  // this fast path; resolveProjectDir falls back to a cwd-field scan.
   return cwd.replace(/[/.]/g, '-');
 }
 
@@ -62,18 +64,20 @@ function userTextOf(rec) {
 }
 
 export function detectRetries(toolCalls) {
+  // Count repeat events: for each call, whether the same tool+target recurs
+  // within the look-ahead window. counts[key] = number of repeats (0 = none).
   const counts = {};
   for (let i = 0; i < toolCalls.length; i++) {
     for (let j = i + 1; j < toolCalls.length && j <= i + RETRY_WINDOW; j++) {
       if (toolCalls[i].tool === toolCalls[j].tool &&
           toolCalls[i].target && toolCalls[i].target === toolCalls[j].target) {
         const key = `${toolCalls[i].tool} on ${toolCalls[i].target}`;
-        counts[key] = (counts[key] || 1) + 1;
+        counts[key] = (counts[key] || 0) + 1;
         break;
       }
     }
   }
-  return Object.entries(counts).filter(([, n]) => n >= 2).sort((a, b) => b[1] - a[1]);
+  return Object.entries(counts).filter(([, n]) => n >= 1).sort((a, b) => b[1] - a[1]);
 }
 
 export function extractSignals(records) {
@@ -82,16 +86,15 @@ export function extractSignals(records) {
   const fileChurn = {};       // path -> count
   const corrections = [];     // {turn, text}
   const idToName = {};        // tool_use_id -> tool name
-  let userTurns = 0, assistantTurns = 0, lastAssistantHadTool = false, turn = 0;
+  let userTurns = 0, assistantTurns = 0, sawAssistant = false, turn = 0;
 
   for (const rec of records) {
     if (rec.type === 'assistant') {
       assistantTurns++; turn++;
+      sawAssistant = true;
       const blocks = Array.isArray(rec.message?.content) ? rec.message.content : [];
-      let hadTool = false;
       for (const b of blocks) {
         if (b?.type !== 'tool_use') continue;
-        hadTool = true;
         if (b.id) idToName[b.id] = b.name;
         const target = b.input?.file_path || b.input?.path || b.input?.command || '';
         toolCalls.push({ turn, tool: b.name, target: String(target).slice(0, 80) });
@@ -99,7 +102,6 @@ export function extractSignals(records) {
           fileChurn[b.input.file_path] = (fileChurn[b.input.file_path] || 0) + 1;
         }
       }
-      lastAssistantHadTool = hadTool;
     } else if (rec.type === 'user') {
       userTurns++; turn++;
       const blocks = rec.message?.content;
@@ -112,7 +114,7 @@ export function extractSignals(records) {
         }
       }
       const text = userTextOf(rec);
-      if (text && lastAssistantHadTool && CORRECTION_RE.test(text) &&
+      if (text && sawAssistant && CORRECTION_RE.test(text) &&
           corrections.length < MAX_CORRECTIONS_PER_SESSION) {
         corrections.push({ turn, text: text.slice(0, MAX_QUOTE_LEN).replace(/\s+/g, ' ').trim() });
       }

--- a/skills/session-retrospective/scripts/distill-sessions.mjs
+++ b/skills/session-retrospective/scripts/distill-sessions.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+// Distill Claude Code session transcripts for the current project into a
+// compact markdown digest for a scout-led retrospective. READ-ONLY: emits a
+// digest to stdout (or --out file); never writes memory/docs/watermark.
+import { readFileSync, readdirSync, existsSync, statSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, basename } from 'node:path';
+
+const FILE_CHURN_THRESHOLD = 4;          // edits to one path before it's a signal
+const RETRY_WINDOW = 6;                   // look-ahead window (tool calls)
+const MAX_CORRECTIONS_PER_SESSION = 12;
+const MAX_QUOTE_LEN = 200;
+const CORRECTION_RE =
+  /^\s*(no\b|don'?t\b|actually\b|wait\b|stop\b|revert\b|undo\b|nope\b|incorrect\b|that'?s (wrong|not\b))/i;
+const EDIT_TOOLS = ['Edit', 'Write', 'NotebookEdit'];
+
+function safeParse(line) { try { return JSON.parse(line); } catch { return null; } }
+
+export function encodeProjectPath(cwd) {
+  // Claude Code names the project dir by replacing path separators and dots.
+  return cwd.replace(/[/.]/g, '-');
+}
+
+export function readRecords(jsonlPath) {
+  const txt = readFileSync(jsonlPath, 'utf8');
+  const out = [];
+  for (const line of txt.split('\n')) {
+    if (!line.trim()) continue;
+    const rec = safeParse(line);
+    if (rec) out.push(rec);
+  }
+  return out;
+}
+
+function firstCwdOf(jsonlPath) {
+  try {
+    for (const rec of readRecords(jsonlPath)) if (rec.cwd) return rec.cwd;
+  } catch { /* ignore */ }
+  return null;
+}
+
+export function resolveProjectDir(cwd, projectsRoot) {
+  const direct = join(projectsRoot, encodeProjectPath(cwd));
+  if (existsSync(direct)) return direct;
+  if (!existsSync(projectsRoot)) return null;
+  // Fallback: match by the `cwd` field inside each dir's transcripts.
+  for (const name of readdirSync(projectsRoot)) {
+    const dir = join(projectsRoot, name);
+    let jsonls;
+    try { jsonls = readdirSync(dir).filter(f => f.endsWith('.jsonl')); }
+    catch { continue; }
+    for (const f of jsonls) if (firstCwdOf(join(dir, f)) === cwd) return dir;
+  }
+  return null;
+}
+
+function userTextOf(rec) {
+  const c = rec.message?.content;
+  if (typeof c === 'string') return c;
+  if (Array.isArray(c)) return c.filter(b => b?.type === 'text').map(b => b.text).join(' ');
+  return '';
+}
+
+export function detectRetries(toolCalls) {
+  const counts = {};
+  for (let i = 0; i < toolCalls.length; i++) {
+    for (let j = i + 1; j < toolCalls.length && j <= i + RETRY_WINDOW; j++) {
+      if (toolCalls[i].tool === toolCalls[j].tool &&
+          toolCalls[i].target && toolCalls[i].target === toolCalls[j].target) {
+        const key = `${toolCalls[i].tool} on ${toolCalls[i].target}`;
+        counts[key] = (counts[key] || 1) + 1;
+        break;
+      }
+    }
+  }
+  return Object.entries(counts).filter(([, n]) => n >= 2).sort((a, b) => b[1] - a[1]);
+}
+
+export function extractSignals(records) {
+  const toolErrors = {};      // "Tool: error" -> count
+  const toolCalls = [];       // {turn, tool, target}
+  const fileChurn = {};       // path -> count
+  const corrections = [];     // {turn, text}
+  const idToName = {};        // tool_use_id -> tool name
+  let userTurns = 0, assistantTurns = 0, lastAssistantHadTool = false, turn = 0;
+
+  for (const rec of records) {
+    if (rec.type === 'assistant') {
+      assistantTurns++; turn++;
+      const blocks = Array.isArray(rec.message?.content) ? rec.message.content : [];
+      let hadTool = false;
+      for (const b of blocks) {
+        if (b?.type !== 'tool_use') continue;
+        hadTool = true;
+        if (b.id) idToName[b.id] = b.name;
+        const target = b.input?.file_path || b.input?.path || b.input?.command || '';
+        toolCalls.push({ turn, tool: b.name, target: String(target).slice(0, 80) });
+        if (EDIT_TOOLS.includes(b.name) && b.input?.file_path) {
+          fileChurn[b.input.file_path] = (fileChurn[b.input.file_path] || 0) + 1;
+        }
+      }
+      lastAssistantHadTool = hadTool;
+    } else if (rec.type === 'user') {
+      userTurns++; turn++;
+      const blocks = rec.message?.content;
+      if (Array.isArray(blocks)) {
+        for (const b of blocks) {
+          if (b?.type === 'tool_result' && b.is_error) {
+            const name = idToName[b.tool_use_id] || 'tool';
+            toolErrors[`${name}: error`] = (toolErrors[`${name}: error`] || 0) + 1;
+          }
+        }
+      }
+      const text = userTextOf(rec);
+      if (text && lastAssistantHadTool && CORRECTION_RE.test(text) &&
+          corrections.length < MAX_CORRECTIONS_PER_SESSION) {
+        corrections.push({ turn, text: text.slice(0, MAX_QUOTE_LEN).replace(/\s+/g, ' ').trim() });
+      }
+    }
+  }
+  const retries = detectRetries(toolCalls);
+  const churn = Object.entries(fileChurn)
+    .filter(([, n]) => n >= FILE_CHURN_THRESHOLD).sort((a, b) => b[1] - a[1]);
+  return { userTurns, assistantTurns, toolErrors, retries, fileChurn: churn, corrections };
+}
+
+function sessionMeta(records, jsonlPath) {
+  const id = basename(jsonlPath, '.jsonl');
+  let branch = '?', firstTs = null, lastTs = null;
+  const skills = new Set();
+  for (const r of records) {
+    if (r.gitBranch) branch = r.gitBranch;
+    if (r.attributionSkill) skills.add(r.attributionSkill);
+    if (r.attributionPlugin) skills.add(r.attributionPlugin);
+    if (r.timestamp) {
+      const t = Date.parse(r.timestamp);
+      if (!Number.isNaN(t)) { if (firstTs === null || t < firstTs) firstTs = t; if (lastTs === null || t > lastTs) lastTs = t; }
+    }
+  }
+  const date = firstTs ? new Date(firstTs).toISOString().slice(0, 10) : '?';
+  const durationMin = (firstTs && lastTs) ? Math.round((lastTs - firstTs) / 60000) : 0;
+  return { id, branch, date, durationMin, skills: [...skills] };
+}
+
+export function parseSession(jsonlPath) {
+  const records = readRecords(jsonlPath);
+  return { ...sessionMeta(records, jsonlPath), ...extractSignals(records) };
+}
+
+export function readSubagents(sessionDir) {
+  const dir = join(sessionDir, 'subagents');
+  if (!existsSync(dir)) return [];
+  const out = [];
+  for (const m of readdirSync(dir).filter(f => f.endsWith('.meta.json'))) {
+    const meta = safeParse(readFileSync(join(dir, m), 'utf8')) || {};
+    const jsonl = join(dir, m.replace('.meta.json', '.jsonl'));
+    let turns = 0, errors = 0, ended = '?';
+    if (existsSync(jsonl)) {
+      const sig = extractSignals(readRecords(jsonl));
+      turns = sig.userTurns + sig.assistantTurns;
+      errors = Object.values(sig.toolErrors).reduce((a, b) => a + b, 0);
+      ended = errors > 0 ? 'with errors' : 'ok';
+    }
+    out.push({ agentType: meta.agentType || '?', description: meta.description || '', turns, errors, ended });
+  }
+  return out;
+}
+
+export function readWatermark(path) {
+  if (!existsSync(path)) return { analyzed: [] };
+  const d = safeParse(readFileSync(path, 'utf8'));
+  return d && Array.isArray(d.analyzed) ? d : { analyzed: [] };
+}
+
+export function renderDigest(sessions) {
+  const out = ['# Session retrospective digest', '',
+    `Generated: ${new Date().toISOString()}`,
+    `Sessions analyzed: ${sessions.length}`, ''];
+  for (const s of sessions) {
+    out.push(`## Session ${s.id} — ${s.date}  (branch: ${s.branch}, ${s.userTurns} user / ${s.assistantTurns} assistant turns, ~${s.durationMin} min)`);
+    if (s.skills.length) out.push(`Skills/plugins seen: ${s.skills.join(', ')}`);
+    out.push('');
+    if (s.subagents?.length) {
+      out.push('### Sub-agents');
+      for (const a of s.subagents) out.push(`- ${a.agentType} — "${a.description}" — ${a.turns} turns, ${a.errors} errors, ended: ${a.ended}`);
+      out.push('');
+    }
+    out.push('### Signals');
+    const te = Object.entries(s.toolErrors).sort((a, b) => b[1] - a[1]);
+    for (const [k, n] of te) out.push(`- Tool errors: ${k} ×${n}`);
+    for (const [k, n] of s.retries) out.push(`- Retry/loop: ${k} ×${n}`);
+    for (const [p, n] of s.fileChurn) out.push(`- File churn: ${p} edited ×${n}`);
+    if (s.corrections.length) {
+      out.push('- Candidate corrections:');
+      for (const c of s.corrections) out.push(`  - "${c.text}" (turn ${c.turn})`);
+    }
+    if (!te.length && !s.retries.length && !s.fileChurn.length && !s.corrections.length) {
+      out.push('- (no notable signals)');
+    }
+    out.push('');
+  }
+  return out.join('\n');
+}
+
+function parseArgs(argv) {
+  const a = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (!argv[i].startsWith('--')) continue;
+    const key = argv[i].slice(2);
+    const next = argv[i + 1];
+    a[key] = (next && !next.startsWith('--')) ? argv[++i] : true;
+  }
+  return a;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const cwd = process.cwd();
+  const projectsRoot = join(homedir(), '.claude', 'projects');
+  const projectDir = args['project-dir'] || resolveProjectDir(cwd, projectsRoot);
+  if (!projectDir) {
+    process.stderr.write(
+      'No Claude Code transcripts found for this project.\n' +
+      'session-retrospective currently supports Claude Code only.\n' +
+      'Fallback: paste a session transcript or summary and scout will analyze it directly.\n');
+    process.exit(3);
+  }
+  const wmPath = args.watermark || join('.agents', 'memory', 'scout', '.last-retrospective');
+  const analyzed = args.all ? new Set() : new Set(readWatermark(wmPath).analyzed);
+  const exclude = args['exclude-session'];
+  const jsonls = readdirSync(projectDir).filter(f => f.endsWith('.jsonl'))
+    .map(f => join(projectDir, f))
+    .sort((a, b) => statSync(a).mtimeMs - statSync(b).mtimeMs);
+  const sessions = [];
+  for (const jp of jsonls) {
+    const id = basename(jp, '.jsonl');
+    if (analyzed.has(id) || id === exclude) continue;
+    const s = parseSession(jp);
+    s.subagents = readSubagents(join(projectDir, id));
+    sessions.push(s);
+  }
+  const digest = renderDigest(sessions);
+  if (args.out) {
+    writeFileSync(args.out, digest);
+    process.stderr.write(`Digest written to ${args.out} (${sessions.length} sessions)\n`);
+  } else {
+    process.stdout.write(digest + '\n');
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/skills/session-retrospective/scripts/distill-sessions.mjs
+++ b/skills/session-retrospective/scripts/distill-sessions.mjs
@@ -227,6 +227,10 @@ function main() {
       'Fallback: paste a session transcript or summary and scout will analyze it directly.\n');
     process.exit(3);
   }
+  if (!existsSync(projectDir)) {
+    process.stderr.write(`project-dir not found: ${projectDir}\n`);
+    process.exit(1);
+  }
   const wmPath = args.watermark || join('.agents', 'memory', 'scout', '.last-retrospective');
   const analyzed = args.all ? new Set() : new Set(readWatermark(wmPath).analyzed);
   const exclude = args['exclude-session'];

--- a/skills/session-retrospective/scripts/distill-sessions.test.mjs
+++ b/skills/session-retrospective/scripts/distill-sessions.test.mjs
@@ -43,6 +43,18 @@ test('detectRetries flags a repeated tool+target', () => {
   const r = detectRetries(calls);
   assert.equal(r.length, 1);
   assert.equal(r[0][0], 'Bash on npm test');
+  assert.equal(r[0][1], 1);
+});
+
+test('detectRetries counts multiple repeats of the same tool+target', () => {
+  const calls = [
+    { turn: 1, tool: 'Bash', target: 'npm test' },
+    { turn: 2, tool: 'Bash', target: 'npm test' },
+    { turn: 3, tool: 'Bash', target: 'npm test' },
+  ];
+  const r = detectRetries(calls);
+  assert.equal(r.length, 1);
+  assert.equal(r[0][1], 2);
 });
 
 test('renderDigest is bounded markdown with session + sub-agent sections', () => {

--- a/skills/session-retrospective/scripts/distill-sessions.test.mjs
+++ b/skills/session-retrospective/scripts/distill-sessions.test.mjs
@@ -1,0 +1,93 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  encodeProjectPath, extractSignals, detectRetries,
+  renderDigest, parseSession, resolveProjectDir, readSubagents,
+} from './distill-sessions.mjs';
+
+test('encodeProjectPath replaces slashes and dots with dashes', () => {
+  assert.equal(encodeProjectPath('/Users/a/dev/x'), '-Users-a-dev-x');
+  assert.equal(encodeProjectPath('/U/x.y.z'), '-U-x-y-z');
+});
+
+test('extractSignals: tool errors (name-correlated), file churn, corrections', () => {
+  const recs = [
+    { type: 'assistant', message: { role: 'assistant', content: [
+      { type: 'tool_use', id: 't1', name: 'Edit', input: { file_path: 'a.js' } }] } },
+    { type: 'user', message: { role: 'user', content: [
+      { type: 'tool_result', tool_use_id: 't1', is_error: true }] } },
+    { type: 'assistant', message: { role: 'assistant', content: [
+      { type: 'tool_use', id: 't2', name: 'Edit', input: { file_path: 'a.js' } }] } },
+    { type: 'user', message: { role: 'user', content: 'no, that is wrong, revert it' } },
+    { type: 'assistant', message: { role: 'assistant', content: [
+      { type: 'tool_use', id: 't3', name: 'Edit', input: { file_path: 'a.js' } }] } },
+    { type: 'assistant', message: { role: 'assistant', content: [
+      { type: 'tool_use', id: 't4', name: 'Edit', input: { file_path: 'a.js' } }] } },
+  ];
+  const s = extractSignals(recs);
+  assert.equal(s.toolErrors['Edit: error'], 1);
+  const churn = Object.fromEntries(s.fileChurn);
+  assert.equal(churn['a.js'], 4);
+  assert.equal(s.corrections.length, 1);
+  assert.match(s.corrections[0].text, /no, that is wrong/);
+});
+
+test('detectRetries flags a repeated tool+target', () => {
+  const calls = [
+    { turn: 1, tool: 'Bash', target: 'npm test' },
+    { turn: 2, tool: 'Bash', target: 'npm test' },
+  ];
+  const r = detectRetries(calls);
+  assert.equal(r.length, 1);
+  assert.equal(r[0][0], 'Bash on npm test');
+});
+
+test('renderDigest is bounded markdown with session + sub-agent sections', () => {
+  const sessions = [{
+    id: 'abc', date: '2026-05-27', branch: 'main', durationMin: 12,
+    userTurns: 3, assistantTurns: 5, skills: ['memory'],
+    toolErrors: { 'Edit: error': 2 }, retries: [], fileChurn: [['a.js', 4]],
+    corrections: [{ turn: 4, text: 'revert that' }],
+    subagents: [{ agentType: 'python-dev', description: 'add endpoint', turns: 9, errors: 0, ended: 'ok' }],
+  }];
+  const md = renderDigest(sessions);
+  assert.match(md, /## Session abc/);
+  assert.match(md, /### Sub-agents/);
+  assert.match(md, /python-dev/);
+  assert.ok(md.length < 50_000, 'digest stays bounded');
+});
+
+test('resolveProjectDir returns null when projects root is missing', () => {
+  const root = join(mkdtempSync(join(tmpdir(), 'sr-')), 'nope');
+  assert.equal(resolveProjectDir('/Users/a/dev/x', root), null);
+});
+
+test('parseSession + readSubagents on a written fixture', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sr-'));
+  const jsonl = join(dir, 'sess1.jsonl');
+  const recs = [
+    { type: 'assistant', timestamp: '2026-05-27T10:00:00Z', gitBranch: 'main', attributionSkill: 'memory',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: 'x', name: 'Bash', input: { command: 'ls' } }] } },
+    { type: 'user', timestamp: '2026-05-27T10:05:00Z', message: { role: 'user', content: 'thanks' } },
+  ];
+  writeFileSync(jsonl, recs.map(r => JSON.stringify(r)).join('\n'));
+  const s = parseSession(jsonl);
+  assert.equal(s.id, 'sess1');
+  assert.equal(s.branch, 'main');
+  assert.deepEqual(s.skills, ['memory']);
+  assert.equal(s.assistantTurns, 1);
+  assert.equal(s.userTurns, 1);
+
+  const sessDir = join(dir, 'sess1');
+  mkdirSync(join(sessDir, 'subagents'), { recursive: true });
+  writeFileSync(join(sessDir, 'subagents', 'agent-1.meta.json'),
+    JSON.stringify({ agentType: 'python-dev', description: 'add endpoint' }));
+  writeFileSync(join(sessDir, 'subagents', 'agent-1.jsonl'),
+    JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [] } }));
+  const subs = readSubagents(sessDir);
+  assert.equal(subs.length, 1);
+  assert.equal(subs[0].agentType, 'python-dev');
+});

--- a/skills/session-retrospective/scripts/distill-sessions.test.mjs
+++ b/skills/session-retrospective/scripts/distill-sessions.test.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   encodeProjectPath, extractSignals, detectRetries,
-  renderDigest, parseSession, resolveProjectDir, readSubagents,
+  renderDigest, parseSession, resolveProjectDir, readSubagents, readWatermark,
 } from './distill-sessions.mjs';
 
 test('encodeProjectPath replaces slashes and dots with dashes', () => {
@@ -102,4 +102,18 @@ test('parseSession + readSubagents on a written fixture', () => {
   const subs = readSubagents(sessDir);
   assert.equal(subs.length, 1);
   assert.equal(subs[0].agentType, 'python-dev');
+});
+
+test('readWatermark: missing file, valid file, malformed JSON', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sr-'));
+  // missing file → empty analyzed list
+  assert.deepEqual(readWatermark(join(dir, 'none')), { analyzed: [] });
+  // valid file → parsed object
+  const ok = join(dir, 'wm.json');
+  writeFileSync(ok, JSON.stringify({ lastRun: '2026-05-27T00:00:00Z', analyzed: ['a', 'b'] }));
+  assert.deepEqual(readWatermark(ok).analyzed, ['a', 'b']);
+  // malformed JSON → falls back to empty analyzed list
+  const bad = join(dir, 'bad.json');
+  writeFileSync(bad, '{ not json');
+  assert.deepEqual(readWatermark(bad), { analyzed: [] });
 });


### PR DESCRIPTION
## Summary

Adds a **`session-retrospective`** skill (adopted by `scout`) that distills past Claude Code sessions — main **and** sub-agent — into evidenced, **ack-gated** improvements to a project's team memory and shared docs. This is the mechanism behind the bundles' "Phase 3 — Reinforcement": mining what actually happened, not just re-reading code/PRs.

- **Read-only parser** `skills/session-retrospective/scripts/distill-sessions.mjs` (zero deps, Node ESM): locates `~/.claude/projects/<cwd>/` transcripts since a watermark + each session's `subagents/`, emits a **bounded markdown digest** of signals (tool errors, retry loops, file churn, candidate corrections, sub-agent outcomes). Extracts signals only — never judges, never writes (only `--out` writes a digest file). Clean exit-3 fallback on non–Claude Code hosts.
- **`SKILL.md` + 4 references**: the propose → **wait for ack** → write (memory via the `memory` skill, surgical edits to `.agents/workflow.md`/`conventions.md`, a dated `.agents/retrospectives/` report) → advance watermark procedure, with anti-memory-poisoning rules (evidence-by-session-id, no auto-writes).
- **Wiring**: `session-retrospective` added to `scout`'s skills, registered in `skills.json`, present in all four marketplaces (incl. hand-curated `.claude-plugin`).
- **Docs**: bundle READMEs (team-web/ios/test-automation) now note scout mines past sessions on-demand in reinforcement; also includes the earlier Quick-start "three phases" + onboarding mermaid additions across all four bundles.

Scope (YAGNI, per spec): Claude-Code-first; no non-Claude transcript adapters, no Stop-hook nudge, no app-profiler variant, no auto-write — all documented follow-ups.

## Test Plan

- [x] `npm test` — 8/8 unit tests green (parser functions, signal extraction, retry counting, digest bounds, watermark, sub-agent reads)
- [x] `npm run validate` — 4 bundles valid, all marketplaces up to date
- [x] Calibrated against real transcripts (`--all`) — schema matched, bounded digest with sub-agent + signal sections
- [x] Fallback verified — exit 3 + message when no transcripts found; `--project-dir` typo exits 1 cleanly
- [x] Behavioral check — a scout subagent ran the skill end-to-end: produced evidenced findings (each citing a real session id + target) and stopped at the ack gate without writing
- [x] Two-stage review (spec + code quality) per task + final whole-implementation review; all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)