### PR TITLE
Add Session End memory write protocol to non-TA agents

### DIFF
--- a/agents/ba/AGENT.md
+++ b/agents/ba/AGENT.md
@@ -204,3 +204,12 @@ Never silently expand scope. Every addition is a conscious decision.
 - When presenting options: "Option A: [description]. Option B: [description]. I recommend A because [reason]."
 - When something is ambiguous: present two interpretations, ask the user to choose
 - Keep handoff messages structured: story ID, title, status, open questions
+
+## Session End — Memory (MANDATORY)
+
+Before returning your result — even when spawned as a sub-agent:
+
+1. **Always:** invoke the `memory` skill → **Log** op — task worked on, key findings or decisions, any blockers or gaps.
+2. **When applicable:** invoke the `memory` skill → **Write** op for any durable fact: a recurring pattern, a correction received, a domain clarification, a stakeholder preference.
+
+If unsure whether something is durable — log it. The skill covers format and file layout.

--- a/agents/ios-dev/AGENT.md
+++ b/agents/ios-dev/AGENT.md
@@ -227,3 +227,12 @@ you intended; "I implemented it locally" is not done.
 - `git --no-pager` always. Never commit unless asked.
 - Never force-push or reset without confirmation.
 - Prefer small, focused commits. Message explains *why*, not *what*.
+
+## Session End — Memory (MANDATORY)
+
+Before returning your result — even when spawned as a sub-agent:
+
+1. **Always:** invoke the `memory` skill → **Log** op — task worked on, key findings or decisions, any blockers or gaps.
+2. **When applicable:** invoke the `memory` skill → **Write** op for any durable fact: a recurring quirk, a correction received, a workaround found, a new file added to the project.
+
+If unsure whether something is durable — log it. The skill covers format and file layout.

--- a/agents/js-dev/AGENT.md
+++ b/agents/js-dev/AGENT.md
@@ -171,3 +171,12 @@ tsc --noEmit → tests → lint → diff stat. Fix failures before moving on.
 - `git --no-pager` always. Never commit unless asked.
 - Never force-push or reset without confirmation.
 - Prefer small, focused commits. Message explains *why*, not *what*.
+
+## Session End — Memory (MANDATORY)
+
+Before returning your result — even when spawned as a sub-agent:
+
+1. **Always:** invoke the `memory` skill → **Log** op — task worked on, key findings or decisions, any blockers or gaps.
+2. **When applicable:** invoke the `memory` skill → **Write** op for any durable fact: a recurring quirk, a correction received, a workaround found, a new file added to the project.
+
+If unsure whether something is durable — log it. The skill covers format and file layout.

--- a/agents/personal-assistant/AGENT.md
+++ b/agents/personal-assistant/AGENT.md
@@ -182,3 +182,7 @@ After processing signals:
 - Modify `access-control.yaml` or `USER.md`
 - Delete vault notes
 - Overwrite a daily note
+
+## Session End
+
+Before returning your result: append a daily log entry (§ Operational memory). Write a curated entry for any durable fact learned this session — user preference, new contact, project constraint, correction received.

--- a/agents/python-dev/AGENT.md
+++ b/agents/python-dev/AGENT.md
@@ -170,3 +170,12 @@ py_compile → tests → diff stat. Fix failures before moving on.
 - Never commit directly to `main`/`master` — always a feature branch. Never force-push or reset a shared branch without explicit confirmation.
 - For assigned task work, committing and pushing is part of task completion — the `completing-a-task` skill is your authoritative guide. For ad-hoc exploration in a user-driven interactive session, ask before committing.
 - Prefer small, focused commits. Message explains *why*, not *what*.
+
+## Session End — Memory (MANDATORY)
+
+Before returning your result — even when spawned as a sub-agent:
+
+1. **Always:** invoke the `memory` skill → **Log** op — task worked on, key findings or decisions, any blockers or gaps.
+2. **When applicable:** invoke the `memory` skill → **Write** op for any durable fact: a recurring quirk, a correction received, a workaround found, a new file added to the project.
+
+If unsure whether something is durable — log it. The skill covers format and file layout.


### PR DESCRIPTION
Suggestion PR to fill a gap I kept hitting in practice.

**Problem observed:** subagents (`ba`, `ios-dev`, `js-dev`, `python-dev`, `personal-assistant`) consistently miss their memory write at the end of a session — task summaries don't get logged, durable facts don't get written. Hooks cover the **read** side (SessionStart / SubagentStart inject memory + context), but there's no Stop/SessionEnd hook for the **write** side, and the AGENT.md files for these 5 agents don't carry the protocol in prose either.

The TA agents (TAL, qa-engineer, test-automation-engineer) already have `## Session End — Memory (MANDATORY)`. This PR adds the same block to the 5 non-TA agents that were missing it. Role-specific "Write op" examples per agent (e.g. ios-dev gets "workaround found, new file added"; ba gets "stakeholder preference, domain clarification"; personal-assistant gets its simpler daily-log variant).

Treat this as a **suggestion** — happy to adjust wording or scope.

**Scope:** +40 lines across 5 AGENT.md files. No frontmatter changes, no other files touched.