### PR TITLE
feat(agents): make independent tool calls go out in parallel

### DIFF
--- a/agents/personal-assistant/AGENT.md
+++ b/agents/personal-assistant/AGENT.md
@@ -25,6 +25,26 @@ exist *to support* the conversation, not the other way around.
 Default posture: **engaged, helpful, resourceful**. You are not a silent
 filter. You are a colleague the user talks to.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## How you communicate
 
 **`.agents/team-comms.md` is the canonical answer to "how do I route

--- a/bundles/feature-development/agents/android-dev/AGENT.md
+++ b/bundles/feature-development/agents/android-dev/AGENT.md
@@ -21,6 +21,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/feature-development/agents/ba/AGENT.md
+++ b/bundles/feature-development/agents/ba/AGENT.md
@@ -19,6 +19,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/feature-development/agents/ios-dev/AGENT.md
+++ b/bundles/feature-development/agents/ios-dev/AGENT.md
@@ -20,6 +20,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/feature-development/agents/js-dev/AGENT.md
+++ b/bundles/feature-development/agents/js-dev/AGENT.md
@@ -20,6 +20,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/feature-development/agents/project-manager/AGENT.md
+++ b/bundles/feature-development/agents/project-manager/AGENT.md
@@ -19,6 +19,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/feature-development/agents/python-dev/AGENT.md
+++ b/bundles/feature-development/agents/python-dev/AGENT.md
@@ -20,6 +20,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/feature-development/agents/qa-engineer/AGENT.md
+++ b/bundles/feature-development/agents/qa-engineer/AGENT.md
@@ -19,6 +19,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/feature-development/agents/scout/AGENT.md
+++ b/bundles/feature-development/agents/scout/AGENT.md
@@ -21,6 +21,26 @@ metadata:
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 Read `.agents/memory/scout/project_briefing.md` in this directory for what you've learned in past conversations. Update it when you learn something worth remembering.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Terminal Interaction
 
 **You run interactively — the engineer is watching your terminal.** Unlike the other roles, scout is not an unattended background worker. The user launched you directly and is present.

--- a/bundles/feature-development/agents/tech-lead/AGENT.md
+++ b/bundles/feature-development/agents/tech-lead/AGENT.md
@@ -19,6 +19,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/feature-development/agents/test-automation-engineer/AGENT.md
+++ b/bundles/feature-development/agents/test-automation-engineer/AGENT.md
@@ -20,6 +20,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/manual-qa/agents/app-profiler/AGENT.md
+++ b/bundles/manual-qa/agents/app-profiler/AGENT.md
@@ -16,6 +16,26 @@ You are a QA App-Profiler Agent. Learn a new web application through conversatio
 
 Browser control is via the Playwright MCP (wired by the `playwright-testing` skill). The exploration steps below name capabilities, not exact tool names — discover those from your installed MCP.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Start: Check for Existing Profile
 
 Read `.agents/manual-qa/app_profile.md` if it exists. If it does:

--- a/bundles/manual-qa/agents/test-author/AGENT.md
+++ b/bundles/manual-qa/agents/test-author/AGENT.md
@@ -13,6 +13,26 @@ authors:
 
 You are a QA Test Case Writer. Transform rough ideas into precise, executable test cases.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Setup (do this first, before talking to the user)
 
 1. Read `.agents/manual-qa/app_profile.md` — gives you base_url, credentials, selectors, suite structure. **Don't ask for anything already there.**

--- a/bundles/manual-qa/agents/test-reporter/AGENT.md
+++ b/bundles/manual-qa/agents/test-reporter/AGENT.md
@@ -13,6 +13,26 @@ authors:
 
 You are a QA Test-reporter Agent. Turn an array of test-runner results into a clean Markdown report.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Input
 
 You receive a message with:

--- a/bundles/manual-qa/agents/test-run-lead/AGENT.md
+++ b/bundles/manual-qa/agents/test-run-lead/AGENT.md
@@ -13,6 +13,26 @@ authors:
 
 You are a QA Test-Run Lead Agent. You orchestrate a complete test run — from assembling the suite (authoring and sizing cases when needed) through execution to the final report. You are the **single orchestrator** for a run: the user talks to you, and you dispatch `test-author`, `test-sizer`, `test-runner`, and `test-reporter` as sub-agents via the Agent tool.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Before You Start
 
 Check whether `.agents/manual-qa/app_profile.md` exists.

--- a/bundles/manual-qa/agents/test-runner/AGENT.md
+++ b/bundles/manual-qa/agents/test-runner/AGENT.md
@@ -20,6 +20,26 @@ Apply `verification-before-completion`: before reporting `"result": "PASS"`, you
 
 Apply `systematic-debugging` when any step fails: before retrying, take a screenshot and snapshot to understand WHAT the actual page state is. Form a hypothesis, then try the alternative locator.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Setup
 
 Before executing, read two files if they exist:

--- a/bundles/manual-qa/agents/test-sizer/AGENT.md
+++ b/bundles/manual-qa/agents/test-sizer/AGENT.md
@@ -15,6 +15,26 @@ You are a QA Test Case Sizer. Your job: evaluate the size and execution complexi
 
 You are calibrated for AI agent execution via Playwright MCP: every step costs tokens, every page navigation costs time, every unexpected interaction increases failure risk. Smaller, focused tests = lower cost + higher reliability + easier failure diagnosis.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Two Modes
 
 **Mode A — Evaluate existing TC files**

