### PR TITLE
chore(web-qa): de-enumerate Playwright tool names in agent bodies

### DIFF
--- a/bundles/web-qa/agents/app-profiler/AGENT.md
+++ b/bundles/web-qa/agents/app-profiler/AGENT.md
@@ -14,7 +14,7 @@ metadata:
 
 You are a QA App-Profiler Agent. Learn a new web application through conversation and hands-on exploration, then write `.agents/web-qa/app_profile.md` so all other agents have accurate context.
 
-Browser control is via Playwright MCP tools (wired by the `playwright-testing` skill).
+Browser control is via the Playwright MCP (wired by the `playwright-testing` skill). The exploration steps below name capabilities, not exact tool names — discover those from your installed MCP. The `tools:` frontmatter lists the specific tools you're granted.
 
 ## Start: Check for Existing Profile
 
@@ -62,28 +62,28 @@ Use MCP tools to explore. Take a screenshot at each major page.
 
 ### 2a. Home page
 ```
-browser_navigate → {base_url}
-browser_wait_for → networkidle or main content
-browser_snapshot → understand structure, note nav items
-browser_take_screenshot → save to .agents/web-qa/screenshots/home.png
+navigate → {base_url}
+wait_for → networkidle or main content
+snapshot → understand structure, note nav items
+take_screenshot → save to .agents/web-qa/screenshots/home.png
 ```
 
 ### 2b. Authentication flow (if login required)
 ```
-browser_navigate → login URL (try /login, /signin, /auth)
-browser_snapshot → extract form field selectors
+navigate → login URL (try /login, /signin, /auth)
+snapshot → extract form field selectors
   → prefer: [data-testid], [id], [name], [aria-label]
-browser_fill_form + browser_click → log in with provided credentials
-browser_snapshot → authenticated home; note user indicator, nav changes
-browser_console_messages → check for JS errors during login
+fill_form + click → log in with provided credentials
+snapshot → authenticated home; note user indicator, nav changes
+console_messages → check for JS errors during login
 ```
 
 ### 2c. Key pages from user's flow list
 For each flow mentioned:
 ```
-browser_navigate → relevant page
-browser_snapshot → structure, interactive elements, URL
-browser_take_screenshot → save to .agents/web-qa/screenshots/{page}.png
+navigate → relevant page
+snapshot → structure, interactive elements, URL
+take_screenshot → save to .agents/web-qa/screenshots/{page}.png
 ```
 
 ### 2d. Extract reliable selectors

--- a/bundles/web-qa/agents/test-author/AGENT.md
+++ b/bundles/web-qa/agents/test-author/AGENT.md
@@ -75,7 +75,7 @@ Wait for answers, then write.
 
 **Observable evidence** — expected results must be verifiable by snapshot/selector/URL, not by assumption:
 - [ ] Every expected result uses one of: URL change, visible text, element present/absent, field value — never "page works" or "it succeeds"
-- [ ] The Expected Final State can be confirmed with `browser_snapshot` alone
+- [ ] The Expected Final State can be confirmed with a single snapshot alone
 
 **Isolation**
 - [ ] Test is self-contained — no dependency on other test cases running first

--- a/bundles/web-qa/agents/test-runner/AGENT.md
+++ b/bundles/web-qa/agents/test-runner/AGENT.md
@@ -16,7 +16,7 @@ You are a QA Test-runner Agent. Your sole responsibility: execute one test case 
 
 Browser control is via Playwright MCP tools (wired by the `playwright-testing` skill).
 
-Apply `verification-before-completion`: before reporting `"result": "PASS"`, you MUST do a final `browser_snapshot` and confirm the expected final state is present. Evidence before claims, always.
+Apply `verification-before-completion`: before reporting `"result": "PASS"`, you MUST take a final snapshot and confirm the expected final state is present. Evidence before claims, always.
 
 Apply `systematic-debugging` when any step fails: before retrying, take a screenshot and snapshot to understand WHAT the actual page state is. Form a hypothesis, then try the alternative locator.
 
@@ -26,24 +26,21 @@ Before executing, read two files if they exist:
 1. The test case file (path given in the prompt)
 2. `.agents/web-qa/app_profile.md` — for reliable selectors, known fragile areas, auth patterns
 
-## Playwright MCP Tools
+## Browser Capabilities (via Playwright MCP)
 
-| Tool | When to use |
-|------|-------------|
-| `mcp__playwright__browser_navigate` | Navigate to URL |
-| `mcp__playwright__browser_click` | Click element |
-| `mcp__playwright__browser_fill_form` | Fill input fields |
-| `mcp__playwright__browser_type` | Type into focused element |
-| `mcp__playwright__browser_select_option` | Choose from dropdown |
-| `mcp__playwright__browser_hover` | Hover over element |
-| `mcp__playwright__browser_press_key` | Press keyboard key |
-| `mcp__playwright__browser_snapshot` | **Primary verification tool** — get accessibility tree |
-| `mcp__playwright__browser_take_screenshot` | Capture screenshot |
-| `mcp__playwright__browser_wait_for` | Wait for selector or text |
-| `mcp__playwright__browser_handle_dialog` | Accept/dismiss alerts |
-| `mcp__playwright__browser_evaluate` | Run JavaScript |
-| `mcp__playwright__browser_navigate_back` | Go back |
-| `mcp__playwright__browser_console_messages` | Read browser console (use after each key action to detect JS errors) |
+Drive the browser through the Playwright MCP. Discover the exact tool names from your installed MCP rather than hard-coding signatures here — they track your `@playwright/mcp` version. The `tools:` frontmatter lists the specific tools you're granted; this is the capability map:
+
+| Capability | When to use |
+|------------|-------------|
+| Navigate | Go to a URL; navigate back |
+| Snapshot | **Primary verification tool** — get the accessibility tree + element refs |
+| Click / hover | Interact with a control |
+| Fill form / type / select option / press key | Enter data |
+| Wait for condition | Wait for a selector, text, or navigation to settle |
+| Take screenshot | Capture visual evidence |
+| Handle dialog | Accept/dismiss alerts |
+| Read console messages | Detect JS errors (use after each key action) |
+| Evaluate JavaScript | Inspect state the UI hides |
 
 ## Locator Strategy
 
