### PR TITLE
fix(manual-qa): fall back to `npx -y ccusage` when ccusage isn't installed

### DIFF
--- a/bundles/manual-qa/hooks/scripts/benchmark-preflight
+++ b/bundles/manual-qa/hooks/scripts/benchmark-preflight
@@ -115,7 +115,7 @@ elif [ -f "$SESSION_PRE_FILE" ]; then
 else
   # No session_id and no session-start snapshot at all -- nothing to
   # retry-match against, one immediate snapshot as last resort.
-  ccusage session --json > "$PRE_FILE" 2>/dev/null \
+  ccusage_session_json > "$PRE_FILE" 2>/dev/null \
     || printf '{}' > "$PRE_FILE"
 fi
 

--- a/bundles/manual-qa/hooks/scripts/benchmark-session-start
+++ b/bundles/manual-qa/hooks/scripts/benchmark-session-start
@@ -71,7 +71,7 @@ if [ ! -f "$TS_FILE" ]; then
     # No session_id on this payload at all (older Claude Code / unusual
     # invocation) -- nothing to retry-match against, take one snapshot as
     # before rather than burning the full retry window for nothing.
-    ccusage session --json > "$SESSION_PRE_FILE" 2>/dev/null \
+    ccusage_session_json > "$SESSION_PRE_FILE" 2>/dev/null \
       || printf '{}' > "$SESSION_PRE_FILE"
   fi
 

--- a/bundles/manual-qa/hooks/scripts/benchmark-stop
+++ b/bundles/manual-qa/hooks/scripts/benchmark-stop
@@ -88,6 +88,12 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 # <project>/scripts/ — resolve self-relatively (run-hook.cmd always sets $0
 # to the full path, so this works regardless of cwd).
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Sourced for ccusage_session_json() — resolves `ccusage` on PATH, else
+# `npx -y ccusage`. Without it the post-run snapshot is empty on any machine
+# where ccusage isn't globally installed, which silently degrades the whole
+# run to tokens_coverage: "subagents_only".
+# shellcheck source=ccusage-wait.sh
+. "${HOOK_DIR}/ccusage-wait.sh"
 STATE_DIR="${PROJECT_DIR}/.claude"
 
 # Cheap pre-check that needs no stdin/sid: this hook fires globally (matcher
@@ -239,7 +245,7 @@ fi
 session_started_at="$(cat "$SESSION_STARTED_AT_FILE" 2>/dev/null || true)"
 
 # Capture post-run token snapshot.
-ccusage session --json > "$POST_FILE" 2>/dev/null \
+ccusage_session_json > "$POST_FILE" 2>/dev/null \
   || printf '{}' > "$POST_FILE"
 
 # Backfill/rebuild the tc-trace from the main transcript's own

--- a/bundles/manual-qa/hooks/scripts/benchmark-tc
+++ b/bundles/manual-qa/hooks/scripts/benchmark-tc
@@ -18,6 +18,11 @@ PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 # next to this script, not at <project>/scripts/ — resolve self-relatively so
 # this works regardless of cwd (run-hook.cmd always sets $0 to the full path).
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Sourced for ccusage_session_json() — resolves `ccusage` on PATH, else
+# `npx -y ccusage`. Without it this hook's snapshot is empty on any machine
+# where ccusage isn't globally installed.
+# shellcheck source=ccusage-wait.sh
+. "${HOOK_DIR}/ccusage-wait.sh"
 STATE_DIR="${PROJECT_DIR}/.claude"
 
 payload="$(cat 2>/dev/null || true)"
@@ -46,7 +51,7 @@ if [ ! -f "$STATE_FILE" ]; then
   if [ -f "$SESSION_PRE_FILE" ]; then
     cp "$SESSION_PRE_FILE" "$PRE_FILE"
   else
-    ccusage session --json > "$PRE_FILE" 2>/dev/null \
+    ccusage_session_json > "$PRE_FILE" 2>/dev/null \
       || printf '{}' > "$PRE_FILE"
   fi
   printf '{"first_dispatch_at":"%s","pre_file":"%s","trace_file":"%s"}\n' \

--- a/bundles/manual-qa/hooks/scripts/ccusage-wait.sh
+++ b/bundles/manual-qa/hooks/scripts/ccusage-wait.sh
@@ -58,6 +58,98 @@
 # snapshot is still useful, build-run-metrics.mjs's own unscoped fallback
 # path handles it).
 
