### PR TITLE
fix(microsoft-365): default to browser auth-code flow to pass Conditi…

### DIFF
--- a/skills/microsoft-365/SKILL.md
+++ b/skills/microsoft-365/SKILL.md
@@ -115,23 +115,35 @@ projects — authenticate once, use everywhere).
 
 ### Login flow (important for Claude)
 
-When the user is not authenticated, **run `auth.py login` via Bash tool**. The
-output will contain `LOGIN_URL=...` and `LOGIN_CODE=...` lines. **You must relay
-both values to the user in your response** — they need to open the URL in their
-browser and enter the code to complete sign-in. The script blocks until they do.
+The default `login` opens an **interactive browser** (auth-code + PKCE on a
+localhost redirect). This passes Conditional Access policies that block the
+device-code flow. Because it needs a browser + a local redirect listener, **ask
+the user to run it in their own terminal**:
 
 ```
-python3 scripts/auth.py login    # Device-code flow — relay URL and code to user
-python3 scripts/auth.py status   # Check token validity
-python3 scripts/auth.py logout   # Clear cached credentials
+python3 scripts/auth.py login            # Browser auth-code+PKCE (default)
+python3 scripts/auth.py status           # Check token validity
+python3 scripts/auth.py logout           # Clear cached credentials
 ```
+
+If the browser flow can't be used (no GUI / SSH), fall back:
+
+```
+python3 scripts/auth.py login device     # Device-code — relay LOGIN_URL/LOGIN_CODE to user
+python3 scripts/auth.py login authcode   # Browser via nativeclient redirect (manual URL paste)
+```
+
+For `login device`, the output contains `LOGIN_URL=...` and `LOGIN_CODE=...` —
+relay both to the user. Note: many tenants block device-code via Conditional
+Access ("...an authentication flow that is restricted by your admin"); prefer
+the default browser flow.
 
 ### Environment variables (optional)
 
 | Variable | Default | Description |
 |---|---|---|
 | `SDLC_SKILLS_CACHE_DIR` | `~/.msgraph-skill` | Shared cache root for all sdlc-skills (token cache, venv). When set, the skill stores its data under `$SDLC_SKILLS_CACHE_DIR/msgraph/`. |
-| `MSGRAPH_CLIENT_ID` | `084a3e9f-a9f4-43f7-89f9-d229cf97853e` | Override with your own Azure AD app |
+| `MSGRAPH_CLIENT_ID` | `3d7688c6-f449-4d04-8b0d-57d94818e922` | Public client with localhost redirect; override with your own Azure AD app |
 | `MSGRAPH_TENANT_ID` | `common` | Restrict to a specific tenant |
 
 Variables can be set via environment or in a `.env` file at the skill root or cwd.
@@ -146,7 +158,7 @@ register your own Azure AD app:
 2. Add delegated permissions: `Mail.Read`, `Calendars.Read`, `Team.ReadBasic.All`,
    `Channel.ReadBasic.All`, `Sites.Read.All`, `Files.Read.All`.
 3. Under Authentication → Add platform → Mobile and desktop, enable the
-   `https://login.microsoftonline.com/common/oauth2/nativeclient` redirect URI.
+   `http://localhost` redirect URI (required for the default browser flow).
 4. Set `MSGRAPH_CLIENT_ID=<your-app-id>` in your `.env` and re-run login.
 
 ## Installation
@@ -172,3 +184,32 @@ on first script run — no manual setup needed.
 ```bash
 python3 scripts/auth.py login
 ```