--- a/bundles/product-management/agents/discovery-researcher/AGENT.md
+++ b/bundles/product-management/agents/discovery-researcher/AGENT.md
@@ -19,6 +19,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/product-management/agents/product-owner/AGENT.md
+++ b/bundles/product-management/agents/product-owner/AGENT.md
@@ -19,6 +19,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/test-automation/agents/qa-engineer/AGENT.md
+++ b/bundles/test-automation/agents/qa-engineer/AGENT.md
@@ -25,6 +25,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/test-automation/agents/scout/AGENT.md
+++ b/bundles/test-automation/agents/scout/AGENT.md
@@ -22,6 +22,26 @@ metadata:
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 Read `.agents/memory/scout/project_briefing.md` in this directory for what you've learned in past conversations. Update it when you learn something worth remembering.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Terminal Interaction
 
 **You run interactively — the engineer is watching your terminal.** Unlike the other roles, scout is not an unattended background worker. The user launched you directly and is present.

--- a/bundles/test-automation/agents/test-automation-engineer/AGENT.md
+++ b/bundles/test-automation/agents/test-automation-engineer/AGENT.md
@@ -25,6 +25,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.

--- a/bundles/test-automation/agents/test-automation-lead/AGENT.md
+++ b/bundles/test-automation/agents/test-automation-lead/AGENT.md
@@ -20,6 +20,26 @@ metadata:
 
 Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
 
+## Tool-call economy (MANDATORY)
+
+Independent tool calls go out **together, in one message**. Reading N files, running N greps, or
+inspecting N files of a diff are independent of each other — issue them as parallel calls in a
+single turn, not one call per turn.
+
+This changes how many round trips a task takes, never what it inspects. A blocking review still
+reads everything it needs before it rules; it just stops paying a turn per file.
+
+- **Diffs** — `git show <sha>` once for the whole diff, then targeted follow-ups in parallel; not
+  `git show <sha> -- <file>` once per file.
+- **Searching** — one `grep -n "a\|b\|c"` beats three greps.
+- **Ranges** — one `sed -n '1,60p;120,180p'` beats two calls.
+- **Probing** — don't `ls` a path to decide whether to use it; run the real command and handle the
+  failure.
+
+Measured on a real board: the same blocking code review, same verdict, took 33 turns / 14 tool
+calls one way and 61 turns / 36 tool calls the other. The gap was 15 sequential single-file
+`git show` calls that could have been two.
+
 ## Session Start — Orientation (MANDATORY)
 
 Load this context before any task — it overrides defaults in this file.


### PR DESCRIPTION
## Why

Dispatched agents serialise reads that are independent of each other, paying a model round trip per file.

Measured on a real board — two blocking code reviews of comparable diffs, **same session, same task shape**:

| | turns | tool calls | report |
|---|---|---|---|
| `opus-4-8` | 33 | 14 | 10,948 chars |
| `sonnet-5` | 61 | 36 | 5,625 chars |

Same verdict either way, and the longer loop produced the **shorter** report — so the extra turns weren't buying depth. The gap was concrete:

```
 4  git show f8f0369f -- backend/registry/alembic/versions/...
 5  git show f8f0369f -- backend/registry/src/octoweb/re...
 7  git show f8f0369f -- backend/registry/src/octoweb/re...
 8  git show f8f0369f -- backend/registry/src/octoweb/re...
 9  git show f8f0369f -- backend/registry/src/octoweb/re...
11  git show f8f0369f:backend/registry/src/octoweb/regis...
...                                    (15 calls in total)
```

versus reading the whole diff in two calls. Plus greps issued one at a time, and probe-then-retry (`ls .venv/bin/pytest`, then run it anyway).

Every one of those 15 calls is independent. Issued in parallel they'd cost ~2 turns and return byte-for-byte the same content.

## It generalises

Across the same corpus, on identical *review* tasks:

| model | n | turns/agent | s/turn | median ctx |
|---|---|---|---|---|
| `opus-4-8` | 41 | 43.8 | 5.99 | 79,486 |
| `sonnet-5` | 64 | 67.9 | 4.87 | 94,730 |

Per-turn latency is *not* worse — it's slightly better. The cost is loop length, and it compounds: more turns accumulate more context, and per-turn latency tracks context, so later turns get slower. Tool execution itself is only 3–8% of a subagent's wall-clock; the rest is model time.

## What this changes — and deliberately doesn't

One shared section, added to all 23 agents across the four bundles.

It does **not** tell an agent to read less, skip verification, or decide sooner. A blocking reviewer's job is to block when there are flaws, and trimming what it inspects would trade correctness for speed. This changes only how many round trips the same reading costs.

Placed after each agent's `## Identity` section, so the operating rule follows who the agent is and precedes its task instructions.

## Verification

- `npm run validate` — clean (bundles, marketplaces, externals, dupes)
- `node --test` — 468 pass, 0 fail

## Caveat

The turn-by-turn evidence is one matched pair, supported by the n=41/n=64 aggregate. The instruction's *effect* is unmeasured — worth an A/B on the next workflow run before assuming the gap closes.
