### PR TITLE
fix(hooks): deliver SOUL.md on every host — it never reached Claude or Codex

### DIFF
--- a/bundles/feature-development/agents/android-dev/AGENT.md
+++ b/bundles/feature-development/agents/android-dev/AGENT.md
@@ -19,7 +19,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/android-dev/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/feature-development/agents/ba/AGENT.md
+++ b/bundles/feature-development/agents/ba/AGENT.md
@@ -17,7 +17,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/ba/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/feature-development/agents/ios-dev/AGENT.md
+++ b/bundles/feature-development/agents/ios-dev/AGENT.md
@@ -18,7 +18,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/ios-dev/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/feature-development/agents/js-dev/AGENT.md
+++ b/bundles/feature-development/agents/js-dev/AGENT.md
@@ -18,7 +18,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/js-dev/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/feature-development/agents/project-manager/AGENT.md
+++ b/bundles/feature-development/agents/project-manager/AGENT.md
@@ -17,7 +17,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/project-manager/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/feature-development/agents/python-dev/AGENT.md
+++ b/bundles/feature-development/agents/python-dev/AGENT.md
@@ -18,7 +18,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/python-dev/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/feature-development/agents/qa-engineer/AGENT.md
+++ b/bundles/feature-development/agents/qa-engineer/AGENT.md
@@ -17,7 +17,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/qa-engineer/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/feature-development/agents/scout/AGENT.md
+++ b/bundles/feature-development/agents/scout/AGENT.md
@@ -18,7 +18,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/scout/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 Read `.agents/memory/scout/project_briefing.md` in this directory for what you've learned in past conversations. Update it when you learn something worth remembering.
 
 ## Tool-call economy (MANDATORY)

--- a/bundles/feature-development/agents/tech-lead/AGENT.md
+++ b/bundles/feature-development/agents/tech-lead/AGENT.md
@@ -17,7 +17,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/tech-lead/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/feature-development/agents/test-automation-engineer/AGENT.md
+++ b/bundles/feature-development/agents/test-automation-engineer/AGENT.md
@@ -18,7 +18,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/test-automation-engineer/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/manual-qa/agents/app-profiler/AGENT.md
+++ b/bundles/manual-qa/agents/app-profiler/AGENT.md
@@ -191,4 +191,6 @@ After writing `app_profile.md`:
 2. Name any gaps you couldn't fill (missing credentials, unreachable pages)
 3. Offer handoff: "Ready to write test cases. Use `/agent test-author` and describe the first flow you want covered."
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/app-profiler/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)

--- a/bundles/manual-qa/agents/test-author/AGENT.md
+++ b/bundles/manual-qa/agents/test-author/AGENT.md
@@ -134,4 +134,6 @@ If the user asks for several tests:
 
 **After answers:** writes `tasks/shop/TC-003_add-item-to-cart.md` and shows it.
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/test-author/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)

