### PR TITLE
Add BUNDLE.md catalog descriptors + make web-qa lead orchestrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ ship today:
 |---|---|---|
 | `team-web` | shared core + python-dev/js-dev + QA | JS/TS frontend + FastAPI/FastMCP backend delivery team |
 | `team-ios` | shared core + ios-dev + QA | Swift / SwiftUI delivery team |
-| `web-qa` | 5 bundle-local agents (setup, tc-writer, orchestrator, executor, reporter) | Manual-QA team — onboard an app, author test cases, run them live via Playwright MCP, and report. Ships its own agents and seeds the test-case/report-format reference docs into `.agents/web-qa/knowledge/`. |
+| `web-qa` | 6 bundle-local agents (app-profiler, test-sizer, test-author, test-run-lead, test-runner, test-reporter) | Manual-QA team — `app-profiler` onboards the app, then `test-run-lead` orchestrates a run: authoring (`test-author`) and sizing (`test-sizer`) cases when needed, running them live via Playwright MCP (`test-runner`), and reporting (`test-reporter`). Ships its own agents and seeds the test-case/report-format reference docs into `.agents/web-qa/knowledge/`. |
 | `test-automation` | shared core (scout) + test-automation-engineer + qa-engineer + bundle-local `test-automation-lead` (Tal) | Automation-focused team — Tal orchestrates the analyst → implementer → reviewer pipeline, owns test-framework architecture and the automation merge gate. Pins `test-automation-workflow` + `test-case-analysis`; TMS-agnostic. |
 
 See [`bundles/SPEC.md`](bundles/SPEC.md) and each bundle's `README.md` to

--- a/bin/validate-bundles.mjs
+++ b/bin/validate-bundles.mjs
@@ -2,7 +2,9 @@
 // Validate every bundles/<id>/bundle.json against the repo. Run in CI and
 // before publishing. Checks, per bundle:
 //   - directory name matches manifest `id`
-//   - a README.md exists (the team's front-door doc)
+//   - a README.md exists (the team's front-door doc, human/LLM-readable)
+//   - a BUNDLE.md exists with non-empty name/description/owner frontmatter
+//     (the structured catalog descriptor)
 //   - `agents` is a non-empty array and every entry exists under agents/
 //   - every `briefings` role is in `agents` and its file exists
 //   - every `skills` id resolves in skills.json (or a monorepo skills/ dir)
@@ -16,6 +18,19 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
 const PKG_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Parse the YAML frontmatter of a BUNDLE.md into a flat key→value map.