@@ -65,12 +62,12 @@ Prefer in order: `data-testid` → ARIA role → visible text → `name` attribu
 3. **Substitute `{{base_url}}`** with the actual URL provided
 4. **For each step** in the Steps table:
    a. Execute the action using the appropriate MCP tool
-   b. Call `browser_snapshot` to verify the expected result for that step
-   c. Call `browser_console_messages` after navigation and form submissions — if JS errors appear, note them
+   b. Take a snapshot to verify the expected result for that step
+   c. Read console messages after navigation and form submissions — if JS errors appear, note them
    d. If locator fails: take a screenshot, snapshot the DOM, form a hypothesis — then retry with next locator in the priority order
 5. **Teardown**: execute teardown steps if present; if absent, navigate to base_url
 6. **Verification before completion** (MANDATORY before reporting PASS):
-   - Call `browser_snapshot` one final time
+   - Take a snapshot one final time
    - Confirm the Expected Final State described in the test case is actually present in the snapshot
    - Only if confirmed → report PASS
 7. **Screenshot**: always take a final screenshot to `reports/screenshots/{TC_ID}_{YYYY-MM-DD}.png`
@@ -78,7 +75,7 @@ Prefer in order: `data-testid` → ARIA role → visible text → `name` attribu
 ## Failure Protocol (systematic-debugging)
 
 When a step produces unexpected state:
-1. **Gather evidence**: `browser_snapshot` + `browser_take_screenshot` + `browser_console_messages`
+1. **Gather evidence**: snapshot + screenshot + console messages
 2. **State the actual vs expected**: describe in one sentence what is on screen vs what was expected
 3. **Form hypothesis**: "The locator failed because X" or "The redirect didn't happen because Y"
 4. **Retry once** with alternative locator

--- a/bundles/web-qa/agents/test-runner/RULES.md
+++ b/bundles/web-qa/agents/test-runner/RULES.md
@@ -1,8 +1,8 @@
 # Rules — test-runner
 
 1. **MCP-only browser control.** Never write or run Python scripts. All browser interaction is exclusively via Playwright MCP tools.
-2. **verification-before-completion is mandatory before any PASS.** The final `browser_snapshot` must confirm the Expected Final State from the test case is present. A green result without a confirming snapshot is not-yet-passed.
-3. **On failure, gather evidence before anything else.** `browser_snapshot` + `browser_take_screenshot` + `browser_console_messages` — in that order. State actual vs expected in one sentence.
+2. **verification-before-completion is mandatory before any PASS.** The final snapshot must confirm the Expected Final State from the test case is present. A green result without a confirming snapshot is not-yet-passed.
+3. **On failure, gather evidence before anything else.** Snapshot + screenshot + console messages — in that order. State actual vs expected in one sentence.
 4. **Retry once, then FAIL and STOP.** If a locator fails, retry with the next locator in the priority chain. If still failing, mark FAIL and stop. Never continue remaining steps after a failure.
 5. **Never continue steps after a failure.** The test case result is FAIL the moment a step cannot be completed. Do not execute subsequent steps.
 6. **Output exactly one JSON block.** The final message must end with exactly one ` ```json ` block matching the schema. No additional JSON objects.


### PR DESCRIPTION
## What

Finishes **decision #2 from the PR #23 cleanup** (2026-05-26: *"we can remove tool names and instruct to use playwright"*). That pass converted the `playwright-testing` and `test-case-analysis` **skills** to capability-based guidance but never swept the **agent files**, leaving them inconsistent.

This sweeps the four web-qa agent files that still hard-coded literal `mcp__playwright__browser_*` / `browser_*` names in their prose:

| File | Change |
|---|---|
| `test-runner/AGENT.md` | "Playwright MCP Tools" table → "Browser Capabilities" map; inline `browser_*` → capability verbs |
| `test-runner/RULES.md` | `browser_snapshot`/`browser_take_screenshot`/`browser_console_messages` → snapshot / screenshot / console messages |
| `app-profiler/AGENT.md` | Phase-2 exploration blocks → bare capability verbs (`navigate`/`snapshot`/`fill_form`…); added discover-from-MCP note |
| `test-author/AGENT.md` | `browser_snapshot` → "a single snapshot" |

## What is deliberately NOT changed

- **`tools:` frontmatter allowlists** keep the fully-qualified `mcp__playwright__browser_*` names — those are the agents' **permission grants**, not documentation. Removing them breaks tool access.

## Verification

- 0 literal `browser_*`/`mcp__playwright` refs remain in agent bodies
- `tools:` allowlists intact
- `npm run validate` → all 4 bundles valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)