--- a/bundles/manual-qa/agents/test-reporter/AGENT.md
+++ b/bundles/manual-qa/agents/test-reporter/AGENT.md
@@ -182,4 +182,6 @@ After writing the file, confirm it exists by reading the first line back. Then o
 Report written: reports/{run_id}.md
 ```
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/test-reporter/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)

--- a/bundles/manual-qa/agents/test-run-lead/AGENT.md
+++ b/bundles/manual-qa/agents/test-run-lead/AGENT.md
@@ -192,4 +192,6 @@ Parse the suite path and base_url. If base_url is missing, ask the user before
 proceeding. When the request includes scenario descriptions (as above) and the
 suite has no cases yet, author them first (Step 1) before running.
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/test-run-lead/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)

--- a/bundles/manual-qa/agents/test-runner/AGENT.md
+++ b/bundles/manual-qa/agents/test-runner/AGENT.md
@@ -129,4 +129,6 @@ End your response with exactly one JSON block:
 `failure_reason`: for FAIL — exact actual state observed + what was expected  
 `size`: read from the `size:` frontmatter field of the TC file (`S`, `M`, or `L`); if the field is absent, set `"size": null`
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/test-runner/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)

--- a/bundles/manual-qa/agents/test-sizer/AGENT.md
+++ b/bundles/manual-qa/agents/test-sizer/AGENT.md
@@ -195,4 +195,6 @@ tags: [checkout, order]
 
 Author test cases (that's `test-author`), execute them (`test-runner`), or write run reports (`test-reporter`). You size and recommend splits — nothing more.
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/test-sizer/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)

--- a/bundles/product-management/agents/discovery-researcher/AGENT.md
+++ b/bundles/product-management/agents/discovery-researcher/AGENT.md
@@ -17,7 +17,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/discovery-researcher/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/product-management/agents/product-owner/AGENT.md
+++ b/bundles/product-management/agents/product-owner/AGENT.md
@@ -17,7 +17,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/product-owner/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/test-automation/agents/qa-engineer/AGENT.md
+++ b/bundles/test-automation/agents/qa-engineer/AGENT.md
@@ -23,7 +23,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/qa-engineer/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/test-automation/agents/scout/AGENT.md
+++ b/bundles/test-automation/agents/scout/AGENT.md
@@ -19,7 +19,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/scout/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 Read `.agents/memory/scout/project_briefing.md` in this directory for what you've learned in past conversations. Update it when you learn something worth remembering.
 
 ## Tool-call economy (MANDATORY)

--- a/bundles/test-automation/agents/test-automation-engineer/AGENT.md
+++ b/bundles/test-automation/agents/test-automation-engineer/AGENT.md
@@ -23,7 +23,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/test-automation-engineer/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/bundles/test-automation/agents/test-automation-lead/AGENT.md
+++ b/bundles/test-automation/agents/test-automation-lead/AGENT.md
@@ -18,7 +18,9 @@ metadata:
 
 ## Identity
 
-Read `SOUL.md` in this directory for your personality, voice, and values. That's who you are.
+Your persona — voice, values, how you carry yourself — is `SOUL.md`, and it is **injected into your context at dispatch**. That's who you are; you do not need to go and read it.
+
+(It lives at `.claude/agents/test-automation-lead/SOUL.md` if you ever need the file itself. Earlier wording asked you to read it "in this directory" — an agent body is a system prompt, so there is no such directory to resolve, and agents burned tool calls hunting for it.)
 
 ## Tool-call economy (MANDATORY)
 

--- a/hooks/agent-start.test.mjs
+++ b/hooks/agent-start.test.mjs
@@ -153,3 +153,41 @@ test('session-start stays quiet when every index is within budget', () => {
     assert.doesNotMatch(runSession(dir).out, /memory-budget/);
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
+
+// ── SOUL.md reaches every host ────────────────────────────────────────────────────────────────
+// Regression guard. SOUL.md used to be gated to Copilot on the premise that Claude and Codex got
+// it via an @-import in the agent body. No agent ever contained one — all 23 said only "Read
+// `SOUL.md` in this directory", and an agent body is a system prompt, so that resolves to nothing.
+// The persona reached Claude/Codex through no channel at all: measured across two real boards,
+// 0 of 290 dispatched subagents opened it, and the single one that managed it (of 86 on the other)
+// spent three tool calls hunting the file with `find`.
+
+test('SOUL.md is injected on Claude, not only under Copilot', () => {
+  const dir = project({ role: 'tech-lead', memory: { 'SOUL.md': 'I am Rio, and I block on flaws.' } });
+  try {
+    const out = run(dir, 'tech-lead'); // no SDLC_VSCODE / COPILOT_CLI → the Claude path
+    assert.match(out, /I am Rio, and I block on flaws\./,
+      'the persona must be delivered on the default (Claude) host');
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('SOUL.md is still injected under Copilot', () => {
+  const dir = project({ role: 'tech-lead', memory: { 'SOUL.md': 'I am Rio, and I block on flaws.' } });
+  try {
+    const out = run(dir, 'tech-lead', { SDLC_VSCODE: '1' });
+    assert.match(out, /I am Rio, and I block on flaws\./);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('SOUL.md is found in the agent directory, not just the memory dir', () => {
+  // On Claude the file ships inside .claude/agents/<role>/, which is where resolve_role_file must
+  // look — a memory-dir-only lookup is exactly how this went unnoticed.
+  const dir = project({ role: 'tech-lead' });
+  try {
+    const agentDir = join(dir, '.claude', 'agents', 'tech-lead');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'SOUL.md'), 'persona from the agent dir');
+    const out = run(dir, 'tech-lead');
+    assert.match(out, /persona from the agent dir/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});

--- a/hooks/lib.sh
+++ b/hooks/lib.sh
@@ -144,18 +144,22 @@ collect_shared_context() {
   printf '%s' "$out"
 }
 
-# Concatenate a role's startup memory — the persona (SOUL.md, injected only for
-# VS Code / Copilot CLI, which reference it softly and don't expand @-imports;
-# Claude expands it natively and Codex inlines it) plus the memory snapshot/index
+# Concatenate a role's startup memory — the persona (SOUL.md) plus the memory snapshot/index
 # (snapshot.md is the generic name, MEMORY.md is the index `init` seeds). Echoes
 # the combined string (empty if the role has no memory dir / no files).
 # $1 = project dir, $2 = role name. Shared by agent-start (subagent dispatch) and
 # session-start (Copilot CLI orchestrator, resolved from session-state).
 # The role-memory file names injected from .agents/memory/<role>/ — a CURATED,
 # configurable list (hook config → $SDLC_ROLE_MEMORY_FILES, space-separated; default
-# below). SOUL.md (the persona) is honored only under Copilot — Claude/Codex receive
-# it via the agent body's @-import, so injecting it here too would duplicate it.
-# Echoes one name per line (after the SOUL gate). Shared by collect_role_memory,
+# below). SOUL.md is injected on EVERY host. It used to be gated to Copilot on the premise
+# that "Claude/Codex receive it via the agent body's @-import" — but no agent has ever
+# contained such an import: all 23 say only "Read `SOUL.md` in this directory", and an agent
+# body is a system prompt, so "this directory" resolves to nothing an agent can act on.
+# The persona therefore reached Claude/Codex through NO channel at all. Measured across two
+# real boards before the fix: 0 of 290 dispatched subagents opened SOUL.md, and 2 of 86 — the
+# one that managed it burned three tool calls hunting the file with `find`.
+# This is the same failure already recorded for RULES.md below, with the same fix: deliver it.
+# Echoes one name per line. Shared by collect_role_memory,
 # build_capped_context's inline memory loop, and list_role_memory_files so all agree.
 # RULES.md sits second on purpose. ORDER IS THE PRIORITY: the inline loop takes
 # files while they still fit the cap and spills the rest to a read-list, so what
@@ -167,9 +171,6 @@ SDLC_ROLE_MEMORY_FILES_DEFAULT="SOUL.md RULES.md snapshot.md MEMORY.md project_b
 role_memory_files() {
   local mf
   for mf in ${SDLC_ROLE_MEMORY_FILES:-$SDLC_ROLE_MEMORY_FILES_DEFAULT}; do
-    if [ "$mf" = "SOUL.md" ] && [ -z "${SDLC_VSCODE:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
-      continue                          # persona arrives via @-import on Claude/Codex
-    fi
     printf '%s\n' "$mf"
   done
 }


### PR DESCRIPTION
## The claim, tested

You suspected agents never read their `SOUL.md`. Measured across two real boards:

| board | subagents | opened SOUL.md |
|---|---|---|
| octoweb | 290 | **0** (0.0%) |
| benchmark | 86 | **2** (2.3%) |

And the one that managed it had to hunt:

```
find <repo> -maxdepth 1 -iname "SOUL.md"        → nothing
find <repo> -iname "SOUL.md" -path "*scout*"    → found by guessing its own name
cat  <repo>/.claude/agents/scout/SOUL.md
```

Three tool calls to open a file it was told to read.

## Root cause

`role_memory_files` gated SOUL.md to Copilot, on this premise:

> *"SOUL.md (the persona) is honored only under Copilot — Claude/Codex receive it via the agent body's @-import, so injecting it here too would duplicate it."*

**No agent has ever contained such an import.** All 23 say only:

```
Read `SOUL.md` in this directory for your personality, voice, and values.
```

An agent body is a system prompt — "this directory" resolves to nothing an agent can act on. So the hook skipped it believing the body imported it, and the body asked the agent to read a path it cannot locate. On Claude and Codex the persona reached the agent through **no channel at all**.

Verified on a live board:

```
resolve_role_file → /…/benchmark/.claude/agents/tech-lead/SOUL.md   ← resolvable
Claude  injects:  RULES.md snapshot.md MEMORY.md project_briefing.md ← SOUL.md absent
Copilot injects:  SOUL.md RULES.md snapshot.md MEMORY.md …           ← present
```

The file was always findable. Only the gate stopped it.

## The same bug, already recorded

A few lines below in the same file:

> *"(Measured: a lead violated a context-frugality rule that lived only in RULES.md, a file no host was installing into its context at all.)"*

Identical failure, already diagnosed once, fixed by delivering the file. This takes the same fix.

## Changes

- **`hooks/lib.sh`** — the gate is removed; `resolve_role_file` already searches `.claude/agents/<role>/`, so nothing else was needed. The stale comments asserting the @-import premise are corrected.
- **22 agents** — the Identity section now states the persona is already in context and names the real path for the rare case something wants the file. Telling an agent to read a file it cannot find isn't a harmless no-op: it costs tool calls when obeyed, and trains the agent to skip instructions when it isn't.

## Regression guard

Three tests in `agent-start.test.mjs`. **Verified they fail (2 of 3) with the gate restored** and pass with it removed — a guard that cannot fail is decoration.

`node --test`: **471 pass, 0 fail**. `npm run validate` clean.

## Not included

Two **untracked** WIP agents exist in the working tree — `bundles/feature-development/agents/designer/` and `bundles/product-management/agents/designer/`. They carry the same broken wording and will need the same Identity fix when they land; I reverted my edit to them rather than touch uncommitted work.
