### PR TITLE
Test automation project seeding enhancements

### DIFF
--- a/skills/seeding-a-project/references/scout-survey.md
+++ b/skills/seeding-a-project/references/scout-survey.md
@@ -4,6 +4,7 @@
 
 - [Step 0.5 — PR-sampling survey](#step-05--pr-sampling-survey)
 - [Step 0.7 — Project-systems capture](#step-07--project-systems-capture)
+  - [Coherence checks (before writing profile.md)](#coherence-checks-before-writing-profilemd)
 
 Full procedure for the two pre-write phases scout runs before it
 emits any content files: sampling the team's PR history to understand
@@ -198,6 +199,35 @@ value or `ASK`:
 11. **Squash / rebase / merge-commit** — optional; defaults to
     `squash`. Override if branch-protection demands a different
     strategy.
+
+### Coherence checks (before writing profile.md)
+
+Some field combinations are incoherent — record + flag, don't fix
+silently:
+
+- **`Bug filing style: story-subtask` requires `Issue tracker: jira`
+  or `azure-boards`.** Sub-task is a Jira/ADO primitive; GitHub
+  Issues / GitLab Issues / Linear have no equivalent. If the operator
+  pre-filled `story-subtask` with a flat tracker, ask interactively
+  rather than silently degrading to `github-issue`. Note the answer
+  in the Step 0.7 report.
+- **`Bug filing target` is meaningful only when `Bug filing style:
+  separate-ticket`.** Empty otherwise. If the operator set both
+  `style: github-issue` and a non-empty `target`, ask whether they
+  meant `separate-ticket`.
+- **`Test case storage: tms` or `both-synced` requires
+  `TMS != none`.** A TMS-storage policy without a TMS adapter is
+  unwriteable. Ask the operator, or downgrade to `markdown` and flag.
+- **`Automation PR base` should match `Merge policy` reality.** If
+  the base is the project's default branch *and* `Merge policy:
+  manual`, that's a contradiction worth surfacing — the team
+  presumably wants PM to merge somewhere protected; confirm the base
+  is what they meant.
+
+The check happens after the operator pre-fill and any interactive
+asks, before scout writes `profile.md`. Surface incoherent
+combinations in the Step 0.7 report alongside the resolved values so
+the operator sees what was changed and why.
 
 ### Destination
 

--- a/skills/seeding-a-project/references/templates.md
+++ b/skills/seeding-a-project/references/templates.md
@@ -494,61 +494,120 @@ Detected from codebase analysis. These are descriptive (what IS), not prescripti
 
 ## .agents/testing.md Template
 
+Scout's read by Sage (qa-engineer) and Axel (test-automation-engineer)
+before they touch tests. **Treat the sections below as themes, not
+required fields.** Scout fills what the repo actually evidences; unknown
+or absent topics are flagged under § Unconfirmed so agents know to ask
+PM before improvising. Stay short — link to deeper docs rather than
+restating them.
+
 ```markdown
-# Test Infrastructure
+# Testing
+
+> Scout-generated. Update when the framework, run commands, or
+> conventions change. Agents read this before adding tests.
 
 ## Framework
-- **Unit/Integration:** pytest / jest / vitest
-- **E2E:** Playwright / Cypress / none
-- **API:** httpx / supertest / curl
+- **Name + version:** e.g. Playwright 1.47 / Cypress 13 / pytest 8 +
+  playwright-python 0.4 / WDIO 8 / JUnit 5 + Playwright-Java / NUnit 4
+- **Why this stack** (only if non-obvious from the repo)
 
-## Commands
-```bash
-# All tests
-[command]
-
-# Unit only
-[command]
-
-# Integration (requires DB)
-[command]
-
-# E2E (requires running app)
-[command]
-
-# Coverage
-[command]
-```
+## Run commands
+- **Single test, local:** exact command (include env wrappers and
+  reporter flags if the project uses them — e.g.
+  `npx cross-env TEST_ENV_NAME=SIT1 LOCAL_RUN=true npx playwright test path/to/spec --grep TC-001 --reporter=list`)
+- **Whole suite, local:** exact command
+- **CI variant — what the pipeline actually runs:** exact command,
+  verbatim. Tests Axel writes must be runnable with this command.
+- **Differences to flag** (headless vs headed, viewport, retry count,
+  env, …) — anything that changes test behavior between local and CI.
 
 ## Structure
-```
-tests/
-├── unit/              ← No external deps, fast
-├── integration/       ← Real DB, slower
-├── e2e/               ← Full stack, Playwright
-├── conftest.py        ← Shared fixtures
-└── fixtures/          ← Test data files
-```
+- **Tests live in:** `tests/` / `e2e/` / `cypress/e2e/` /
+  `src/test/java/` / …
+- **Folder roles** (one line each — omit folders that don't exist; don't
+  invent):
+  - `<dir>/specs/` or `<dir>/` — test files; grouped by feature, not by
+    ticket ID
+  - `<dir>/pages/` — Page Object classes (if used)
+  - `<dir>/steps/` — extracted `test.step` helpers (if extracted; some
+    teams keep `test.step()` inline in spec files instead — record which)
+  - `<dir>/fixtures/` — framework fixtures (Playwright / pytest /
+    JUnit-extensions)
+  - `<dir>/helpers/` — utility functions, **grouped by topic** (one file
+    per topic, e.g. `helpers/auth.ts`, `helpers/api/orders.ts`).
+    Suite-local helpers stay in the spec file
+  - `<dir>/data/` — test data (JSON / CSV / SQL fixtures)
 
-## Fixtures & Setup
-- Database: [real / mocked / in-memory SQLite]
-- Auth: [fixture / factory / skip]
-- Test data: [factories / fixtures / inline]
+## Test data strategy
+- **Where data lives** (path)
+- **Generation pattern:** generate-per-test / reuse-shared-with-cleanup /
+  static-fixtures / mixed — and **how to tell which applies for a new
+  test**
+- **Cleanup ownership:** afterEach / afterAll / external script / none
+- **Anything project-specific** (tenant scoping, env-keyed subfolders
+  like `data/sit1/`, factories vs JSON, …)
 
-## Patterns Detected
-- Arrange-Act-Assert structure
-- One test file per source module
-- Shared fixtures in conftest.py
-- Test markers: @pytest.mark.slow, @pytest.mark.integration
+## Hooks, fixtures, and run-mode policy
+- **Auto-applied hooks** the framework wires in (authed session,
+  base URL, browser context …) — name + where they live
+- **Project-wide teardown / reset** — name + trigger
+- **Serial vs parallel rule:** when does the project enforce serial
+  mode (`test.describe.configure({ mode: 'serial' })` or equivalent)?
+  Data dependency is the usual reason — document the rule explicitly so
+  Axel applies it correctly when AFS test-data inventory signals shared
+  state.
 
-## CI Integration
-- Tests run on: [push / PR / both]
-- Config: `.github/workflows/test.yml`
-- Timeout: [X minutes]
-- Coverage threshold: [X% or none]
+## Locator strategy
+- **Ladder** (preferred order):
+  `getByRole` with accessible name → `getByTestId` / `data-testid` →
+  `getByLabel` / `getByPlaceholder` → `getByText` →
+  CSS / XPath as last resort (with a comment explaining why)
+- **Stop+flag rule:** if a target element has no test ID **and** roles
+  / labels are insufficient (multi-match accessible name, no a11y
+  affordance), Axel pauses and surfaces the gap to PM rather than
+  falling back to brittle CSS chains.
+- **Edge cases & project exceptions** — record any selectors where the
+  default ladder doesn't fit (e.g. a component library that wraps role
+  internally; legacy widgets with no accessibility tree)
+- **Existing testid convention** — pattern + example
+  (e.g. `data-testid="<feature>-<element>"`)
 
-## Known Issues
-- [Any flaky tests, slow tests, skip reasons]
+## Reporters & evidence
+- **Local artifacts:** where the framework writes them
+  (`playwright-report/`, `test-results/screenshots/`, …)
+- **CI artifacts:** what the pipeline uploads (HTML report, JSON,
+  videos)
+- **Step logger / reporter:** Allure / `test.step` / custom — name and
+  how to extend, so Axel integrates rather than introducing a new one
+
+## CI integration
+- **Workflow file:** `.github/workflows/<name>.yml` (or GitLab CI /
+  Azure Pipelines equivalent)
+- **Trigger:** on push / PR / both
+- **Timeout & retry policy:** [X min; project-default retry count]
+- **Coverage threshold:** [X% or N/A]
+
+## Conventions to follow when adding tests
+> Bullets — short, observed-from-repo. Aspirational rules go in the
+> framework guide; this section captures what the project actually does.
+- One `describe` per feature file; tests grouped by feature
+- Steps inline OR extracted to `<dir>/steps/` — pick whichever the
+  project uses
+- Helpers grouped by topic; suite-local helpers stay in the spec file
+- Env values via the project's existing loader; **grep for an existing
+  key before adding a new one** (no duplicate config)
+- Data-dependent tests run in serial mode
+- Helpers are trusted: when a test fails and the helper has worked
+  elsewhere, suspect the test first
+
+## Known issues
+- [Flaky areas, slow suites, environments with known incompatibilities,
+  any framework-version pitfalls]
+
+## Unconfirmed
+- [Scout's flagged gaps — Axel and Sage ask PM/user before improvising
+  on these]
 ```
 
 ---


### PR DESCRIPTION
Two surgical enrichments to `seeding-a-project` aimed at test-automation onboarding quality:

- `references/templates.md` — `.agents/testing.md` template gets test-automation-specific sections (Test data strategy, Hooks/fixtures/run-mode policy, Locator strategy, Reporters & evidence, Conventions to follow when adding tests, Unconfirmed). Sage and Axel read this before touching tests; richer template = fewer downstream improvisations.
- `references/scout-survey.md` — new Coherence checks subsection in Step 0.7 catching incoherent profile.md field combinations (e.g. `story-subtask` requires Jira/Azure, `Bug filing target` only meaningful for `separate-ticket`).