+// Only the simple `key: value` lines we care about — no full YAML needed.
+function parseFrontmatter(text) {
+  const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const out = {};
+  for (const line of m[1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (kv) out[kv[1]] = kv[2].trim();
+  }
+  return out;
+}
 
 function dirsWith(parent, marker) {
   const root = join(PKG_ROOT, parent);
@@ -79,6 +94,17 @@ function main() {
 
     if (b.id !== id) err(id, `manifest id "${b.id}" != directory name "${id}"`);
     if (!existsSync(join(dir, "README.md"))) err(id, "missing README.md");
+
+    const bundleMd = join(dir, "BUNDLE.md");
+    if (!existsSync(bundleMd)) {
+      err(id, "missing BUNDLE.md (catalog descriptor)");
+    } else {
+      const fm = parseFrontmatter(readFileSync(bundleMd, "utf8"));
+      if (!fm) err(id, "BUNDLE.md has no YAML frontmatter");
+      else
+        for (const k of ["name", "description", "owner"])
+          if (!fm[k]) err(id, `BUNDLE.md frontmatter missing "${k}"`);
+    }
 
     const hasLocal = Array.isArray(b.localAgents) && b.localAgents.length > 0;
     const declaredAgents = Array.isArray(b.agents) ? b.agents : [];

--- a/bundles/SPEC.md
+++ b/bundles/SPEC.md
@@ -47,8 +47,9 @@ exist globally is still possible via `localAgents` (an escape hatch).
 
 ```
 bundles/<id>/
-├── bundle.json              required — the manifest
+├── BUNDLE.md                required — structured catalog descriptor (name/description/owner frontmatter)
 ├── README.md                required — the team's front-door doc (roster, install, how it works)
+├── bundle.json              required — the manifest
 ├── instructions.md          optional — team-level guidance
 ├── briefings/
 │   └── <role>.md            optional — per-role stack overlay
@@ -59,6 +60,34 @@ bundles/<id>/
 └── agents/                  optional — bundle-local roles (escape hatch)
     └── <name>/               installed like a global agent (AGENT.md + SOUL.md)
 ```
+
+## `BUNDLE.md` — structured catalog descriptor
+
+The catalog identifies a bundle by the presence of a `BUNDLE.md` file in the
+bundle folder. It's the bundle's **structured** identity — essentially a
+`.md.yaml`: YAML frontmatter with three fields and little or no prose. All
+skills and agents nearby are treated as artifacts of that bundle and displayed
+together in the catalog.
+
+```markdown
+---
+name: Web Team                # human label
+description: Fullstack web…    # short, concise summary
+owner: AIRUN                   # practice, project, team, or group of people
+---
+
+See [`README.md`](README.md) for the roster, install steps, and how the team works.
+```
+
+`BUNDLE.md` and `README.md` sit side by side, with distinct jobs:
+
+- **`BUNDLE.md`** — structured info the catalog parses directly (name,
+  description, owner).
+- **`README.md`** — the human/LLM-readable front-door doc (roster, install,
+  how it works); the catalog can generate a richer summary from it.
+- **`bundle.json`** — the install manifest that drives `init.mjs`.
+
+The descriptor carries no install config.
 
 ## `bundle.json` schema
 
@@ -159,7 +188,8 @@ machinery is in place; concrete hooks (format-on-edit, etc.) come later.
   no-op (or a clean refresh with `--update`) and allow clean removal.
 - **`npm run validate:bundles`** (`bin/validate-bundles.mjs`, run in CI via
   `.github/workflows/validate.yml`) checks each bundle: dir name matches
-  `id`, a `README.md` exists, `agents[]` is non-empty and every entry exists
+  `id`, a `README.md` exists, a `BUNDLE.md` exists with non-empty
+  `name`/`description`/`owner` frontmatter, `agents[]` is non-empty and every entry exists
   under `agents/`, every `briefings` role is in `agents[]` and its file
   exists, every `skills[]` id resolves in `skills.json`/`skills/`,
   `instructions` (if set) exists, `hooks` (if set) parses, each

--- a/bundles/team-ios/BUNDLE.md
+++ b/bundles/team-ios/BUNDLE.md
@@ -1,0 +1,7 @@
+---
+name: iOS Team
+description: iOS delivery team — Swift/SwiftUI development, QA, and core roles.
+owner: AIRUN
+---
+
+See [`README.md`](README.md) for the roster, install steps, and how the team works.

--- a/bundles/team-web/BUNDLE.md
+++ b/bundles/team-web/BUNDLE.md
@@ -1,0 +1,7 @@
+---
+name: Web Team
+description: Fullstack web delivery team — JS/TS frontend, Python backend, QA, and core roles.
+owner: AIRUN
+---
+
+See [`README.md`](README.md) for the roster, install steps, and how the team works.

--- a/bundles/test-automation/BUNDLE.md
+++ b/bundles/test-automation/BUNDLE.md
@@ -1,0 +1,7 @@
+---
+name: Test Automation Team
+description: Automation team that turns TMS cases into merged, honest automated tests via an analyst → implementer → reviewer pipeline.
+owner: AIRUN
+---
+
+See [`README.md`](README.md) for the roster, install steps, and how the team works.

--- a/bundles/web-qa/BUNDLE.md
+++ b/bundles/web-qa/BUNDLE.md
@@ -1,0 +1,7 @@
+---
+name: Web QA Team
+description: Standalone agentic manual-QA team for web apps — onboard, author cases, run live via Playwright MCP, and report.
+owner: AIRUN
+---
+
+See [`README.md`](README.md) for the roster, install steps, and how the team works.

--- a/bundles/web-qa/README.md
+++ b/bundles/web-qa/README.md
@@ -17,8 +17,8 @@ into `.agents/web-qa/knowledge/`, and splices the team conventions into
 ## Quick start
 
 The team runs in **three phases**. Unlike the other bundles there is no
-`scout` and no single orchestrator: `app-profiler` onboards, then you run
-the authoring/running agents **in order**.
+`scout`: `app-profiler` onboards the app, then `test-run-lead` orchestrates
+the rest — it authors and sizes cases when needed, runs them, and reports.
 
 **Install (once)** — `npx github:arozumenko/sdlc-skills init --bundle web-qa`.
 Installs the 6 agents into `.claude/agents/`, seeds reference docs into
@@ -34,17 +34,24 @@ reliable selectors, fragile areas). **Why it's first:** there's no scout
 here — `app-profiler` is the onboarding agent, and every other web-qa agent
 reads this profile before acting.
 
-**Phase 2 — Usage (size → author → run).**
-- **`test-sizer`** (optional) rates cases S/M/L for agent-execution cost.
-- **`test-author`** turns a feature/flow description into
-  `tasks/<suite>/TC-NNN_<slug>.md` (URLs as `{{base_url}}/path`).
-- **`test-run-lead`** — launch as the **active agent** with a `base_url`. It
-  discovers the suite, dispatches one `test-runner` per case (each runs live
-  via Playwright MCP and must capture a confirming snapshot to record PASS),
-  then triggers `test-reporter` to write `reports/RUN-YYYY-MM-DD-NNN.md`.
-  Don't invoke `test-runner` / `test-reporter` by hand during a led run.
-  **The logic:** every agent reads `app_profile.md` for selectors and auth,
-  so cases and runs stay grounded in the real app.
+**Phase 2 — Usage (`test-run-lead` orchestrates).** Launch `test-run-lead` as
+the **active agent** with a suite path and `base_url` — it's the single
+orchestrator for a run. It assembles the suite first, dispatching sub-agents
+*when needed*:
+- **`test-author`** — when the suite has no cases yet and you've given
+  descriptions/flows to work from, it writes `tasks/<suite>/TC-NNN_<slug>.md`
+  (URLs as `{{base_url}}/path`).
+- **`test-sizer`** — when cases lack a `size:`, it scores them S/M/L for
+  agent-execution cost and writes it into their frontmatter.
+
+Then it runs the suite: one `test-runner` per case (each runs live via
+Playwright MCP and must capture a confirming snapshot to record PASS),
+followed by `test-reporter` writing `reports/RUN-YYYY-MM-DD-NNN.md`. You talk
+only to the lead — don't invoke `test-sizer` / `test-author` / `test-runner` /
+`test-reporter` by hand during a led run (you can still run sizer/author
+standalone for authoring outside a run). **The logic:** every agent reads
+`app_profile.md` for selectors and auth, so cases and runs stay grounded in
+the real app.
 
 **Phase 3 — Reinforcement (assisted; you curate — there's no scout here).**
 The project's knowledge lives in durable, growing artifacts that every agent
@@ -69,17 +76,19 @@ flowchart TD
         profiler --> profile
     end
 
-    subgraph p2["Phase 2 — Usage · you launch these in order"]
-        sizer["test-sizer — rate S/M/L (optional)"]
-        author["test-author — write TC-NNN files"]
-        lead["test-run-lead — active agent,<br/>owns the run loop"]
+    subgraph p2["Phase 2 — Usage · you launch test-run-lead (orchestrator)"]
+        lead["test-run-lead — active agent,<br/>orchestrates the run"]
+        author["test-author — write TC-NNN files<br/>(when cases missing)"]
+        sizer["test-sizer — rate S/M/L<br/>(when cases unsized)"]
         runner["test-runner — run one case<br/>live via Playwright MCP"]
         reporter["test-reporter — write run report"]
-        sizer --> author --> lead
-        lead -->|dispatches| runner --> reporter
+        lead -->|"when needed"| author
+        lead -->|"when needed"| sizer
+        lead -->|"per case"| runner
+        lead -->|"at end"| reporter
     end
 
-    profile -->|"every agent reads it"| sizer
+    profile -->|"every agent reads it"| lead
 
     subgraph p3["Phase 3 — Reinforcement · assisted (you curate)"]
         artifacts[(".agents/web-qa/app_profile.md<br/>tasks/ suite · reports/ history")]
@@ -96,14 +105,18 @@ flowchart TD
 | `app-profiler` | profiler | Onboards the app — explores the UI, maps flows, writes `.agents/web-qa/app_profile.md` |
 | `test-sizer` | sizer | Rates cases S/M/L for AI-agent execution cost; sizes descriptions before authoring and scores existing TC files into their `size:` frontmatter |
 | `test-author` | author | Takes a feature or flow description and authors formatted test cases under `tasks/<suite>/` |
-| `test-run-lead` | lead | Discovers the suite to run, dispatches `test-runner` sub-runs via the Agent tool, triggers `test-reporter` |
+| `test-run-lead` | lead | **Run orchestrator** — assembles the suite (dispatches `test-author` / `test-sizer` when needed), runs one `test-runner` per case, triggers `test-reporter` |
 | `test-runner` | runner | Runs one test case live via Playwright MCP and emits a structured JSON result |
 | `test-reporter` | reporter | Collects test-runner results and writes the run report to `reports/` |
 
 ## How this team works
 
-Run the agents in order: **app-profiler → test-sizer → test-author → test-run-lead → test-runner → test-reporter**. `test-run-lead` owns the run loop and must be invoked as the
-**active agent** (it dispatches `test-runner` sub-runs via the Agent tool).
+Onboard once with **app-profiler**, then drive **test-run-lead** — the single
+run orchestrator. It must be invoked as the **active agent**; it dispatches
+`test-author` and `test-sizer` to assemble the suite when needed, then a
+`test-runner` per case and `test-reporter` at the end (all via the Agent
+tool). You can also run `test-sizer` / `test-author` standalone for authoring
+outside a run.
 
 Test cases live in `tasks/<suite>/TC-NNN_<slug>.md`; run reports land in
 `reports/RUN-YYYY-MM-DD-NNN.md` with screenshots in `reports/screenshots/`.

--- a/bundles/web-qa/agents/test-run-lead/AGENT.md
+++ b/bundles/web-qa/agents/test-run-lead/AGENT.md
@@ -1,6 +1,6 @@
 ---
 name: test-run-lead
-description: Use when running a full manual-QA suite — discovers all test cases in a suite folder, dispatches a test-runner per case (sequentially) via the Agent tool, collects JSON results plus usage metrics, detects isolation issues, and triggers the test-reporter. Run this agent as the active agent and give it a suite path + base_url.
+description: Use when running a manual-QA suite — assembles the suite first (authoring missing cases via test-author and sizing unsized ones via test-sizer, when needed), then dispatches a test-runner per case (sequentially) via the Agent tool, collects JSON results plus usage metrics, detects isolation issues, and triggers the test-reporter. The single orchestrator for a run: run it as the active agent and give it a suite path + base_url.
 model: sonnet
 group: qa
 color: green
@@ -12,7 +12,7 @@ metadata:
   author: "Olha Stetsenko (git: olexis-st)"
 ---
 
-You are a QA Test-Run Lead Agent. You manage a complete test run from discovery to final report.
+You are a QA Test-Run Lead Agent. You orchestrate a complete test run — from assembling the suite (authoring and sizing cases when needed) through execution to the final report. You are the **single orchestrator** for a run: the user talks to you, and you dispatch `test-author`, `test-sizer`, `test-runner`, and `test-reporter` as sub-agents via the Agent tool.
 
 ## Before You Start
 
@@ -20,19 +20,37 @@ Check whether `.agents/web-qa/app_profile.md` exists.
 - If it does NOT exist: warn the user — "No app_profile.md found. Consider running `/agent app-profiler` first to configure selectors and credentials for your app. Proceeding anyway..."
 - If it exists: note that test-runner agents will use it for context.
 
-## Step 1 — Discover Test Cases
+## Step 1 — Assemble the Suite (author when needed)
 
 Use `Glob` to find all `TC-*.md` files in the provided suite folder.
-- Sort by filename (alphabetical = numerical order with zero-padded IDs)
-- If no files found: stop and tell the user — "No test cases found in `{path}`. Create test cases first using `/agent test-author`."
+- If cases exist: sort by filename (alphabetical = numerical order with zero-padded IDs) and proceed to Step 2.
+- If **no** files are found, decide based on what the user gave you:
+  - **There is material to author from** (the request includes feature/flow descriptions, a user story, a bug report, or points at a spec) → dispatch `test-author` to create the cases, then re-`Glob`:
+    ```
+    Agent: test-author
+    Prompt: "Author test cases for {suite_path} from: {the descriptions / material the user provided}. Read .agents/web-qa/app_profile.md for base_url, credentials, selectors, and suite structure."
+    ```
+    `test-author` reads the app profile and asks only for what it cannot infer.
+  - **There is nothing to author from** → stop and ask the user for either existing test cases or descriptions to author from. Do not invent cases out of thin air.
 
-## Step 2 — Create Run ID
+## Step 2 — Size Unsized Cases (when needed)
+
+Read each TC file's frontmatter and check for a `size:` value.
+- For any case **missing** `size:`, dispatch `test-sizer` to score it (it writes `size:` into the frontmatter via Edit):
+  ```
+  Agent: test-sizer
+  Prompt: "Score the size (S/M/L) of these test cases and write `size:` into each file's frontmatter: {paths of unsized TC files}"
+  ```
+- Cases that already have a `size:` are left as-is.
+- Sizing is preparatory, not a gate — if `test-sizer` can't size a case, note it and proceed to the run anyway.
+
+## Step 3 — Create Run ID
 
 Format: `RUN-{YYYY-MM-DD}-{NNN}` where NNN is zero-padded and starts at 001.
 - Use `Glob` on `reports/RUN-{YYYY-MM-DD}-*.md` to find today's existing runs
 - Increment sequence number accordingly
 
-## Step 3 — Execute Test Cases (sequential)
+## Step 4 — Execute Test Cases (sequential)
 
 For each TC file, dispatch a `test-runner` sub-agent via the Agent tool:
 
@@ -68,14 +86,14 @@ Attach all three fields to the result object.
 
 **If the `<usage>` block is absent**, set `tokens: null, tool_uses: null, duration_ms: null` — the test-reporter will omit the Performance Metrics section gracefully.
 
-## Step 4 — Verify Results (verification-before-completion)
+## Step 5 — Verify Results (verification-before-completion)
 
 Before proceeding to the report:
 - Count: `results_collected` == `tc_files_found`
 - If counts differ: investigate which TCs are missing and add BLOCKED entries
 - Only proceed when every TC has a result entry
 
-## Step 4b — Detect Test Isolation Issues (systematic-debugging)
+## Step 5b — Detect Test Isolation Issues (systematic-debugging)
 
 Before generating the report, scan the `failure_reason` of every FAIL result for isolation signals:
 
@@ -85,7 +103,7 @@ Before generating the report, scan the `failure_reason` of every FAIL result for
 | "still in cart", "leftover", "previous" | State leaked from an earlier test case |
 | "already logged in", "session active" | Login state not cleaned up by prior test |
 
-If any match: add a warning to the Step 6 summary:
+If any match: add a warning to the Step 7 summary:
 ```
 ⚠️ Possible test isolation issue — {TC-ID}: {failure_reason}
    Check Teardown section of the test case. Consider running the suite again after manual cleanup.
@@ -93,7 +111,7 @@ If any match: add a warning to the Step 6 summary:
 
 This distinguishes a **test design bug** from an **application bug** — both need different follow-up actions.
 
-## Step 5 — Generate Report
+## Step 6 — Generate Report
 
 Dispatch a `test-reporter` sub-agent via the Agent tool:
 
@@ -104,7 +122,7 @@ Prompt: "Generate test run report with run_id={run_id}, suite={suite_name}, envi
 
 The `json_array` must include `tokens`, `tool_uses`, `duration_ms` on every result object.
 
-## Step 6 — Summary to User
+## Step 7 — Summary to User
 
 Print:
 ```
@@ -125,8 +143,13 @@ Failed tests:
 ```
 Run suite tasks/smoke against https://app.example.com
 Run all tests in tasks/regression/ against https://staging.myapp.com
+Build and run a checkout smoke suite at tasks/checkout against https://app.example.com:
+  - guest can add an item and reach the payment step
+  - logged-in user can complete a purchase with a saved card
 ```
 
-Parse the suite path and base_url. If base_url is missing, ask the user before proceeding.
+Parse the suite path and base_url. If base_url is missing, ask the user before
+proceeding. When the request includes scenario descriptions (as above) and the
+suite has no cases yet, author them first (Step 1) before running.
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.

--- a/bundles/web-qa/agents/test-run-lead/SOUL.md
+++ b/bundles/web-qa/agents/test-run-lead/SOUL.md
@@ -17,5 +17,5 @@ You are an orderly conductor. Every test case gets a result. No case is silently
 ## Working Style
 
 - You are methodical without being slow. Each step has a clear completion signal before the next begins.
-- You delegate faithfully: test-runners execute, the test-reporter reports. You lead the run, collect, and verify.
-- You never write the report yourself — that belongs to the test-reporter agent.
+- You delegate faithfully: test-author writes cases, test-sizer sizes them, test-runners execute, the test-reporter reports. You orchestrate — assembling the suite when needed, then leading the run, collecting, and verifying.
+- You never author, size, run, or report yourself — each belongs to its own agent. You bring in test-author and test-sizer only when the suite needs them, and you never substitute for them.

--- a/bundles/web-qa/instructions.md
+++ b/bundles/web-qa/instructions.md
@@ -6,18 +6,25 @@ which always wins over this file.
 
 ## Pipeline
 
-Each stage hands off to the next; invoke agents in order:
+Onboard once with `app-profiler`, then drive `test-run-lead` — it is the
+single orchestrator for a run and brings in the authoring/sizing agents when
+the suite needs them. You can still invoke `test-sizer` or `test-author`
+standalone for authoring work outside a run.
 
 - **`app-profiler`** — run once to onboard the app: explores the UI, records its
   structure and flows, and writes `.agents/web-qa/app_profile.md`.
+- **`test-run-lead`** — the run orchestrator; run it as the **active agent**
+  (it uses the Agent tool to spawn sub-runs). Assembles the suite first —
+  dispatching **`test-author`** to write missing cases and **`test-sizer`** to
+  size unsized ones, *when needed* — then dispatches one `test-runner` per
+  case and triggers `test-reporter`.
 - **`test-sizer`** — rates cases S/M/L for AI-agent execution cost: sizes rough
   descriptions before authoring (flagging Large ones to split) and scores
-  existing TC files, writing `size:` into their frontmatter.
+  existing TC files, writing `size:` into their frontmatter. Dispatched by the
+  lead, or run standalone.
 - **`test-author`** — takes a feature or flow description and writes formatted
-  test cases under `tasks/<suite>/TC-NNN_<slug>.md`.
-- **`test-run-lead`** — run as the **active agent** (it uses the Agent tool
-  to spawn sub-runs). Discovers the suite to execute, dispatches one
-  `test-runner` sub-run per test case, then triggers `test-reporter`.
+  test cases under `tasks/<suite>/TC-NNN_<slug>.md`. Dispatched by the lead, or
+  run standalone.
 - **`test-runner`** — receives a single `TC-NNN` file path and a `base_url`;
   runs the case live via Playwright MCP; emits a structured JSON result.
 - **`test-reporter`** — collects test-runner results and writes the run report to
@@ -47,6 +54,8 @@ A PASS without a confirming snapshot is invalid.
 
 ## Test-run-lead is the active agent
 
-Run `test-run-lead` directly (not via another agent). It owns the run loop
-and dispatches `test-runner` sub-runs via the Agent tool — do not invoke
-`test-runner` manually when a led suite run is in progress.
+Run `test-run-lead` directly (not via another agent). It owns the run and
+dispatches sub-runs via the Agent tool — `test-author` / `test-sizer` to
+assemble the suite when needed, then `test-runner` per case and
+`test-reporter` at the end. Do not invoke `test-runner` manually when a led
+suite run is in progress.


### PR DESCRIPTION
## Summary

Two related changes to the bundles, driven by a publisher CR.

### 1. `BUNDLE.md` catalog descriptors (publisher requirement)

The publisher's catalog identifies each bundle by a **`BUNDLE.md`** file. It's a *structured* descriptor (think `.md.yaml`): YAML frontmatter with `name` / `description` / `owner` (`owner: AIRUN` across all bundles) and minimal prose.

`BUNDLE.md` and `README.md` **coexist** with distinct jobs:
- **`BUNDLE.md`** — structured info the catalog parses directly.
- **`README.md`** — human/LLM-readable front-door doc (roster, install, how it works); the catalog generates a summary from it.
- **`bundle.json`** — unchanged install manifest driving `init.mjs`.

`bin/validate-bundles.mjs` now requires **both** `README.md` and `BUNDLE.md` (the latter with non-empty `name`/`description`/`owner` frontmatter, parsed via a small dependency-free helper). `bundles/SPEC.md` documents the split. We kept our own format rather than Microsoft APM.

### 2. web-qa: `test-run-lead` is now the single run orchestrator

Previously `test-run-lead` was scoped to runs only (discover existing cases → `test-runner` → `test-reporter`). It now **assembles the suite first**, dispatching sub-agents *when needed*:
- **`test-author`** — when the suite has no cases yet and descriptions/flows are provided (never fabricates cases otherwise).
- **`test-sizer`** — when cases lack a `size:` (preparatory, never a gate).

Then it runs `test-runner` per case and `test-reporter` at the end. Updates `AGENT.md`, `SOUL.md`, the bundle `instructions.md`, and the README flow narrative / mermaid / roster. Also fixes the stale web-qa roster row in the top-level README (was listing 5 outdated agent names).

## Validation

`npm run validate:bundles` → all 4 bundles valid. Negative-tested that a missing frontmatter field fails with a non-zero exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)