+# ---------------------------------------------------------------------------
+# ccusage invocation resolver — added 2026-08-12.
+#
+# WHY: `ccusage` ships on npm and is frequently NOT installed globally. On a
+# machine without it, every `ccusage session --json` call in this pipeline
+# returned nothing, the `|| printf '{}'` fallbacks wrote empty snapshots, and
+# every run silently degraded to `tokens_coverage: "subagents_only"` with null
+# token counts. Nothing errored — the graceful-degradation design worked
+# exactly as intended — so the only symptom was an empty metrics JSON that
+# looked like a data problem rather than a missing dependency. Confirmed on
+# this box: `command -v ccusage` → not found, while RUN-2026-08-12-002's
+# metrics came back with every per-case value null.
+#
+# FIX: prefer a real binary on PATH; fall back to `npx -y ccusage`, which
+# resolves the package on demand. If neither is available, return non-zero and
+# let each caller's existing `{}` fallback take over — same never-block,
+# never-fail-the-hook philosophy as the rest of the pipeline.
+#
+# Resolution is cached in _CCUSAGE_MODE for the life of the shell, so the
+# 60s poll loop below doesn't re-probe PATH on every iteration.
+#
+# The mode is a flag dispatched through a `case`, NOT an argv string expanded
+# unquoted. An earlier draft stored "npx -y ccusage" in a variable and relied
+# on word-splitting at the call site; that works under bash (these hooks all
+# have a bash shebang) but silently breaks under zsh, which does not split
+# unquoted expansions — the whole string is looked up as one command name and
+# the call exits 127 with empty stderr, which looks exactly like "ccusage is
+# missing". Caught while validating this very fix from a zsh prompt.
+#
+# TIMING CAVEAT: a PATH binary answers in ~100ms; `npx` pays node startup
+# plus, on the very first call before npm's _npx cache is warm, a package
+# download. That matters to wait_for_scoped_ccusage, whose budget is real
+# wall-clock — under npx it will make far fewer attempts within the same 60s
+# (possibly only one). That is a deliberate trade: a slow snapshot still
+# beats no snapshot, and the unscoped fallback path already handles a miss.
+# CCUSAGE_TIMEOUT_S bounds a single call so a hung npx (no network, private
+# registry) can't wedge a hook; `timeout` is not present by default on macOS,
+# so it is used only when available.
+# Runs "$@", bounded by a timeout wrapper when the platform genuinely has one.
+#
+# Per-platform reality this has to survive:
+#   Linux   — `timeout` is coreutils, wraps a command. Works.
+#   macOS   — ships NEITHER `timeout` nor `gtimeout` unless the user installed
+#             coreutils via brew. Unbounded is the normal path here.
+#   Windows — `command -v timeout` finds C:\Windows\System32\timeout.exe under
+#             Git Bash, which is an ENTIRELY DIFFERENT command: it pauses for N
+#             seconds and takes `/t`, it does not wrap anything. Dispatching to
+#             it would corrupt every call (and it errors outright when stdin is
+#             redirected, which it is here).
+#
+# So presence on PATH is not evidence of the right command — probe behaviour
+# instead. `timeout 1 true` succeeds only for the coreutils wrapper form;
+# Windows' timeout.exe rejects it. Result cached for the life of the shell.
+_ccusage_run() {
+  if [ -z "${_CCUSAGE_TIMEOUT_MODE:-}" ]; then
+    _CCUSAGE_TIMEOUT_MODE="none"
+    if command -v timeout >/dev/null 2>&1 && timeout 1 true >/dev/null 2>&1; then
+      _CCUSAGE_TIMEOUT_MODE="timeout"
+    elif command -v gtimeout >/dev/null 2>&1 && gtimeout 1 true >/dev/null 2>&1; then
+      _CCUSAGE_TIMEOUT_MODE="gtimeout"
+    fi
+  fi
+
+  case "$_CCUSAGE_TIMEOUT_MODE" in
+    timeout)  timeout  "${CCUSAGE_TIMEOUT_S:-60}" "$@" 2>/dev/null ;;
+    gtimeout) gtimeout "${CCUSAGE_TIMEOUT_S:-60}" "$@" 2>/dev/null ;;
+    *)        "$@" 2>/dev/null ;;
+  esac
+}
+
+ccusage_session_json() {
+  if [ -z "${_CCUSAGE_MODE:-}" ]; then
+    if command -v ccusage >/dev/null 2>&1; then
+      _CCUSAGE_MODE="bin"
+    elif command -v npx >/dev/null 2>&1; then
+      _CCUSAGE_MODE="npx"
+    elif command -v npx.cmd >/dev/null 2>&1; then
+      # Windows: some shells surface only the .cmd shim on PATH.
+      _CCUSAGE_MODE="npxcmd"
+    else
+      _CCUSAGE_MODE="none"
+    fi
+  fi
+
+  case "$_CCUSAGE_MODE" in
+    bin)    _ccusage_run ccusage session --json ;;
+    npx)    _ccusage_run npx -y ccusage session --json ;;
+    npxcmd) _ccusage_run npx.cmd -y ccusage session --json ;;
+    *)      return 1 ;;
+  esac
+}
+
 wait_for_scoped_ccusage() {
   local sid="$1" out_file="$2" debug_log="${3:-}" label="${4:-ccusage-wait}"
   local total_budget_s=60
@@ -68,7 +160,7 @@ wait_for_scoped_ccusage() {
 
   while :; do
     attempt=$((attempt + 1))
-    snapshot="$(ccusage session --json 2>/dev/null || true)"
+    snapshot="$(ccusage_session_json || true)"
     elapsed_s=$(( $(date -u +%s) - start_epoch ))
 
     if printf '%s' "$snapshot" | node -e "


### PR DESCRIPTION
## The bug

Every `ccusage session --json` call in the benchmark pipeline assumes a globally-installed `ccusage` binary. `ccusage` ships on npm and is commonly absent — on a machine without it, all five call sites return nothing, the `|| printf '{}'` fallbacks write empty snapshots, and **every run silently degrades to `tokens_coverage: "subagents_only"` with null token counts.**

Nothing errors. The graceful-degradation design works exactly as intended, which is what makes this hard to spot: the only symptom is a metrics JSON full of nulls, which reads as a data problem rather than a missing dependency.

**Observed on a real run** (octoweb, `RUN-2026-08-12-002`, a 9-case manual-QA suite):

- `command -v ccusage` → not found
- `reports/metrics/RUN-2026-08-12-002.json`: every per-case value `null`, `tokens_coverage: "subagents_only"`, 4 of 10 subagent dispatches traced, and a 4h37m session duration inherited from a stale baseline
- `tokens_by_agent` contained only `test-author` — from an *earlier* session, not the run being measured
- The run's actual cost had to be reconstructed by hand from session transcripts (~$31, 64.2M tokens billed — of which 60.8M were cache reads the JSON never saw)

## The fix

Adds `ccusage_session_json()` to the shared `ccusage-wait.sh` helper: prefers a `ccusage` binary on PATH, falls back to `npx -y ccusage`, returns non-zero when neither is available so each caller's existing `{}` fallback still takes over. All five call sites route through it; `benchmark-tc` and `benchmark-stop` gained the `. ccusage-wait.sh` source line the other two already had.

**Behaviour is unchanged on any machine that already has ccusage installed.**

## Two portability traps this deliberately avoids

Both were found while validating the fix, not theorised:

**1. The resolution is a mode flag dispatched through `case`, not an argv string expanded unquoted.** My first draft stored `"npx -y ccusage"` in a variable and relied on word-splitting at the call site. That works under bash — all these hooks have a bash shebang — but breaks under zsh, which does not word-split unquoted expansions. The whole string is looked up as one command name and the call exits **127 with empty stderr**, which is indistinguishable from "ccusage is missing". A helper that only works when sourced from the right shell is a bad thing to ship.

```
+ccusage_session_json:21> 'npx -y ccusage' session --json    # ← one command name
```

**2. The timeout wrapper probes behaviour rather than trusting PATH.** Under Git Bash on Windows, `command -v timeout` resolves to `C:\Windows\System32\timeout.exe` — an unrelated command that pauses for N seconds, takes `/t`, and errors outright when stdin is redirected (which it is here). Dispatching to it would corrupt every call. `timeout 1 true` succeeds only for the coreutils wrapper form, so the impostor is rejected and the call runs unbounded instead. macOS ships neither `timeout` nor `gtimeout` unless coreutils is installed, so unbounded is the normal path there anyway.

Also probes `npx.cmd`, which is the only npx some Windows shells expose.

## Verification

| Check | Result |
|---|---|
| `bash -n` / `sh -n` / `zsh -n` on all 5 scripts | pass |
| Returns real data under bash | exit 0, 57.9KB, 75 session entries |
| Returns real data under zsh (the shell that broke the argv-string draft) | exit 0, identical output |
| Every entry carries `period` | 75/75 — the field `build-run-metrics.mjs` matches on |
| Current session id present in output | **found** — so `tokens_coverage: "full_session"` now resolves where it previously fell through to unscoped |
| Windows `timeout.exe` simulated (stub on PATH failing the way it does) | probe rejected it (`timeout_mode=none`), call still returned real data |

## Known trade-off

`npx` pays node startup, plus a package download on the very first call before npm's `_npx` cache is warm. That matters to `wait_for_scoped_ccusage`, whose budget is real wall-clock: under npx it will make fewer attempts within the same 60s, possibly only one. Deliberate — a slow snapshot beats no snapshot, and the unscoped fallback already handles a miss. `CCUSAGE_TIMEOUT_S` bounds a single call where a timeout wrapper is genuinely available.

A follow-up worth considering: warm the npx cache once at session start so the poll loop isn't paying resolution cost on every attempt.