### PR TITLE
docs(bundles): restore missing Quick start heading

### DIFF
--- a/bundles/team-ios/README.md
+++ b/bundles/team-ios/README.md
@@ -15,6 +15,8 @@ Testing / Swift Concurrency skills via `ios-dev`), seeds per-role stack
 briefings into `.agents/memory/<role>/`, and splices the team conventions
 into `AGENTS.md` / `CLAUDE.md`.
 
+## Quick start
+
 The team runs in **three phases**. You launch only two agents yourself —
 `scout`, then `project-manager`; the hooks and the orchestrator handle the
 rest.

--- a/bundles/team-web/README.md
+++ b/bundles/team-web/README.md
@@ -15,6 +15,8 @@ each agent's skills, seeds per-role stack briefings into
 `.agents/memory/<role>/`, and splices the team conventions into
 `AGENTS.md` / `CLAUDE.md`.
 
+## Quick start
+
 The team runs in **three phases**. You launch only two agents yourself —
 `scout`, then `project-manager`; the hooks and the orchestrator handle the
 rest.

--- a/bundles/test-automation/README.md
+++ b/bundles/test-automation/README.md
@@ -11,6 +11,8 @@ merge gate.
 npx github:arozumenko/sdlc-skills init --bundle test-automation
 ```
 
+## Quick start
+
 The pipeline runs in **three phases**. You launch `scout` once, then drive
 **Tal** directly for every automation task; Tal dispatches the analyst →
 implementer → reviewer pipeline as subagents.

--- a/bundles/web-qa/README.md
+++ b/bundles/web-qa/README.md
@@ -14,6 +14,8 @@ Installs the 6 agents below into `.claude/agents/`, seeds QA reference docs
 into `.agents/web-qa/knowledge/`, and splices the team conventions into
 `AGENTS.md` / `CLAUDE.md`.
 
+## Quick start
+
 The team runs in **three phases**. Unlike the other bundles there is no
 `scout` and no single orchestrator: `app-profiler` onboards, then you run
 the authoring/running agents **in order**.


### PR DESCRIPTION
## Summary

Follow-up to #28. The "three phases" restructure of the bundle READMEs accidentally dropped the `## Quick start` heading, so the phase content read as part of `## Install` and the `### How it flows` mermaid section was a parentless h3. This re-adds the heading in all four bundles (team-web, team-ios, test-automation, web-qa).

Heading structure is now consistent: `## Install → ## Quick start → ### How it flows → ## Roster`.

## Test Plan
- [x] `npm run validate:bundles` — 4 bundles valid
- [x] Verified each README now has exactly one `## Quick start` h2 with `### How it flows` nested under it

🤖 Generated with [Claude Code](https://claude.com/claude-code)