+
+## Known issues / troubleshooting
+
+- **Conditional Access blocks device-code** — Error: *"Your sign-in was
+  successful but does not meet the criteria to access this resource ... an
+  authentication flow that is restricted by your admin."* Many tenants block the
+  device-code flow via Conditional Access. This is why the default `login` now
+  uses the interactive browser (auth-code + PKCE) flow. If you still see this
+  message *after* the browser sign-in, the CA policy is keying on device
+  compliance / managed app / location rather than the auth flow — that needs
+  your tenant admin (check Entra → Sign-in logs → your sign-in → Conditional
+  Access tab for the exact policy).
+
+- **`AADSTS50011` redirect URI mismatch** — The configured `MSGRAPH_CLIENT_ID`
+  app has no `http://localhost` redirect registered. The default app does; if
+  you override it with your own app, register the `http://localhost` redirect
+  (Authentication → Mobile and desktop applications). The legacy device-code
+  flow (`login device`) needs no redirect URI if you must avoid this.
+
+- **Default app is a shared public client** — `3d7688c6-...` is a third-party
+  public-client app reused because it has the `http://localhost` redirect. It is
+  not controlled by this project. For a durable / auditable setup, register your
+  own Azure AD app (see *Custom Azure AD app* above) and set `MSGRAPH_CLIENT_ID`.
+
+- **Teams scopes may not consent on the default app** — The default app's
+  registered scopes do **not** include `Team.ReadBasic.All` /
+  `Channel.ReadBasic.All`. Mail, calendar, and SharePoint work; Teams scans may
+  fail with a consent error. Use your own app registration with all six
+  delegated permissions if you need Teams.

--- a/skills/microsoft-365/scripts/auth.py
+++ b/skills/microsoft-365/scripts/auth.py
@@ -2,9 +2,17 @@
 Shared authentication helper for skill-msgraph scripts.
 
 Usage as a CLI:
-    python3 scripts/auth.py login    # device-code flow, caches token
-    python3 scripts/auth.py status   # show token validity + scopes
-    python3 scripts/auth.py logout   # clear cache
+    python3 scripts/auth.py login            # browser auth-code+PKCE (default)
+    python3 scripts/auth.py login device     # device-code flow (legacy)
+    python3 scripts/auth.py login authcode   # browser via nativeclient redirect
+    python3 scripts/auth.py status           # show token validity + scopes
+    python3 scripts/auth.py logout           # clear cache
+
+The default `login` uses an interactive browser (auth-code + PKCE) on a
+localhost redirect. This passes Conditional Access policies that block the
+device-code flow ("...an authentication flow that is restricted by your
+admin"). The default app below is registered with an http://localhost
+redirect so this works out of the box.
 
 Usage from other scripts:
     from auth import get_client
@@ -27,7 +35,9 @@ import _bootstrap  # noqa: F401 — auto-installs deps, re-execs if needed
 
 import tempfile
 import time
+import webbrowser
 from typing import Optional
+from urllib.parse import parse_qs, urlparse
 
 import msal
 from azure.core.credentials import AccessToken, TokenCredential
@@ -70,8 +80,16 @@ _load_dotenv()
 # Defaults
 # ---------------------------------------------------------------------------
 
-DEFAULT_CLIENT_ID = "084a3e9f-a9f4-43f7-89f9-d229cf97853e"
+# Public client app registered with an http://localhost redirect URI, so the
+# interactive browser (auth-code + PKCE) flow works without registering your
+# own app. Override with MSGRAPH_CLIENT_ID to use your own.
+DEFAULT_CLIENT_ID = "3d7688c6-f449-4d04-8b0d-57d94818e922"
 DEFAULT_TENANT_ID = "common"
+
+# Legacy "native client" redirect URI, used by the `login authcode` flow: the
+# browser lands on this (blank) page carrying ?code=...&state=... which the
+# user pastes back. Only works with an app registered for this redirect.
+NATIVE_CLIENT_REDIRECT = "https://login.microsoftonline.com/common/oauth2/nativeclient"
 
 SCOPES = [
     "Mail.Read",
@@ -192,6 +210,70 @@ class _MSALCredential(TokenCredential):
     # Auth management (used by CLI)
     # ------------------------------------------------------------------
 
+    def login_interactive(self) -> dict:
+        """Open the system browser (auth-code + PKCE) on a localhost redirect.
+
+        This is the default flow. It passes Conditional Access policies that
+        block the device-code flow. Requires the app to allow an
+        ``http://localhost`` redirect URI (the default app does).
+        """
+        result = self._app.acquire_token_interactive(
+            scopes=self._scopes,
+            prompt="select_account",
+        )
+        if "error" in result:
+            raise RuntimeError(
+                f"Authentication failed: {result.get('error_description', result['error'])}"
+            )
+        self._save_cache()
+        return result
+
+    def login_authcode(self) -> dict:
+        """Browser auth-code + PKCE flow via the legacy ``nativeclient`` redirect.
+
+        Fallback for apps registered with the ``nativeclient`` redirect instead
+        of ``http://localhost``. The browser lands on the blank nativeclient
+        page carrying the auth code in the URL, which the user pastes back.
+        """
+        flow = self._app.initiate_auth_code_flow(
+            self._scopes,
+            redirect_uri=NATIVE_CLIENT_REDIRECT,
+            prompt="select_account",
+        )
+        auth_uri = flow["auth_uri"]
+        print("=" * 60)
+        print("  Microsoft Graph — Browser Login (auth-code + PKCE)")
+        print("=" * 60)
+        print()
+        print("  1. A browser window should open. If not, open this URL:")
+        print()
+        print(f"     {auth_uri}")
+        print()
+        print("  2. Sign in. Your browser will land on a (blank) page at")
+        print("     login.microsoftonline.com/.../nativeclient")
+        print("  3. Copy that page's FULL URL from the address bar and paste")
+        print("     it below.")
+        print()
+        print("=" * 60)
+        print()
+        try:
+            webbrowser.open(auth_uri)
+        except Exception:
+            pass
+        redirected = input("Paste the full redirect URL here: ").strip()
+        query = urlparse(redirected).query
+        if not query:
+            # User may have pasted just the "code=...&state=..." fragment.
+            query = redirected.lstrip("?")
+        auth_response = {k: v[0] for k, v in parse_qs(query).items()}
+        result = self._app.acquire_token_by_auth_code_flow(flow, auth_response)
+        if "error" in result:
+            raise RuntimeError(
+                f"Authentication failed: {result.get('error_description', result['error'])}"
+            )
+        self._save_cache()
+        return result
+
     def login(self) -> dict:
         """Initiate device-code flow and block until the user completes it."""
         flow = self._app.initiate_device_flow(scopes=self._scopes)
@@ -298,7 +380,20 @@ def _cmd_login() -> None:
     print(f"Client ID : {cred._app.client_id}")
     print(f"Token cache: {cred._cache_path}")
     print()
-    result = cred.login()
+    # Default to the interactive browser flow (auth-code + PKCE on localhost),
+    # which works with the default app and passes Conditional Access policies
+    # that block device-code. Overrides:
+    #   login device     -> device-code flow (legacy)
+    #   login authcode   -> browser via nativeclient redirect (manual paste)
+    mode = sys.argv[2].lower() if len(sys.argv) > 2 else "localhost"
+    if mode == "device":
+        result = cred.login()
+    elif mode == "authcode":
+        result = cred.login_authcode()
+    else:
+        print("Opening your browser for sign-in …")
+        print()
+        result = cred.login_interactive()
     account = result.get("id_token_claims", {}).get("preferred_username", "unknown")
     print(f"Logged in as: {account}")
     print(f"Token cache : {cred._cache_path}")


### PR DESCRIPTION
…onal Access

The device-code flow is blocked by many tenants' Conditional Access policies ("...an authentication flow that is restricted by your admin"), and the previous default app had no redirect URIs registered, so no browser flow could replace it (AADSTS50011).

- Default `login` now uses interactive browser auth-code + PKCE on a localhost redirect (`login_interactive`); device-code and nativeclient flows kept as `login device` / `login authcode` fallbacks.
- Default client ID switched to a public-client app registered with an http://localhost redirect so the browser flow works out of the box.
- SKILL.md: documented login flows, env defaults, custom-app localhost redirect, and a Known issues section (CA device-code block, AADSTS50011, shared default app, missing Teams scopes).