### PR TITLE
feat(designer): adopt impeccable quality gate + design-story presentation uplift

### DIFF
--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -330,6 +330,12 @@
       "version": "0.2.0"
     },
     {
+      "name": "impeccable",
+      "source": "./skills/impeccable",
+      "description": "Design critique + a deterministic anti-pattern detector (59 non-LLM rules over rendered UI) + live-browser iteration for AI-generated frontends — audit/polish/harden/animate/colorize/typeset playbooks. Apache-2.0, by Paul Bakaus. Used by the designer as a quality gate beside visual-testing.",
+      "version": "0.2.0"
+    },
+    {
       "name": "kotlin-concurrency-and-flow",
       "source": "./skills/kotlin-concurrency-and-flow",
       "description": "Kotlin coroutine scope ownership and Flow modelling — structured concurrency, cancellation, suspend APIs over a stored CoroutineScope, and StateFlow/SharedFlow/Channel for state vs. events (by Chris Banes, Apache-2.0)",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -456,6 +456,12 @@
       "version": "0.2.0"
     },
     {
+      "name": "impeccable",
+      "source": "./skills/impeccable",
+      "description": "Design critique + a deterministic anti-pattern detector (59 non-LLM rules over rendered UI) + live-browser iteration for AI-generated frontends — audit/polish/harden/animate/colorize/typeset playbooks. Apache-2.0, by Paul Bakaus. Used by the designer as a quality gate beside visual-testing.",
+      "version": "0.2.0"
+    },
+    {
       "name": "kotlin-concurrency-and-flow",
       "source": "./skills/kotlin-concurrency-and-flow",
       "description": "Kotlin coroutine scope ownership and Flow modelling — structured concurrency, cancellation, suspend APIs over a stored CoroutineScope, and StateFlow/SharedFlow/Channel for state vs. events (by Chris Banes, Apache-2.0)",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -330,6 +330,12 @@
       "version": "0.2.0"
     },
     {
+      "name": "impeccable",
+      "source": "./skills/impeccable",
+      "description": "Design critique + a deterministic anti-pattern detector (59 non-LLM rules over rendered UI) + live-browser iteration for AI-generated frontends — audit/polish/harden/animate/colorize/typeset playbooks. Apache-2.0, by Paul Bakaus. Used by the designer as a quality gate beside visual-testing.",
+      "version": "0.2.0"
+    },
+    {
       "name": "kotlin-concurrency-and-flow",
       "source": "./skills/kotlin-concurrency-and-flow",
       "description": "Kotlin coroutine scope ownership and Flow modelling — structured concurrency, cancellation, suspend APIs over a stored CoroutineScope, and StateFlow/SharedFlow/Channel for state vs. events (by Chris Banes, Apache-2.0)",

--- a/bundles/feature-development/agents/designer/AGENT.md
+++ b/bundles/feature-development/agents/designer/AGENT.md
@@ -7,7 +7,7 @@ group: core
 theme: {color: colour170, icon: "🎨", short_name: dsn}
 aliases: [remy]
 skills: [brainstorming, memory]
-skills-on-demand: [user-flow-maps, screen-specs, visual-testing]
+skills-on-demand: [user-flow-maps, screen-specs, visual-testing, impeccable]
 metadata:
   authors:
     - Artem Rozumenko <artyom.rozumenko@gmail.com>
@@ -45,10 +45,11 @@ Your role memory and this project's `.agents/*.md` digests (team-comms, profile,
 
 If no flow or acceptance criteria exist yet, ask the BA (Alex) to produce them — or the Product Owner (Priya) if discovery hasn't run. Designing without them produces screens nobody agreed to.
 
-## Three skills, loaded on demand
+## Four skills, loaded on demand
 
-You own two generators and a checker. Load the one the task calls for — they are `skills-on-demand`,
-so they are installed on disk but not in your standing context until you invoke them.
+You own two generators and two checkers. Load the one the task calls for — they are
+`skills-on-demand`, so they are installed on disk but not in your standing context until you invoke
+them.
 
 1. **`user-flow-maps`** — when a flow, journey, or screen-to-screen behaviour needs to become a
    visual map reviewers can sign off on. Platform-agnostic: it renders screens, decisions,
@@ -64,6 +65,15 @@ so they are installed on disk but not in your standing context until you invoke 
    is browser-driven — no headless engine) and diffs each against a committed baseline with `reg-cli`.
    A green diff means unchanged-since-baseline, not correct — read the spec for correctness. Invoke
    the `visual-testing` skill and follow it.
+4. **`impeccable`** — a design-quality gate (external skill, Apache-2.0). Where `visual-testing`
+   asks "did it drift from the baseline", impeccable asks "is it any good" — it runs deterministic
+   anti-slop detectors (generic fonts, template gradients, cards-in-cards) and carries audit /
+   critique / polish playbooks. Run it on a design **after** `screen-specs` produces it, as the
+   taste/quality pass that catches AI-generic output no regression check would. Its findings are
+   prompts to improve, not automatic verdicts. Invoke the `impeccable` skill and follow it.
+
+**The two checks are complementary — run both on a finished design:** `impeccable` for *quality*
+(is this slop?), `visual-testing` for *regression* (did this change vs the approved baseline?).
 
 **Platform scope of `screen-specs`:** it now covers **mobile** (device library —
 iphone / iphone-max / android / iphone-se — and MD3-vs-iOS platform calls) AND

--- a/bundles/feature-development/skills/screen-specs/SKILL.md
+++ b/bundles/feature-development/skills/screen-specs/SKILL.md
@@ -36,8 +36,31 @@ disagree.
    node scripts/build-screens.mjs \
      --system <design-system.json> --specs <dir> --out <dir> [--img ../assets/img/]
    ```
+   Every flow page carries a **journey filmstrip** above its screens — the
+   flow's screens ordered by their `node` id (whole numbers ascending, then
+   decimals under their parent; node-less screens sort last), each a small
+   clickable card that jumps to its full section below. It renders in both
+   layouts.
+
+   Add `--layout story` to build into a shared **design-story site** instead
+   of a standalone set: pages land in `<out>/screens/<slug>.html` (one
+   directory deeper — a relative `--img` base gets an extra `../`
+   automatically) so they sit next to user-flow-maps' `flows/` output. Under
+   `story`, each screen's Flow node value links back to
+   `../flows/<flowSlug>.html#node-<id>`, and its Criteria chips link to
+   `../coverage.html#ac-<id>` — both resolve once the sibling builds
+   (`build-flowmaps.mjs --layout story` and `build-story.mjs`) have run;
+   until then they just 404, no build depends on the other running first.
 4. **Verify.** See `references/verifying.md`. Check that no mock overflows its
    frame, no image is broken, and the page never scrolls sideways.
+5. **Tie flows and screens into one site.** Once both builds have written
+   into the same `<out>` with `--layout story`, run
+   ```bash
+   node scripts/build-story.mjs --flows <flowspec dir|file> --screens <dir> --out <dir>
+   ```
+   to generate `<out>/index.html` (the design-story hub) and
+   `<out>/coverage.html` (the acceptance-criteria coverage matrix). See
+   "Design-story site" below for the full recipe.
 
 ## What a spec carries
 
@@ -100,6 +123,41 @@ Everything resolves through `design-system.json`'s tokens — colour roles becom
 CSS custom properties, the shape scale becomes radii. Swap the palette there and
 every mock in the set follows. Light and dark are both generated.
 
+## Design-story site
+
+The end-to-end recipe that turns the two skills' separate outputs into one
+navigable site a reviewer walks top to bottom — Problem → Journey → Screens →
+Coverage, everything cross-linked:
+
+```bash
+node <user-flow-maps>/scripts/build-flowmaps.mjs <flowspec.json> \
+  --out <dir> --layout story --screens <screens dir>
+
+node scripts/build-screens.mjs \
+  --system <design-system.json> --specs <screens dir> --out <dir> --layout story
+
+node scripts/build-story.mjs \
+  --flows <flowspec.json|dir> --screens <screens dir> --out <dir> [--system <design-system.json>]
+```
+
+All three point `--out` at the **same directory**. Order doesn't matter for
+correctness (each build degrades to a dead link, never a failure, if a
+sibling hasn't run yet), but running `build-story.mjs` last means its hub and
+coverage page reflect what's actually on disk. The result:
+
+```
+<dir>/
+  index.html      # the hub: Problem, Journey, Screens, Coverage
+  coverage.html   # every AC id x which node(s)/screen(s)/state(s) realize it
+  flows/<slug>.html
+  screens/<slug>.html
+```
+
+Open `<dir>/index.html`. It links to each `flows/<slug>.html` (the journey),
+groups screen links by flow in journey order, and summarizes coverage with a
+link to the full matrix — it never re-renders a mock or a poster, only links
+to the pages the other two builds produced.
+
 ## Files
 
 | Path | What it is |
@@ -107,7 +165,9 @@ every mock in the set follows. Light and dark are both generated.
 | `scripts/screenspec.js` | Mobile renderer: tokens, region renderers, device mock, state resolution. Browser and Node. |
 | `scripts/screenspec.web.js` | Web renderer: responsive breakpoints, app shell, region renderers for the web target. Browser and Node. |
 | `scripts/styles.js` | The four selectable web styles (Material UI, Neo-Flat, Minimal-Neutral, Fluent) — palette and token overrides per style. |
-| `scripts/build-screens.mjs` | CLI: design system + specs → linked HTML pages, one per flow, plus a design-system index. |
+| `scripts/build-screens.mjs` | CLI: design system + specs → linked HTML pages, one per flow (with a journey filmstrip), plus a design-system index. `--layout story` cross-links into a shared design-story site. |
+| `scripts/journey.mjs` | `journeyOrder(screens)` — sorts a flow's screens into journey order by `node` id; backs the filmstrip and the hub's per-flow screen groups. |
+| `scripts/build-story.mjs` | CLI: flow spec(s) + screen spec(s) → `index.html` (design-story hub) and `coverage.html` (AC coverage matrix). Reads both builds' inputs, renders neither's mocks — only links. |
 | `references/schema.md` | The spec contract, field by field. |
 | `references/verifying.md` | What to check before calling the set done. |
 | `references/coverage-both-ways.md` | Node→screen *and* screen→node coverage. Run after any flow-map edit — a retired node leaves an orphaned screen that a one-directional check cannot see. |

--- a/bundles/feature-development/skills/screen-specs/scripts/__fixtures__/story/story.screens.json
+++ b/bundles/feature-development/skills/screen-specs/scripts/__fixtures__/story/story.screens.json
@@ -1,0 +1,18 @@
+{
+  "flow": "story-flow",
+  "title": "Story flow screens",
+  "screens": [
+    {
+      "id": "S-001-0",
+      "node": "1",
+      "title": "Result",
+      "purpose": "Show the result of the search.",
+      "ac": ["AC-1"],
+      "nav": { "kind": "root", "title": "Result" },
+      "regions": [
+        { "type": "appbar", "label": "Header", "content": "Result" },
+        { "type": "cta", "label": "Book now", "content": "Book Now" }
+      ]
+    }
+  ]
+}

--- a/bundles/feature-development/skills/screen-specs/scripts/build-screens.mjs
+++ b/bundles/feature-development/skills/screen-specs/scripts/build-screens.mjs
@@ -41,22 +41,38 @@ const LIB = ['styles.js', 'screenspec.js', 'screenspec.web.js']
 const argv = process.argv.slice(2);
 const arg = (k, d) => { const i = argv.indexOf(k); return i >= 0 ? argv[i + 1] : d; };
 if (argv.includes('-h') || argv.includes('--help') || !argv.length) {
-  console.log('usage: build-screens.mjs --system <design-system.json> --specs <dir> --out <dir> [--img ../assets/img/]');
+  console.log('usage: build-screens.mjs --system <design-system.json> --specs <dir> --out <dir> [--img ../assets/img/] [--layout flat|story]');
   process.exit(argv.length ? 0 : 1);
 }
 const sysPath = resolve(arg('--system'));
 const specDir = resolve(arg('--specs', dirname(sysPath)));
 const outDir = resolve(arg('--out', join(specDir, 'html')));
-const imgBase = arg('--img', '../assets/img/');
+const layout = arg('--layout', 'flat');
+let imgBase = arg('--img', '../assets/img/');
+// Story layout writes one directory deeper (<out>/screens/<slug>.html instead
+// of <out>/<slug>.html), so a relative asset base needs one more `../` to
+// still resolve to the same place on disk. Absolute/remote bases pass through.
+if (layout === 'story' && !/^([a-z]+:)?\/\//i.test(imgBase) && !imgBase.startsWith('/')) {
+  imgBase = '../' + imgBase;
+}
 const ds = JSON.parse(readFileSync(sysPath, 'utf8'));
 const specs = readdirSync(specDir).filter(f => f.endsWith('.screens.json'))
   .sort()
   .map(f => ({ file: f, data: JSON.parse(readFileSync(join(specDir, f), 'utf8')) }));
-if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+// Story layout writes per-flow pages into screens/ so they can sit next to
+// build-flowmaps.mjs's flows/ output (and the future design-story hub's
+// index.html) without a filename collision. Flat (default) writes straight
+// to --out, exactly as before.
+const screensDir = layout === 'story' ? join(outDir, 'screens') : outDir;
+if (!existsSync(screensDir)) mkdirSync(screensDir, { recursive: true });
 
 const esc = s => String(s == null ? '' : s)
   .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 const slugOf = s => String(s.flow || s.title || 'flow').toLowerCase().replace(/[^a-z0-9]+/g, '-');
+// Mirrors build-flowmaps.mjs's own `slug()` exactly (same formula, trimmed)
+// so a screen's "Flow node" link to `../flows/<slug>.html` lands on the file
+// that script actually writes for the shared flow key.
+const flowSlugOf = k => String(k || 'flow').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 
 /* -------------------------------------------------------- target-aware chrome
    One design system renders one target throughout a build, so these labels
@@ -351,12 +367,26 @@ for (const { data } of specs) {
 
     const p1=panel('Traceability');
     const dl=el('dl','kv');
+    ${layout === 'story' ? `// story layout (A — cross-link screen -> flow/coverage): the flow node
+    // value links back to its node in the flow poster, and each AC chip links
+    // to its coverage row (coverage.html is T3's; the anchor target is stable
+    // ahead of it existing). FLOW_SLUG mirrors build-flowmaps.mjs's own slug().
+    const FLOW_SLUG=${JSON.stringify(flowSlugOf(data.flow || data.title))};
     const kv=(k,v)=>{if(!v||(Array.isArray(v)&&!v.length))return;
+      dl.appendChild(el('dt',null,k));
+      const dd=el('dd');
+      if(k==='Criteria'){(Array.isArray(v)?v:[v]).forEach(a=>{
+        const s2=el('a','ac'); s2.textContent=a; s2.href='../coverage.html#ac-'+String(a).split(' ')[0]; dd.appendChild(s2);});}
+      else if(k==='Flow node'){(Array.isArray(v)?v:[v]).forEach((n,i)=>{
+        if(i>0) dd.appendChild(document.createTextNode(', '));
+        const nd=el('a',null,String(n)); nd.href='../flows/'+FLOW_SLUG+'.html#node-'+n; dd.appendChild(nd);});}
+      else dd.textContent=Array.isArray(v)?v.join(', '):String(v);
+      dl.appendChild(dd);};` : `const kv=(k,v)=>{if(!v||(Array.isArray(v)&&!v.length))return;
       dl.appendChild(el('dt',null,k));
       const dd=el('dd');
       if(k==='Criteria'){(Array.isArray(v)?v:[v]).forEach(a=>{const s2=el('span','ac');s2.textContent=a;dd.appendChild(s2);});}
       else dd.textContent=Array.isArray(v)?v.join(', '):String(v);
-      dl.appendChild(dd);};
+      dl.appendChild(dd);};`}
     kv('Flow node',s.node); kv('Presentation',(s.nav||{}).kind); kv('Criteria',s.ac);
     if(s.content) kv('Seeded content',Object.entries(s.content).map(([k,v])=>k+': '+v).join(' · '));
     p1.appendChild(dl);
@@ -466,7 +496,7 @@ for (const { data } of specs) {
   ` : ''}
 })();
 `;
-  writeFileSync(join(outDir, slug + '.html'),
+  writeFileSync(join(screensDir, slug + '.html'),
     page({ title: (data.flow ? data.flow + ' screens' : data.title), body, data: { ...data, system: ds }, glue }));
   console.log('wrote', slug + '.html');
 }
@@ -567,7 +597,7 @@ const indexGlue = `
 })();
 `;
 const totalScreens = specs.reduce((a, s) => a + (s.data.screens || []).length, 0);
-writeFileSync(join(outDir, 'index.html'),
+writeFileSync(join(screensDir, 'index.html'),
   page({ title: (ds.name || 'Design system'), body: indexBody,
          data: { system: ds, flows: specs.length, screens: totalScreens }, glue: indexGlue }));
 console.log('wrote index.html');

--- a/bundles/feature-development/skills/screen-specs/scripts/build-screens.mjs
+++ b/bundles/feature-development/skills/screen-specs/scripts/build-screens.mjs
@@ -25,6 +25,12 @@ const require = createRequire(import.meta.url);
 // mobile and web capability.
 const ScreenSpec = require(join(__dirname, 'screenspec.js'));
 require(join(__dirname, 'screenspec.web.js'));
+// journey.mjs is pure ESM, unit-tested on its own (journey.test.mjs). The
+// filmstrip renders client-side from the same DATA the rest of the page's
+// glue reads, so journeyOrder()'s source is inlined into the browser
+// <script> below (next to LIB) rather than `require`d/`import`ed server-side.
+const JOURNEY_SRC = readFileSync(join(__dirname, 'journey.mjs'), 'utf8')
+  .replace(/export\s+function\s+journeyOrder/, 'function journeyOrder');
 // The page's inlined <script> runs in a browser, not Node, so it needs the
 // three UMD sources concatenated (styles first, then core, then web) rather
 // than the `require`d objects above — those only serve Node-side rendering.
@@ -105,6 +111,19 @@ h2{font-size:23px;line-height:30px;font-weight:500;margin:0}
   border:1px solid var(--m-outline-variant);background:var(--m-surface-container-low);
   color:var(--m-on-surface-variant);font-size:13px;font-weight:500;font-family:inherit}
 .bpbtn.on{background:var(--m-secondary-container);color:var(--m-on-secondary-container);border-color:transparent}
+.filmstrip-wrap{margin-top:28px}
+.filmstrip-wrap h2{font-size:15px}
+.filmstrip{display:flex;align-items:center;gap:2px;overflow-x:auto;overflow-y:hidden;
+  padding:14px 2px 16px;scrollbar-width:thin}
+.filmstrip::-webkit-scrollbar{height:8px}
+.filmstrip::-webkit-scrollbar-thumb{background:var(--m-outline-variant);border-radius:4px}
+.filmcard{flex:0 0 auto;display:flex;flex-direction:column;gap:4px;width:132px;padding:10px 12px;
+  border-radius:12px;border:1px solid var(--m-outline-variant);background:var(--m-surface-container-low);
+  text-decoration:none;color:inherit}
+.filmcard:hover{border-color:var(--m-primary)}
+.filmcard .fc-id{font-family:ui-monospace,Menlo,monospace;font-size:11px;color:var(--m-primary)}
+.filmcard .fc-title{font-size:12.5px;line-height:16px;font-weight:500;color:var(--m-on-surface)}
+.filmarrow{flex:0 0 auto;width:22px;text-align:center;color:var(--m-outline-variant);font-size:16px}
 .screen{margin-top:44px;border-top:1px solid var(--m-outline-variant);padding-top:28px}
 .screen h2 .id{font-family:ui-monospace,Menlo,monospace;font-size:13px;color:var(--m-primary);margin-right:10px}
 .purpose{margin:8px 0 0;font-size:15px;line-height:23px;color:var(--m-on-surface-variant);max-width:74ch}
@@ -179,6 +198,7 @@ ${body}
 const DATA=JSON.parse(document.getElementById('d').textContent);
 const IMG=${JSON.stringify(imgBase)};
 const el=(t,c,x)=>{const n=document.createElement(t);if(c)n.className=c;if(x!=null)n.textContent=x;return n;};
+${JOURNEY_SRC}
 ${glue}
 /* A mock renders from the top of the screen. When a state's point sits further
    down — an inline error beside the stepper that triggered it — scroll the
@@ -218,6 +238,10 @@ for (const { data } of specs) {
   <div class="meta" id="meta"></div>
   ${isWebDS ? '<div class="meta" id="bptoggle"></div>' : ''}
 </header>
+<div class="filmstrip-wrap">
+  <h2>Journey</h2>
+  <div class="filmstrip" id="filmstrip"></div>
+</div>
 <div id="screens"></div>
 <footer><p>Mocks render the spec's own <code>regions</code> through the tokens in <code>design-system.json</code>. They show structure, hierarchy and real seeded content — not final visual polish. Where a spec records an open question, it is reproduced verbatim rather than resolved.</p></footer>`;
 
@@ -230,6 +254,23 @@ for (const { data } of specs) {
   const calls=scr.reduce((a,s)=>a+((s.platform||[]).length),0);
   [[scr.length+' screens',1],[states+' states',0],[acs.size+' criteria',0],[calls+' platform calls',0]]
     .forEach(([t,on])=>{const c=el('div','chip'+(on?' on':''));c.textContent=t;m.appendChild(c);});
+
+  // Journey filmstrip: the flow's screens in journey order (by node id),
+  // each a small card linking to its full section further down the page.
+  // Layout-independent — same markup regardless of how the sections below
+  // are arranged — and reads only \`s.id\`/\`s.title\`, so it never touches
+  // ScreenSpec.mock()'s render path.
+  const film=document.getElementById('filmstrip');
+  if(film){
+    const ordered=journeyOrder(scr);
+    ordered.forEach((s,i)=>{
+      if(i>0){const ar=el('span','filmarrow');ar.textContent='→';ar.setAttribute('aria-hidden','true');film.appendChild(ar);}
+      const a=el('a','filmcard'); a.href='#'+s.id;
+      a.appendChild(el('div','fc-id',s.id));
+      a.appendChild(el('div','fc-title',s.title||''));
+      film.appendChild(a);
+    });
+  }
 
   const host=document.getElementById('screens');
   // Rebuildable: a web page's breakpoint toggle re-invokes this for every

--- a/bundles/feature-development/skills/screen-specs/scripts/build-story.mjs
+++ b/bundles/feature-development/skills/screen-specs/scripts/build-story.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+/**
+ * build-story.mjs — the design-story hub (C) and coverage matrix (E).
+ *
+ *   node build-story.mjs --flows <flowspec.json|dir> --screens <dir|glob of *.screens.json>
+ *                         --out <dir> [--system <design-system.json>]
+ *
+ * Reads BOTH a flow spec (build-flowmaps.mjs's input) and screen spec(s)
+ * (build-screens.mjs's input) and writes two pages into <out>/, the same
+ * site both `--layout story` builds write `flows/<slug>.html` and
+ * `screens/<slug>.html` into (see docs/superpowers/specs/2026-08-17-design-
+ * story-presentation-uplift.md, section "design-story site layout"):
+ *
+ *   <out>/index.html      — Problem -> Journey -> Screens -> Coverage
+ *   <out>/coverage.html   — every AC id x which node(s)/screen(s)/state(s)
+ *                           realize it, red where it's a gap
+ *
+ * This script does not render mocks or flow posters — it only links to the
+ * pages the other two builds produce. It never modifies them.
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { journeyOrder } from './journey.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/* ------------------------------------------------------------ AC ids
+ * Two idioms already exist, one per side of the join, and cross-links from
+ * T2 already hard-code them into hrefs. Reproducing the exact expressions
+ * (not inventing a third) is what keeps `coverage.html#ac-<id>` resolving
+ * against what a flow/screen page actually emits. */
+
+// Mirrors flowmap.js's own parseAc() regex: a flow transition's `ac` is one
+// free-text string that may name several ids plus trailing prose
+// ("AC-2.1 AC-2.2 - see note").
+const AC_RE = /(?:AC|HYP)-[0-9]+(?:\.[0-9]+)*(?:\/[0-9.]+)*/g;
+
+// A token itself may be slash-joined shorthand for sibling ids
+// ("AC-1.1/1.2" meaning AC-1.1 and AC-1.2"). The token as matched is always
+// kept FIRST and whole, because that is the literal string build-screens.mjs
+// puts in `coverage.html#ac-<...>` hrefs (String(a).split(' ')[0], never
+// slash-split) — losing it would break the anchor those hrefs target. The
+// split constituents are added after it purely so each sibling criterion
+// still gets its own coverage row.
+function expandSlash(id) {
+  if (!id.includes('/')) return [id];
+  const m = id.match(/^([A-Za-z]+-)([0-9.]+)((?:\/[0-9.]+)+)$/);
+  if (!m) return [id];
+  const [, prefix, first, restSlashed] = m;
+  const rest = restSlashed.slice(1).split('/');
+  return [id, prefix + first, ...rest.map(p => prefix + p)];
+}
+
+function flowAcIds(raw) {
+  if (raw == null) return [];
+  const ids = String(raw).match(AC_RE) || [];
+  return [...new Set(ids.flatMap(expandSlash))];
+}
+
+// Mirrors build-screens.mjs's own anchor normalization exactly:
+// String(a).split(' ')[0] applied to one screen/region/state `ac` entry.
+function screenAcIds(raw) {
+  const arr = raw == null ? [] : (Array.isArray(raw) ? raw : [raw]);
+  return [...new Set(arr.flatMap(a => expandSlash(String(a).split(' ')[0])))];
+}
+
+/* ------------------------------------------------------------ slugs
+ * Copied verbatim from build-flowmaps.mjs's slug() and build-screens.mjs's
+ * slugOf(), so a flow/screen's URL here is byte-for-byte the file the other
+ * build actually writes. */
+const flowSlug = f => String(f.key || f.title || 'flow').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+const screenSlug = s => String(s.flow || s.title || 'flow').toLowerCase().replace(/[^a-z0-9]+/g, '-');
+
+const esc = s => String(s == null ? '' : s)
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+/* ------------------------------------------------------------ computeCoverage
+ * Pure data transform, no file/DOM IO — the unit-tested core (E).
+ *
+ *   flowSpecs:   [ { title, flows:[...], findings:[...] }, ... ]  (as loaded
+ *                from --flows; build-flowmaps.mjs's own spec shape)
+ *   screenSpecs: [ { flow, title, screens:[...] }, ... ]          (as loaded
+ *                from --screens; build-screens.mjs's own spec shape)
+ *
+ * Returns { [acId]: { nodes:[{flowKey,flowSlug,nodeId}],
+ *                      screens:[{screenSlug,screenId,flow}],
+ *                      states:[{screenSlug,screenId,stateName}],
+ *                      gap: bool, findings:[{title,tone}] } }
+ *
+ * A criterion is a gap when either:
+ *   - no screen realizes it (referenced by a node/state but never listed on
+ *     a screen), or
+ *   - it is named in a flow spec's `findings` prose (findings carry no
+ *     structured `ac` field, so this scans title+body the same way a
+ *     transition's own trailing note is read) — a known issue even where a
+ *     screen nominally exists.
+ */
+export function computeCoverage({ flowSpecs = [], screenSpecs = [] } = {}) {
+  const criteria = {};
+  const ensure = id => criteria[id] || (criteria[id] = { nodes: [], screens: [], states: [], gap: false, findings: [] });
+
+  for (const doc of flowSpecs) {
+    for (const flow of doc.flows || []) {
+      const key = flow.key || flow.title || 'flow';
+      const fSlug = flowSlug(flow);
+      for (const node of flow.nodes || []) {
+        for (const t of node.transitions || []) {
+          for (const id of flowAcIds(t.ac)) {
+            const c = ensure(id);
+            if (!c.nodes.some(n => n.flowKey === key && n.nodeId === node.id)) {
+              c.nodes.push({ flowKey: key, flowSlug: fSlug, nodeId: node.id });
+            }
+          }
+        }
+      }
+    }
+    for (const f of doc.findings || []) {
+      const text = [f.title, f.body].filter(Boolean).join(' ');
+      for (const id of flowAcIds(text)) {
+        const c = ensure(id);
+        c.gap = true;
+        c.findings.push({ title: f.title, tone: f.tone || '' });
+      }
+    }
+  }
+
+  for (const doc of screenSpecs) {
+    const sSlug = screenSlug(doc);
+    for (const screen of doc.screens || []) {
+      const addScreen = id => {
+        const c = ensure(id);
+        if (!c.screens.some(s => s.screenSlug === sSlug && s.screenId === screen.id)) {
+          c.screens.push({ screenSlug: sSlug, screenId: screen.id, flow: doc.flow });
+        }
+        return c;
+      };
+      screenAcIds(screen.ac).forEach(addScreen);
+      (screen.regions || []).forEach(r => screenAcIds(r.ac).forEach(addScreen));
+      (screen.states || []).forEach(st => {
+        screenAcIds(st.ac).forEach(id => {
+          addScreen(id);
+          const c = criteria[id];
+          if (!c.states.some(s => s.screenSlug === sSlug && s.screenId === screen.id && s.stateName === st.name)) {
+            c.states.push({ screenSlug: sSlug, screenId: screen.id, stateName: st.name });
+          }
+        });
+      });
+    }
+  }
+
+  for (const c of Object.values(criteria)) {
+    if (c.screens.length === 0) c.gap = true;
+  }
+
+  return criteria;
+}
+
+/* ------------------------------------------------------------------ CLI */
+function main() {
+  const argv = process.argv.slice(2);
+  const arg = (k, d) => { const i = argv.indexOf(k); return i >= 0 ? argv[i + 1] : d; };
+  if (argv.includes('-h') || argv.includes('--help') || !argv.length) {
+    console.log('usage: build-story.mjs --flows <flowspec.json|dir> --screens <dir|glob of *.screens.json> --out <dir> [--system <design-system.json>]');
+    process.exit(argv.length ? 0 : 1);
+  }
+  const flowsArg = resolve(arg('--flows'));
+  const screensArg = resolve(arg('--screens'));
+  const outDir = resolve(arg('--out'));
+  const sysPath = arg('--system');
+  if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+
+  const flowSpecs = loadDocs(flowsArg, '.flowspec.json');
+  const screenSpecs = loadDocs(screensArg, '.screens.json');
+  const ds = sysPath ? JSON.parse(readFileSync(resolve(sysPath), 'utf8')) : null;
+
+  const coverage = computeCoverage({ flowSpecs, screenSpecs });
+
+  writeFileSync(join(outDir, 'coverage.html'), coveragePage({ coverage }));
+  console.log('wrote coverage.html');
+
+  writeFileSync(join(outDir, 'index.html'), hubPage({ flowSpecs, screenSpecs, coverage, ds }));
+  console.log('wrote index.html');
+  console.log('\n→', outDir);
+}
+
+// Loads one JSON doc from a file path, or every matching *.suffix file from a
+// directory (screen-specs' own loadScreenSpecs()/build-flowmaps.mjs's
+// loadScreenSpecs() do the same file-vs-dir dance for their own inputs).
+function loadDocs(p, suffix) {
+  if (!p || !existsSync(p)) return [];
+  if (statSync(p).isDirectory()) {
+    return readdirSync(p).filter(f => f.endsWith(suffix)).sort()
+      .map(f => JSON.parse(readFileSync(join(p, f), 'utf8')));
+  }
+  return [JSON.parse(readFileSync(p, 'utf8'))];
+}
+
+/* ------------------------------------------------------------ page chrome
+ * A self-contained look-alike of the two builds' own CHROME/CSS (same token
+ * names, light+dark via prefers-color-scheme) so the hub and coverage pages
+ * read as part of the same site rather than a bolted-on nav bar. */
+const CHROME = `
+*{box-sizing:border-box}
+:root{
+  --surface:#f7fafa;--on-surface:#111;--sc-low:#eef4f4;--sc:#e6eded;--outline-variant:#c7d1d1;
+  --primary:#00696e;--on-primary:#fff;--primary-container:#9df0f7;--on-primary-container:#002022;
+  --secondary-container:#cce8ea;--on-secondary-container:#051f21;
+  --error:#ba1a1a;--error-container:#ffdad6;--on-error-container:#410002;
+}
+@media (prefers-color-scheme:dark){:root{
+  --surface:#0e1414;--on-surface:#dee4e4;--sc-low:#161d1d;--sc:#1a2121;--outline-variant:#3f4948;
+  --primary:#4ddae4;--on-primary:#00363a;--primary-container:#004f53;--on-primary-container:#9df0f7;
+  --secondary-container:#324b4e;--on-secondary-container:#cce8ea;
+  --error:#ffb4ab;--error-container:#93000a;--on-error-container:#ffdad6;
+}}
+body{margin:0;background:var(--surface);color:var(--on-surface);
+  font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;-webkit-font-smoothing:antialiased}
+.wrap{max-width:1120px;margin:0 auto;padding:0 24px 96px}
+.mono{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+nav.bar{display:flex;flex-wrap:wrap;gap:8px;padding:14px 0;position:sticky;top:0;z-index:30;
+  background:var(--surface);border-bottom:1px solid var(--outline-variant)}
+nav.bar a{display:inline-flex;align-items:center;height:32px;padding:0 12px;border-radius:8px;text-decoration:none;
+  font-size:13px;font-weight:500;color:var(--on-surface);border:1px solid var(--outline-variant)}
+nav.bar a.here{background:var(--secondary-container);color:var(--on-secondary-container);border-color:transparent}
+header{padding:46px 0 6px}
+.eyebrow{display:inline-flex;align-items:center;gap:8px;text-transform:uppercase;font-size:12px;font-weight:600;
+  letter-spacing:.6px;color:var(--primary);margin-bottom:12px}
+.eyebrow::before{content:"";width:24px;height:2px;background:var(--primary);border-radius:2px}
+h1{font-size:36px;line-height:44px;font-weight:400;margin:0;text-wrap:balance}
+h2{font-size:23px;line-height:30px;font-weight:500;margin:0}
+.lede{margin-top:14px;max-width:70ch;font-size:16px;line-height:24px;color:var(--on-surface)}
+.meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:18px}
+.chip{display:inline-flex;align-items:center;height:32px;padding:0 12px;border-radius:8px;
+  border:1px solid var(--outline-variant);background:var(--sc-low);color:var(--on-surface);font-size:13.5px;font-weight:500}
+.chip.on{background:var(--secondary-container);color:var(--on-secondary-container);border-color:transparent}
+.chip.gap{background:var(--error-container);color:var(--on-error-container);border-color:transparent}
+section{margin-top:52px}
+.sec-num{display:inline-flex;align-items:center;gap:10px;font-size:12px;font-weight:600;letter-spacing:.6px;
+  text-transform:uppercase;color:var(--primary);margin-bottom:10px}
+.sec-num .n{width:26px;height:26px;border-radius:8px;background:var(--primary-container);color:var(--on-primary-container);
+  display:grid;place-items:center;font-size:12px}
+.lead{max-width:74ch;font-size:15px;line-height:23px;color:var(--on-surface)}
+.cards{display:grid;gap:14px;margin-top:18px}
+@media(min-width:760px){.cards{grid-template-columns:repeat(auto-fill,minmax(320px,1fr))}}
+a.card{display:block;text-decoration:none;color:inherit;border:1px solid var(--outline-variant);border-radius:16px;
+  padding:18px 20px;background:var(--sc-low)}
+a.card:hover{background:var(--sc);border-color:var(--primary)}
+a.card .k{font-family:ui-monospace,Menlo,monospace;font-size:12px;color:var(--primary)}
+a.card h3{margin:6px 0 8px;font-size:17px;line-height:23px;font-weight:500}
+a.card .s{font-size:12.5px;color:var(--on-surface)}
+.flowgroup{margin-top:26px}
+.flowgroup h3{font-size:16px;font-weight:500;margin:0 0 12px}
+.screenchips{display:flex;flex-wrap:wrap;gap:8px}
+a.screenchip{display:inline-flex;align-items:center;gap:8px;text-decoration:none;color:inherit;
+  border:1px solid var(--outline-variant);border-radius:10px;padding:8px 12px;background:var(--sc-low);font-size:13px}
+a.screenchip:hover{border-color:var(--primary)}
+a.screenchip .id{font-family:ui-monospace,Menlo,monospace;font-size:11px;color:var(--primary)}
+table{border-collapse:collapse;width:100%;font-size:13px;line-height:19px}
+th,td{text-align:left;padding:9px 12px;border-bottom:1px solid var(--outline-variant);vertical-align:top}
+th{font-size:10.5px;text-transform:uppercase;letter-spacing:.5px;color:var(--on-surface);background:var(--sc);white-space:nowrap}
+tbody tr:last-child td{border-bottom:0}
+tr.gap{background:var(--error-container)}
+tr.gap td{color:var(--on-error-container)}
+td.id{font-family:ui-monospace,Menlo,monospace;font-size:12px;white-space:nowrap}
+.tw{overflow-x:auto;border:1px solid var(--outline-variant);border-radius:12px}
+.status{display:inline-block;font-size:10.5px;font-weight:700;letter-spacing:.5px;text-transform:uppercase;
+  padding:2px 8px;border-radius:6px}
+.status.ok{background:var(--secondary-container);color:var(--on-secondary-container)}
+.status.gap{background:var(--error);color:#fff}
+.linklist{margin:0;padding:0;list-style:none;display:flex;flex-wrap:wrap;gap:6px}
+.linklist a{font-size:12px}
+.empty{color:var(--on-surface);opacity:.65;font-size:12px}
+footer{margin-top:70px;padding-top:20px;border-top:1px solid var(--outline-variant);font-size:12px;line-height:18px;color:var(--on-surface)}
+a{color:var(--primary)}
+:focus-visible{outline:3px solid var(--primary);outline-offset:2px}
+`;
+
+function shell({ title, body }) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${esc(title)}</title>
+<style>${CHROME}</style>
+</head>
+<body>
+<div class="wrap">
+${body}
+</div>
+</body>
+</html>
+`;
+}
+
+function topNav(current) {
+  return `<nav class="bar">
+  <a class="${current === 'index' ? 'here' : ''}" href="index.html">Design story</a>
+  <a class="${current === 'coverage' ? 'here' : ''}" href="coverage.html">Coverage</a>
+</nav>`;
+}
+
+/* ------------------------------------------------------------ coverage.html (E) */
+function coveragePage({ coverage }) {
+  const ids = Object.keys(coverage).sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  const gapCount = ids.filter(id => coverage[id].gap).length;
+
+  const nodeLinks = c => c.nodes.length
+    ? `<ul class="linklist">${c.nodes.map(n =>
+        `<li><a href="flows/${esc(n.flowSlug)}.html#node-${esc(n.nodeId)}">${esc(n.flowKey)} · node ${esc(n.nodeId)}</a></li>`).join('')}</ul>`
+    : '<span class="empty">none</span>';
+  const screenLinks = c => c.screens.length
+    ? `<ul class="linklist">${c.screens.map(s =>
+        `<li><a href="screens/${esc(s.screenSlug)}.html#${esc(s.screenId)}">${esc(s.screenId)}</a></li>`).join('')}</ul>`
+    : '<span class="empty">none — gap</span>';
+  const stateLinks = c => c.states.length
+    ? `<ul class="linklist">${c.states.map(s =>
+        `<li><a href="screens/${esc(s.screenSlug)}.html#${esc(s.screenId)}">${esc(s.stateName)}</a></li>`).join('')}</ul>`
+    : '<span class="empty">—</span>';
+
+  const rows = ids.map(id => {
+    const c = coverage[id];
+    const cls = c.gap ? 'row gap' : 'row';
+    const noteBits = c.findings.map(f => esc(f.title)).join('; ');
+    return `<tr class="${cls}" id="ac-${esc(id)}">
+  <td class="id">${esc(id)}</td>
+  <td>${nodeLinks(c)}</td>
+  <td>${screenLinks(c)}</td>
+  <td>${stateLinks(c)}</td>
+  <td><span class="status ${c.gap ? 'gap' : 'ok'}">${c.gap ? 'Gap' : 'Covered'}</span>${noteBits ? `<div class="acnote">${noteBits}</div>` : ''}</td>
+</tr>`;
+  }).join('\n');
+
+  const body = `${topNav('coverage')}
+<header>
+  <div class="eyebrow">Coverage</div>
+  <h1>Every acceptance criterion, and what realizes it</h1>
+  <p class="lede">One row per criterion referenced anywhere in the flow or the screens: the flow node(s) that transition on it, the screen(s) that list it, and the state(s) it drives. A criterion with no realizing screen — or named as an open issue in a flow's findings — is a gap.</p>
+  <div class="meta">
+    <div class="chip on">${ids.length} criteri${ids.length === 1 ? 'on' : 'a'}</div>
+    <div class="chip">${ids.length - gapCount} covered</div>
+    <div class="chip${gapCount ? ' gap' : ''}">${gapCount} gap${gapCount === 1 ? '' : 's'}</div>
+  </div>
+</header>
+<section>
+  <div class="tw"><table>
+    <thead><tr><th>Criterion</th><th>Flow node(s)</th><th>Screen(s)</th><th>State(s)</th><th>Status</th></tr></thead>
+    <tbody>
+${rows || '<tr><td colspan="5" class="empty">No criteria found in the supplied specs.</td></tr>'}
+    </tbody>
+  </table></div>
+</section>
+<footer><p>Generated by <code>build-story.mjs</code> from the flow spec(s) passed via <code>--flows</code> and the screen spec(s) passed via <code>--screens</code>. It renders nothing from either — every link here opens the page the matching build actually produced.</p></footer>`;
+
+  return shell({ title: 'Coverage — design story', body });
+}
+
+/* ------------------------------------------------------------ index.html (C) */
+function hubPage({ flowSpecs, screenSpecs, coverage, ds }) {
+  const flows = flowSpecs.flatMap(doc => doc.flows || []);
+  const findingsAll = flowSpecs.flatMap(doc => doc.findings || []);
+  const ids = Object.keys(coverage);
+  const gapCount = ids.filter(id => coverage[id].gap).length;
+
+  const screensByFlowKey = {};
+  for (const doc of screenSpecs) {
+    if (doc.flow == null) continue;
+    screensByFlowKey[doc.flow] = doc;
+  }
+
+  const setTitle = flowSpecs[0]?.title || (ds && ds.name) || 'Design story';
+
+  /* --- Problem --- */
+  const problemCards = flows.map(f => `<div class="card" style="padding:18px 20px">
+  <div class="k mono" style="color:var(--primary);font-size:12px">${esc(f.key || '')}</div>
+  <h3 style="margin:6px 0 8px;font-size:17px;font-weight:500">${esc(f.title || f.key || 'Flow')}</h3>
+  ${f.trigger ? `<p class="lead" style="margin:0 0 6px"><b>Trigger —</b> ${esc(f.trigger)}</p>` : ''}
+  ${f.bet ? `<p class="lead" style="margin:0"><b>The bet —</b> ${esc(f.bet)}</p>` : ''}
+</div>`).join('\n');
+
+  /* --- Journey --- */
+  const journeyCards = flows.map(f => {
+    const slug = flowSlug(f);
+    const screenDoc = screensByFlowKey[f.key];
+    const screenCount = screenDoc ? (screenDoc.screens || []).length : 0;
+    const nodeCount = (f.nodes || []).length;
+    return `<a class="card" href="flows/${esc(slug)}.html">
+  <div class="k">${esc(f.key || '')}</div>
+  <h3>${esc(f.title || f.key || 'Flow')}</h3>
+  <div class="s">${nodeCount} node${nodeCount === 1 ? '' : 's'} · ${screenCount} screen${screenCount === 1 ? '' : 's'}</div>
+</a>`;
+  }).join('\n');
+
+  /* --- Screens, grouped by flow in journey order --- */
+  const screenGroups = flows.map(f => {
+    const slug = flowSlug(f);
+    const screenDoc = screensByFlowKey[f.key];
+    if (!screenDoc || !(screenDoc.screens || []).length) {
+      return `<div class="flowgroup">
+  <h3>${esc(f.title || f.key || 'Flow')}</h3>
+  <p class="empty">No screens yet.</p>
+</div>`;
+    }
+    const sSlug = screenSlug(screenDoc);
+    const ordered = journeyOrder(screenDoc.screens);
+    const chips = ordered.map(s => `<a class="screenchip" href="screens/${esc(sSlug)}.html#${esc(s.id)}">
+  <span class="id">${esc(s.id)}</span>${esc(s.title || '')}
+</a>`).join('');
+    return `<div class="flowgroup">
+  <h3><a href="screens/${esc(sSlug)}.html">${esc(f.title || f.key || 'Flow')}</a></h3>
+  <div class="screenchips">${chips}</div>
+</div>`;
+  }).join('\n');
+
+  const body = `${topNav('index')}
+<header>
+  <div class="eyebrow">Design story</div>
+  <h1>${esc(setTitle)}</h1>
+  <p class="lede">Walk the story top to bottom: the problem that started it, the journey a guest takes through it, every screen that journey renders, and the acceptance criteria that tie it all back to the backlog.</p>
+  <div class="meta">
+    <div class="chip on">${flows.length} flow${flows.length === 1 ? '' : 's'}</div>
+    <div class="chip">${ids.length} criteria</div>
+    <div class="chip${gapCount ? ' gap' : ''}">${gapCount} gap${gapCount === 1 ? '' : 's'}</div>
+  </div>
+</header>
+
+<section>
+  <div class="sec-num"><span class="n">01</span>Problem</div>
+  <p class="lead">What each flow is betting on, and the trigger that starts it.</p>
+  <div class="cards">${problemCards || '<p class="empty">No flows in the supplied spec.</p>'}</div>
+</section>
+
+<section>
+  <div class="sec-num"><span class="n">02</span>Journey</div>
+  <p class="lead">Open a flow to walk its poster — every screen, branch and failure path, tagged to the criterion it satisfies.</p>
+  <div class="cards">${journeyCards || '<p class="empty">No flows in the supplied spec.</p>'}</div>
+</section>
+
+<section>
+  <div class="sec-num"><span class="n">03</span>Screens</div>
+  <p class="lead">Every screen the journey renders, in the order a guest reaches it.</p>
+  ${screenGroups}
+</section>
+
+<section>
+  <div class="sec-num"><span class="n">04</span>Coverage</div>
+  <p class="lead">${ids.length} acceptance criteri${ids.length === 1 ? 'on' : 'a'} referenced across the flow(s) and screens: <b>${ids.length - gapCount} covered</b>, <b>${gapCount} gap${gapCount === 1 ? '' : 's'}</b>.</p>
+  <p><a class="card" href="coverage.html" style="display:inline-block">Open the coverage matrix →</a></p>
+  ${findingsAll.length ? `<details style="margin-top:16px"><summary style="cursor:pointer;color:var(--primary)">${findingsAll.length} finding${findingsAll.length === 1 ? '' : 's'} from the flow spec</summary>
+  ${findingsAll.map(f => `<div class="card" style="margin-top:10px;padding:14px 18px"><b>${esc(f.title)}</b><p class="lead" style="margin-top:4px">${esc(f.body)}</p></div>`).join('')}
+  </details>` : ''}
+</section>
+
+<footer><p>Generated by <code>build-story.mjs</code> from the flow spec(s) and screen spec(s) it was pointed at. It links to <code>flows/</code> and <code>screens/</code> — the pages <code>build-flowmaps.mjs --layout story</code> and <code>build-screens.mjs --layout story</code> write — and renders nothing itself.</p></footer>`;
+
+  return shell({ title: setTitle, body });
+}
+
+/* Only run the file-IO/HTML side when invoked directly, so
+ * `import { computeCoverage }` (the test file's unit-test path) never
+ * touches argv or the filesystem. Must run after every const/function above
+ * it references (CHROME, shell, coveragePage, hubPage) is initialized. */
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) main();

--- a/bundles/feature-development/skills/screen-specs/scripts/build-story.test.mjs
+++ b/bundles/feature-development/skills/screen-specs/scripts/build-story.test.mjs
@@ -1,0 +1,149 @@
+// scripts/build-story.test.mjs
+//
+// T3: build-story.mjs — coverage (E) + design-story hub (C).
+//
+// Two layers:
+//   1. computeCoverage() — pure, no file/DOM IO. Fixture flow+screen specs
+//      share a flow key/node id/ac id so one criterion resolves as covered
+//      and one (referenced only in a flow `findings` entry, with no screen)
+//      resolves as a gap.
+//   2. CLI build-smoke — run the real binary against tiny fixture files
+//      written to a tmpdir, assert coverage.html + index.html exist and
+//      carry the expected anchors/links.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { computeCoverage } from './build-story.mjs';
+
+const __d = dirname(fileURLToPath(import.meta.url));
+const BUILD = join(__d, 'build-story.mjs');
+
+/* -------------------------------------------------------- fixture specs */
+// One flow, two nodes, two criteria:
+//   AC-1 — has a transition AND a screen that lists it -> covered.
+//   AC-2 — has a transition only; no screen realizes it, and a `findings`
+//          entry names it in prose -> gap (both by the "no screen" rule and
+//          the "named in findings" rule).
+const flowDoc = {
+  title: 'Fixture flow',
+  flows: [
+    {
+      key: 'story-flow',
+      title: 'Flow map — story-flow: Test',
+      trigger: 'Guest opens the app',
+      bet: 'A faster path to booking',
+      nodes: [
+        { id: '0', label: 'Start', transitions: [{ target: '1', trigger: 'go', kind: 'primary', nav: 'push', ac: 'AC-1' }] },
+        { id: '1', label: 'Result', transitions: [{ target: '2', trigger: 'confirm', kind: 'primary', nav: 'push', ac: 'AC-2' }] },
+        { id: '2', label: 'End', transitions: [] }
+      ]
+    }
+  ],
+  findings: [
+    { group: 'Gaps', title: 'AC-2 has no screen', tone: 'warn', body: 'Confirmation screen not yet designed for AC-2.' }
+  ]
+};
+
+const screensDoc = {
+  flow: 'story-flow',
+  title: 'Story flow screens',
+  screens: [
+    {
+      id: 'S-001-0',
+      node: '1',
+      title: 'Result',
+      purpose: 'show result',
+      ac: ['AC-1'],
+      nav: { kind: 'root', title: 'Result' },
+      regions: [{ type: 'appbar', label: 'Header', content: 'Result' }],
+      states: [{ name: 'Loaded', trigger: 'data arrives', ac: ['AC-1'] }]
+    }
+  ]
+};
+
+/* --------------------------------------------------------- computeCoverage */
+test('computeCoverage: covered criterion lists its node, screen and state', () => {
+  const cov = computeCoverage({ flowSpecs: [flowDoc], screenSpecs: [screensDoc] });
+  assert.ok(cov['AC-1'], 'AC-1 present');
+  assert.equal(cov['AC-1'].gap, false);
+  assert.ok(cov['AC-1'].nodes.some(n => n.nodeId === '0' && n.flowKey === 'story-flow'), 'node realizes AC-1');
+  assert.ok(cov['AC-1'].screens.some(s => s.screenId === 'S-001-0'), 'screen realizes AC-1');
+  assert.ok(cov['AC-1'].states.some(s => s.stateName === 'Loaded'), 'state realizes AC-1');
+});
+
+test('computeCoverage: criterion with no realizing screen is a gap', () => {
+  const cov = computeCoverage({ flowSpecs: [flowDoc], screenSpecs: [screensDoc] });
+  assert.ok(cov['AC-2'], 'AC-2 present (referenced by a transition)');
+  assert.equal(cov['AC-2'].gap, true);
+  assert.equal(cov['AC-2'].screens.length, 0);
+  assert.ok(cov['AC-2'].nodes.some(n => n.nodeId === '1'), 'still tracks the node that references it');
+});
+
+test('computeCoverage: a criterion named in `findings` prose is flagged gap even if realized', () => {
+  const doc = {
+    ...flowDoc,
+    findings: [{ group: 'Gaps', title: 'AC-1 needs a second look', tone: 'warn', body: 'Screen exists but under-specifies AC-1.' }]
+  };
+  const cov = computeCoverage({ flowSpecs: [doc], screenSpecs: [screensDoc] });
+  assert.equal(cov['AC-1'].gap, true, 'findings mention forces gap even though a screen realizes it');
+  assert.ok(cov['AC-1'].screens.length > 0, 'the screen realization is still recorded');
+});
+
+test('computeCoverage: with no specs at all returns an empty map', () => {
+  assert.deepEqual(computeCoverage({ flowSpecs: [], screenSpecs: [] }), {});
+});
+
+/* ------------------------------------------------------------- CLI smoke */
+function writeFixtures() {
+  const dir = mkdtempSync(join(tmpdir(), 'story-src-'));
+  writeFileSync(join(dir, 'fixture.flowspec.json'), JSON.stringify(flowDoc));
+  writeFileSync(join(dir, 'fixture.screens.json'), JSON.stringify(screensDoc));
+  return dir;
+}
+
+function build(args) {
+  return execFileSync('node', [BUILD, ...args]).toString();
+}
+
+test('CLI: writes coverage.html and index.html', () => {
+  const src = writeFixtures();
+  const out = mkdtempSync(join(tmpdir(), 'story-out-'));
+  build(['--flows', join(src, 'fixture.flowspec.json'), '--screens', join(src, 'fixture.screens.json'), '--out', out]);
+  assert.ok(existsSync(join(out, 'coverage.html')), 'coverage.html written');
+  assert.ok(existsSync(join(out, 'index.html')), 'index.html written');
+});
+
+test('CLI: coverage.html has an ac-<id> anchor per criterion and marks the gap row', () => {
+  const src = writeFixtures();
+  const out = mkdtempSync(join(tmpdir(), 'story-out2-'));
+  build(['--flows', join(src, 'fixture.flowspec.json'), '--screens', join(src, 'fixture.screens.json'), '--out', out]);
+  const html = readFileSync(join(out, 'coverage.html'), 'utf8');
+  assert.match(html, /id="ac-AC-1"/, 'covered criterion anchor');
+  assert.match(html, /id="ac-AC-2"/, 'gap criterion anchor');
+  assert.match(html, /class="row gap"[^>]*id="ac-AC-2"|id="ac-AC-2"[^>]*class="[^"]*gap/, 'gap row is marked');
+  // matches the href a screen's AC chip actually emits (build-screens.mjs):
+  // '../coverage.html#ac-' + String(a).split(' ')[0]
+  assert.match(html, /screens\/story-flow\.html#S-001-0/, 'links back to the realizing screen');
+  assert.match(html, /flows\/story-flow\.html#node-0/, 'links back to a realizing node');
+});
+
+test('CLI: index.html hub has Problem/Journey/Screens/Coverage sections and cross-links', () => {
+  const src = writeFixtures();
+  const out = mkdtempSync(join(tmpdir(), 'story-out3-'));
+  build(['--flows', join(src, 'fixture.flowspec.json'), '--screens', join(src, 'fixture.screens.json'), '--out', out]);
+  const html = readFileSync(join(out, 'index.html'), 'utf8');
+  assert.match(html, />Problem</);
+  assert.match(html, />Journey</);
+  assert.match(html, />Screens</);
+  assert.match(html, />Coverage</);
+  assert.match(html, /Guest opens the app/, 'flow trigger surfaced');
+  assert.match(html, /href="flows\/story-flow\.html"/, 'links to the flow page');
+  assert.match(html, /href="screens\/story-flow\.html"/, 'links to the screens page');
+  assert.match(html, /href="coverage\.html"/, 'links to the coverage page');
+  assert.match(html, /2 criteria/, 'coverage summary count');
+  assert.match(html, /1 gap/, 'coverage summary gap count');
+});

--- a/bundles/feature-development/skills/screen-specs/scripts/journey.mjs
+++ b/bundles/feature-development/skills/screen-specs/scripts/journey.mjs
@@ -1,0 +1,41 @@
+// scripts/journey.mjs
+//
+// journeyOrder(screens) — pure, ESM. Sorts a flow's screens into journey
+// order by their `node` id, matching how user-flow-maps orders flow nodes
+// (flowmap.js's `layout()`): whole numbers ascend as the main sequence; a
+// decimal id (e.g. "2.1") is a branch off its parent whole step and sorts
+// immediately after it, before the next whole step. Multiple decimals under
+// the same parent sort ascending by their fractional part. Screens with no
+// `node` sort last, keeping their original relative order (stable).
+
+// A screen's `node` may be a single id or an array of ids (multiple flow
+// nodes render into one screen); journey order goes by the FIRST id.
+function firstNodeId(screen) {
+  const n = screen && screen.node;
+  if (n == null) return undefined;
+  const first = Array.isArray(n) ? n[0] : n;
+  return first == null ? undefined : String(first);
+}
+
+// "2" -> {whole:2, dec:0} sorts before any of its own branches.
+// "2.1" -> {whole:2, dec:1}; "2.2" -> {whole:2, dec:2}.
+function parseNodeKey(id) {
+  const [wholePart, decPart] = id.split('.');
+  return { whole: parseFloat(wholePart), dec: decPart ? parseFloat(decPart) : 0 };
+}
+
+export function journeyOrder(screens) {
+  const indexed = (screens || []).map((s, i) => ({ s, i, key: firstNodeId(s) }));
+  const withNode = indexed.filter(x => x.key !== undefined);
+  const withoutNode = indexed.filter(x => x.key === undefined);
+
+  withNode.sort((a, b) => {
+    const ka = parseNodeKey(a.key);
+    const kb = parseNodeKey(b.key);
+    if (ka.whole !== kb.whole) return ka.whole - kb.whole;
+    if (ka.dec !== kb.dec) return ka.dec - kb.dec;
+    return a.i - b.i; // stable tie-break
+  });
+
+  return [...withNode, ...withoutNode].map(x => x.s);
+}

--- a/bundles/feature-development/skills/screen-specs/scripts/journey.test.mjs
+++ b/bundles/feature-development/skills/screen-specs/scripts/journey.test.mjs
@@ -1,0 +1,72 @@
+// scripts/journey.test.mjs
+//
+// journeyOrder(screens) sorts a flow's screens into journey order by their
+// `node` id, matching user-flow-maps ordering: whole numbers ascending form
+// the main sequence; a decimal id is a branch that sorts immediately after
+// its parent whole step, before the next whole step. Screens with no `node`
+// sort last, preserving their original relative order (stable).
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { journeyOrder } from './journey.mjs';
+
+test('sorts whole-number node ids ascending', () => {
+  const screens = [
+    { id: 'S-3', node: '3' },
+    { id: 'S-1', node: '1' },
+    { id: 'S-2', node: '2' },
+    { id: 'S-0', node: '0' },
+  ];
+  assert.deepStrictEqual(journeyOrder(screens).map(s => s.id), ['S-0', 'S-1', 'S-2', 'S-3']);
+});
+
+test('decimal node id sorts immediately after its parent whole step', () => {
+  const screens = [
+    { id: 'S-3', node: '3' },
+    { id: 'S-2.1', node: '2.1' },
+    { id: 'S-2', node: '2' },
+    { id: 'S-1', node: '1' },
+  ];
+  assert.deepStrictEqual(journeyOrder(screens).map(s => s.id), ['S-1', 'S-2', 'S-2.1', 'S-3']);
+});
+
+test('multiple decimals under the same parent sort ascending', () => {
+  const screens = [
+    { id: 'S-2.2', node: '2.2' },
+    { id: 'S-3', node: '3' },
+    { id: 'S-2.1', node: '2.1' },
+    { id: 'S-2', node: '2' },
+  ];
+  assert.deepStrictEqual(journeyOrder(screens).map(s => s.id), ['S-2', 'S-2.1', 'S-2.2', 'S-3']);
+});
+
+test('screens with no node sort last, preserving original relative order', () => {
+  const screens = [
+    { id: 'S-none-a' },
+    { id: 'S-2', node: '2' },
+    { id: 'S-none-b' },
+    { id: 'S-1', node: '1' },
+  ];
+  assert.deepStrictEqual(journeyOrder(screens).map(s => s.id),
+    ['S-1', 'S-2', 'S-none-a', 'S-none-b']);
+});
+
+test('node as an array uses the first id for ordering', () => {
+  const screens = [
+    { id: 'S-3', node: ['3', '3.1'] },
+    { id: 'S-1', node: ['1'] },
+    { id: 'S-2', node: ['2', '4'] },
+  ];
+  assert.deepStrictEqual(journeyOrder(screens).map(s => s.id), ['S-1', 'S-2', 'S-3']);
+});
+
+test('does not mutate the input array', () => {
+  const screens = [{ id: 'S-2', node: '2' }, { id: 'S-1', node: '1' }];
+  const copy = screens.slice();
+  journeyOrder(screens);
+  assert.deepStrictEqual(screens, copy);
+});
+
+test('returns a new array (not the same reference)', () => {
+  const screens = [{ id: 'S-1', node: '1' }];
+  assert.notStrictEqual(journeyOrder(screens), screens);
+});

--- a/bundles/feature-development/skills/screen-specs/scripts/story.test.mjs
+++ b/bundles/feature-development/skills/screen-specs/scripts/story.test.mjs
@@ -1,0 +1,63 @@
+// scripts/story.test.mjs
+//
+// Build-smoke coverage for `--layout story` (T2): subdir output under
+// `screens/` plus the A cross-links (screen -> its flow node, screen's AC ->
+// coverage.html), and a regression lock that the default (flat) layout still
+// writes exactly where it always has, at --out root.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __d = dirname(fileURLToPath(import.meta.url));
+const BUILD = join(__d, 'build-screens.mjs');
+const SYSTEM = join(__d, '__fixtures__', 'mobile.ds.json');
+const STORY_SPECS = join(__d, '__fixtures__', 'story');
+
+function build(args) {
+  return execFileSync('node', [BUILD, '--system', SYSTEM, '--specs', STORY_SPECS, ...args]).toString();
+}
+
+test('flat (default, no --layout) writes screen pages at --out root, unchanged', () => {
+  const out = mkdtempSync(join(tmpdir(), 'ss-flat-'));
+  build(['--out', out]);
+  assert.ok(existsSync(join(out, 'story-flow.html')), 'flow page at root');
+  assert.ok(existsSync(join(out, 'index.html')), 'design-system index at root');
+  assert.ok(!existsSync(join(out, 'screens')), 'no screens/ subdir under flat');
+});
+
+test('--layout flat (explicit) is the same as default', () => {
+  const out = mkdtempSync(join(tmpdir(), 'ss-flat2-'));
+  build(['--out', out, '--layout', 'flat']);
+  assert.ok(existsSync(join(out, 'story-flow.html')));
+  assert.ok(!existsSync(join(out, 'screens')));
+});
+
+test('--layout story writes screen pages into screens/', () => {
+  const out = mkdtempSync(join(tmpdir(), 'ss-story-'));
+  build(['--out', out, '--layout', 'story']);
+  assert.ok(existsSync(join(out, 'screens', 'story-flow.html')), 'flow page under screens/');
+  assert.ok(existsSync(join(out, 'screens', 'index.html')), 'design-system index under screens/');
+  assert.ok(!existsSync(join(out, 'story-flow.html')), 'not also written at root');
+});
+
+test('--layout story emits screen -> flow-node and AC -> coverage cross-links (A)', () => {
+  const out = mkdtempSync(join(tmpdir(), 'ss-story-links-'));
+  build(['--out', out, '--layout', 'story']);
+  const html = readFileSync(join(out, 'screens', 'story-flow.html'), 'utf8');
+  // flow slug mirrors build-flowmaps.mjs's own slug() over the shared key.
+  assert.match(html, /FLOW_SLUG=\{?"story-flow"\}?|FLOW_SLUG="story-flow"/);
+  assert.match(html, /'\.\.\/flows\/'\s*\+\s*FLOW_SLUG\s*\+\s*'\.html#node-'\s*\+\s*n/, 'flow-node link');
+  assert.match(html, /\.\.\/coverage\.html#ac-/, 'AC -> coverage.html link');
+});
+
+test('flat layout does not carry story-only cross-link glue', () => {
+  const out = mkdtempSync(join(tmpdir(), 'ss-flat-nolinks-'));
+  build(['--out', out]);
+  const html = readFileSync(join(out, 'story-flow.html'), 'utf8');
+  assert.doesNotMatch(html, /coverage\.html#ac-/);
+  assert.doesNotMatch(html, /FLOW_SLUG/);
+});

--- a/bundles/feature-development/skills/user-flow-maps/SKILL.md
+++ b/bundles/feature-development/skills/user-flow-maps/SKILL.md
@@ -26,6 +26,16 @@ anchor selection and label de-collision. Never write pixel maths in a spec.
    ```bash
    node scripts/build-flowmaps.mjs <spec.json> --out <dir>
    ```
+   Add `--layout story [--screens <dir|file>]` to build into a shared
+   **design-story site** instead of a standalone set: pages land in
+   `<out>/flows/<slug>.html` (one directory deeper than the flat default) so
+   they can sit next to screen-specs' `screens/` output without a filename
+   collision. When `--screens` points at the matching `*.screens.json`
+   spec(s), every flow node whose id matches a screen's `node` becomes a
+   click-through to that screen's page
+   (`../screens/<slug>.html#<screenId>`). Omitting `--screens` (or pointing
+   it at nothing yet built) just renders the flow with no screen links —
+   this build never depends on the other having run first.
 3. **Verify before you claim it works.** Open the pages and check them — the
    library is deterministic but a spec can still describe a flow badly (a
    dangling target, a decision with no outcomes). `references/verifying.md`

--- a/bundles/feature-development/skills/user-flow-maps/scripts/__fixtures__/story.flowspec.json
+++ b/bundles/feature-development/skills/user-flow-maps/scripts/__fixtures__/story.flowspec.json
@@ -1,0 +1,16 @@
+{
+  "title": "Story Test",
+  "flows": [
+    {
+      "key": "story-flow",
+      "title": "Flow map — story-flow: Test",
+      "nodes": [
+        {"id":"0","label":"Start","archetype":"form","regions":[],
+          "transitions":[{"target":"1","trigger":"go","kind":"primary","nav":"push","ac":"AC-1"}],
+          "decision":null},
+        {"id":"1","label":"Result","archetype":"list","regions":[],
+          "transitions":[],"decision":null}
+      ]
+    }
+  ]
+}

--- a/bundles/feature-development/skills/user-flow-maps/scripts/__fixtures__/story.screens.json
+++ b/bundles/feature-development/skills/user-flow-maps/scripts/__fixtures__/story.screens.json
@@ -1,0 +1,15 @@
+{
+  "flow": "story-flow",
+  "title": "Story flow screens",
+  "screens": [
+    {
+      "id": "S-001-0",
+      "node": "1",
+      "title": "Result",
+      "purpose": "show result",
+      "ac": ["AC-1"],
+      "nav": {"kind":"root","title":"Result"},
+      "regions": [{"type":"appbar","label":"Header","content":"Result"}]
+    }
+  ]
+}

--- a/bundles/feature-development/skills/user-flow-maps/scripts/build-flowmaps.mjs
+++ b/bundles/feature-development/skills/user-flow-maps/scripts/build-flowmaps.mjs
@@ -205,7 +205,7 @@ FlowMap.legend(document.getElementById('legend'));
 // FlowMap.render() already stamps with n.id is the only reliable way to
 // recover which node a .n cell is, since L.ord's render order isn't exposed.
 (function(){
-  var SCREEN_MAP = ${JSON.stringify(screensByFlow[f.key] || {})};
+  var SCREEN_MAP = ${JSON.stringify(screensByFlow[f.key] || {}).replace(/</g, '\\u003c')};
   document.querySelectorAll('#poster .n').forEach(function(cell){
     var badge = cell.querySelector('.badge');
     if(!badge) return;

--- a/bundles/feature-development/skills/user-flow-maps/scripts/build-flowmaps.mjs
+++ b/bundles/feature-development/skills/user-flow-maps/scripts/build-flowmaps.mjs
@@ -19,16 +19,12 @@ import { createRequire } from 'node:module';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const LIB = readFileSync(join(__dirname, 'flowmap.js'), 'utf8');
-// flowmap.js is a plain CJS UMD file with no package.json of its own in this
-// directory (unlike screen-specs/scripts, which pins { "type": "commonjs" }
-// next to screenspec.js) — Node's require() walks up to the repo root's
-// { "type": "module" } and (mis)loads it as ESM, which throws since it isn't
-// valid ESM. Evaluate the already-read source through a minimal manual CJS
-// wrapper instead of Node's loader; this is the same source used for the
-// browser-inlined <script>, so both sides render off one file, unchanged.
-const flowmapModule = { exports: {} };
-new Function('module', 'exports', 'require', LIB)(flowmapModule, flowmapModule.exports, require);
-const FlowMap = flowmapModule.exports;
+// flowmap.js is a CJS UMD; scripts/package.json pins { "type": "commonjs" } next
+// to it (as screen-specs/scripts and manual-qa/xlsx-reader/scripts do) so
+// require() loads it correctly despite the repo root's { "type": "module" }.
+// LIB (the same source) is inlined into each generated page's <script>, so the
+// Node side and the browser side render off one file.
+const FlowMap = require(join(__dirname, 'flowmap.js'));
 
 /* ------------------------------------------------------------------ args */
 const argv = process.argv.slice(2);

--- a/bundles/feature-development/skills/user-flow-maps/scripts/build-flowmaps.mjs
+++ b/bundles/feature-development/skills/user-flow-maps/scripts/build-flowmaps.mjs
@@ -11,41 +11,89 @@
  * The spec is data only. Positioning, routing and collision handling live in
  * flowmap.js — nothing here computes a coordinate.
  */
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
-const FlowMap = require(join(__dirname, 'flowmap.js'));
 const LIB = readFileSync(join(__dirname, 'flowmap.js'), 'utf8');
+// flowmap.js is a plain CJS UMD file with no package.json of its own in this
+// directory (unlike screen-specs/scripts, which pins { "type": "commonjs" }
+// next to screenspec.js) — Node's require() walks up to the repo root's
+// { "type": "module" } and (mis)loads it as ESM, which throws since it isn't
+// valid ESM. Evaluate the already-read source through a minimal manual CJS
+// wrapper instead of Node's loader; this is the same source used for the
+// browser-inlined <script>, so both sides render off one file, unchanged.
+const flowmapModule = { exports: {} };
+new Function('module', 'exports', 'require', LIB)(flowmapModule, flowmapModule.exports, require);
+const FlowMap = flowmapModule.exports;
 
 /* ------------------------------------------------------------------ args */
 const argv = process.argv.slice(2);
 if (!argv.length || argv.includes('-h') || argv.includes('--help')) {
-  console.log(`usage: build-flowmaps.mjs <spec.json> --out <dir> [--title "Set title"]
+  console.log(`usage: build-flowmaps.mjs <spec.json> --out <dir> [--title "Set title"] [--layout flat|story] [--screens <dir|file>]
 
 spec.json:
   { "title": "...",                     // set title, shown on the index
     "flows":  [ <flow>, ... ],          // see flowmap.js header for the flow shape
     "composition": { "flows": [...] },  // optional: how the flows join up
     "findings":    [ {group,title,body,tone}, ... ]   // optional: index notes
-  }`);
+  }
+
+--layout story writes flow pages into <out>/flows/ instead of <out>/ and, when
+--screens points at the matching *.screens.json spec(s), links each flow node
+to its screen spec page (../screens/<slug>.html#<screenId>).`);
   process.exit(argv.length ? 0 : 1);
 }
 const specPath = resolve(argv[0]);
 const outDir = resolve(argv[argv.indexOf('--out') + 1] || './flowmaps');
+const layout = argv.includes('--layout') ? argv[argv.indexOf('--layout') + 1] : 'flat';
+const screensArg = argv.includes('--screens') ? resolve(argv[argv.indexOf('--screens') + 1]) : null;
 const spec = JSON.parse(readFileSync(specPath, 'utf8'));
 const setTitle = argv.includes('--title') ? argv[argv.indexOf('--title') + 1]
   : (spec.title || 'Flow maps');
-if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+// Story layout writes into a flows/ subdir so it can sit next to build-screens.mjs's
+// screens/ output (and the future design-story hub's index.html) without a filename
+// collision. Flat (default) keeps writing straight to --out, unchanged.
+const flowsDir = layout === 'story' ? join(outDir, 'flows') : outDir;
+if (!existsSync(flowsDir)) mkdirSync(flowsDir, { recursive: true });
 
 const esc = s => String(s == null ? '' : s)
   .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 const slug = f => String(f.key || f.title || 'flow').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 const cleanTitle = f => String(f.title || f.key || '')
   .replace(/^\s*Flow map\s*[^A-Za-z0-9(]+\s*/, '');
+
+// Mirrors build-screens.mjs's own `slugOf()` exactly (same formula, no trim)
+// so a flow node's link to `../screens/<slug>.html` lands on the file that
+// script actually writes for that spec.
+const screenSlugOf = s => String(s.flow || s.title || 'flow').toLowerCase().replace(/[^a-z0-9]+/g, '-');
+
+function loadScreenSpecs(p) {
+  if (!p || !existsSync(p)) return [];
+  if (statSync(p).isDirectory()) {
+    return readdirSync(p).filter(f => f.endsWith('.screens.json'))
+      .map(f => JSON.parse(readFileSync(join(p, f), 'utf8')));
+  }
+  return [JSON.parse(readFileSync(p, 'utf8'))];
+}
+
+// node id -> {slug, screenId}, keyed by flow key (the join key shared with
+// screen-specs's own `flow` field). Empty/absent --screens just yields {}
+// per flow, so a flow renders normally with no screen links (T2 degrades
+// gracefully rather than failing when the sibling build hasn't run yet).
+const screensByFlow = {};
+for (const s of loadScreenSpecs(screensArg)) {
+  if (s.flow == null) continue;
+  const map = screensByFlow[s.flow] || (screensByFlow[s.flow] = {});
+  const sSlug = screenSlugOf(s);
+  (s.screens || []).forEach(scr => {
+    const nodes = Array.isArray(scr.node) ? scr.node : (scr.node != null ? [scr.node] : []);
+    nodes.forEach(n => { map[String(n)] = { slug: sSlug, screenId: scr.id }; });
+  });
+}
 
 /* ------------------------------------------------------------------ shell */
 function page({ title, body, data, glue }) {
@@ -155,9 +203,31 @@ const F = DATA;
 FlowMap.render(document.getElementById('poster'), F);
 FlowMap.table(document.getElementById('table'), F);
 FlowMap.legend(document.getElementById('legend'));
-`;
+` + (layout === 'story' ? `// story layout (A — cross-link flow -> screens): every rendered node gets a
+// stable id="node-<id>" anchor; a node whose id has a matching screen (from
+// --screens) becomes a click-through to that screen's spec page. The badge
+// FlowMap.render() already stamps with n.id is the only reliable way to
+// recover which node a .n cell is, since L.ord's render order isn't exposed.
+(function(){
+  var SCREEN_MAP = ${JSON.stringify(screensByFlow[f.key] || {})};
+  document.querySelectorAll('#poster .n').forEach(function(cell){
+    var badge = cell.querySelector('.badge');
+    if(!badge) return;
+    var id = badge.textContent;
+    cell.id = 'node-' + id;
+    var hit = SCREEN_MAP[id];
+    if(!hit) return;
+    var a = document.createElement('a');
+    a.href = '../screens/' + hit.slug + '.html#' + hit.screenId;
+    a.className = 'node-link';
+    a.style.cssText = 'position:absolute;inset:0;';
+    a.setAttribute('aria-label', 'Open screen spec for node ' + id);
+    cell.appendChild(a);
+  });
+})();
+` : '');
   const html = page({ title: f.page_title || (f.key ? f.key + ' Flow' : cleanTitle(f)), body, data: f, glue });
-  writeFileSync(join(outDir, slug(f) + '.html'), html);
+  writeFileSync(join(flowsDir, slug(f) + '.html'), html);
   console.log('wrote', slug(f) + '.html', html.length, 'bytes');
 });
 
@@ -251,7 +321,7 @@ const indexData = {
   flows: flows.map(f => ({ ...f, slug: slug(f) })),
   composition: spec.composition || null
 };
-writeFileSync(join(outDir, 'index.html'),
+writeFileSync(join(flowsDir, 'index.html'),
   page({ title: setTitle, body: indexBody, data: indexData, glue: indexGlue }));
 console.log('wrote index.html');
 console.log('\n→', outDir);

--- a/bundles/feature-development/skills/user-flow-maps/scripts/package.json
+++ b/bundles/feature-development/skills/user-flow-maps/scripts/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/bundles/feature-development/skills/user-flow-maps/scripts/story.test.mjs
+++ b/bundles/feature-development/skills/user-flow-maps/scripts/story.test.mjs
@@ -1,0 +1,63 @@
+// scripts/story.test.mjs
+//
+// Build-smoke coverage for `--layout story` (T2): subdir output under
+// `flows/` plus the A cross-link (flow node -> its screen spec page), and a
+// regression lock that the default (flat) layout still writes exactly where
+// it always has, at --out root.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __d = dirname(fileURLToPath(import.meta.url));
+const BUILD = join(__d, 'build-flowmaps.mjs');
+const SPEC = join(__d, '__fixtures__', 'story.flowspec.json');
+const SCREENS = join(__d, '__fixtures__', 'story.screens.json');
+
+function build(args) {
+  return execFileSync('node', [BUILD, ...args]).toString();
+}
+
+test('flat (default, no --layout) writes flow pages at --out root, unchanged', () => {
+  const out = mkdtempSync(join(tmpdir(), 'fm-flat-'));
+  build([SPEC, '--out', out]);
+  assert.ok(existsSync(join(out, 'story-flow.html')), 'flow page at root');
+  assert.ok(existsSync(join(out, 'index.html')), 'index at root');
+  assert.ok(!existsSync(join(out, 'flows')), 'no flows/ subdir under flat');
+});
+
+test('--layout flat (explicit) is the same as default', () => {
+  const out = mkdtempSync(join(tmpdir(), 'fm-flat2-'));
+  build([SPEC, '--out', out, '--layout', 'flat']);
+  assert.ok(existsSync(join(out, 'story-flow.html')));
+  assert.ok(!existsSync(join(out, 'flows')));
+});
+
+test('--layout story writes flow pages into flows/', () => {
+  const out = mkdtempSync(join(tmpdir(), 'fm-story-'));
+  build([SPEC, '--out', out, '--layout', 'story']);
+  assert.ok(existsSync(join(out, 'flows', 'story-flow.html')), 'flow page under flows/');
+  assert.ok(existsSync(join(out, 'flows', 'index.html')), 'flow index under flows/');
+  assert.ok(!existsSync(join(out, 'story-flow.html')), 'not also written at root');
+});
+
+test('--layout story without --screens degrades gracefully (no screens link, still builds)', () => {
+  const out = mkdtempSync(join(tmpdir(), 'fm-story-noscreens-'));
+  build([SPEC, '--out', out, '--layout', 'story']);
+  const html = readFileSync(join(out, 'flows', 'story-flow.html'), 'utf8');
+  assert.match(html, /SCREEN_MAP = \{\}/, 'empty screen map when --screens is absent');
+});
+
+test('--layout story with --screens emits a node -> screen cross-link (A)', () => {
+  const out = mkdtempSync(join(tmpdir(), 'fm-story-screens-'));
+  build([SPEC, '--out', out, '--layout', 'story', '--screens', SCREENS]);
+  const html = readFileSync(join(out, 'flows', 'story-flow.html'), 'utf8');
+  // node "1" (the fixture's only screen-bearing node) resolves to the
+  // matching screen spec's slug + screen id.
+  assert.match(html, /SCREEN_MAP = \{"1":\{"slug":"story-flow","screenId":"S-001-0"\}\}/);
+  assert.match(html, /'\.\.\/screens\/' \+ hit\.slug \+ '\.html#' \+ hit\.screenId/);
+  assert.match(html, /cell\.id = 'node-' \+ id/);
+});

--- a/docs/superpowers/notes/designer-skill-candidates.md
+++ b/docs/superpowers/notes/designer-skill-candidates.md
@@ -1,0 +1,239 @@
+# Designer-agent skill candidates: comparison
+
+Researched 2026-08-17. Sources verified via GitHub REST API (`api.github.com/repos/...`) and
+raw content (`raw.githubusercontent.com/.../README.md`, `.../SKILL.md`).
+
+Context: candidate additions to a designer agent whose existing pipeline is
+`user-flow-maps` (behaviour/journeys) → `screen-specs` (buildable, MD3-token-driven
+mocks) → `visual-testing` (screenshot diff), plus Anthropic's `frontend-design`
+plugin for aesthetic direction/taste.
+
+---
+
+## 1. `nextlevelbuilder/ui-ux-pro-max-skill`
+
+**What it is.** A searchable design-intelligence database packaged as a Claude
+Agent Skill plus a companion npm CLI (`ui-ux-pro-max-cli`). The core is a
+Python search tool (`scripts/search.py`, no external deps) queried over a large
+curated dataset: 79 UI style descriptors (50 active/29 supplemental/9
+deprecated), 192 industry-specific reasoning rules, 192 color palettes tied to
+product types, 74 Google-Fonts pairings, 119 UX guidelines, 105 icon
+references, 17 GSAP animation presets, 25 chart types, across 22 tech stacks
+(React, Vue, Svelte, SwiftUI, Flutter, etc.). The installed skill
+(`.claude/skills/ui-ux-pro-max/SKILL.md`) documents a four-step workflow:
+extract product signals → generate a persisted `MASTER.md` design system (+
+optional per-page overrides) → targeted domain searches (accessibility,
+typography, color, animation, forms, navigation, charts) → stack-specific
+implementation guidance. It ships `data/`, `references/` (quick-reference.md,
+pro-rules.md), and `scripts/` subdirectories — a real, queryable knowledge
+base, not just prose. A premium (paid) tier adds brand identity/logo/asset
+generation on top of the open-source base.
+
+**Category.** Component-library / design-system knowledge, blended with UX
+heuristics (its "Rule Categories by Priority" table covers accessibility,
+touch targets, performance, layout, typography, forms, navigation, charts) and
+a thin layer of aesthetic-direction (79 named styles + palettes + font
+pairings). It is a generalist grab-bag more than any one category.
+
+**Quality signals.** MIT license (open-source core). ~116.9k GitHub stars,
+81 open issues, created 2025-11-30, last push 2026-08-13 (actively maintained,
+uses semantic-release + Conventional Commits). Structured properly as a Claude
+Agent Skill (`SKILL.md` with frontmatter, `skill.json` at v2.13.0, plus
+`design-system`, `brand`, `ui-styling`, `banner-design`, `slides` sibling
+skills). Content is substantial — this is a real curated dataset with a search
+tool, not a thin README. Author credibility: unverified individual/small org
+("Next Level Builder"), not an established design-tooling brand; the
+premium-upsell model (open core + paid brand/logo tier) is a commercial
+product, which should factor into trust/longevity judgments even though the
+repo itself is healthy.
+
+**Overlap vs complement.** Heavy overlap with `screen-specs`: both aim at
+"buildable" design-system output (`MASTER.md`/page overrides is functionally
+the same job as `screen-specs`' design-system.json + token-driven mocks), and
+its accessibility/touch-target/forms rules duplicate what a solid screen-specs
+skill should already encode. It also overlaps with `frontend-design`'s job
+(style/palette/font selection) but takes a "pick from a catalog" approach
+(79 styles, 192 palettes) rather than `frontend-design`'s "derive something
+non-templated" approach — these are somewhat philosophically opposed
+(catalog-driven vs. bespoke-driven). The one genuinely new slice is the
+domain-specific UX guideline corpus (119 guidelines) and multi-stack
+implementation notes (22 stacks) if the designer agent needs stack-specific
+build guidance `screen-specs` doesn't cover.
+
+**Portability.** Self-contained prose + a dependency-free Python 3 script
+(`search.py`) — reasonably portable, installable via the standard skill copy
+mechanism or its own CLI (`npx ui-ux-pro-max-cli init`). No paid-service
+runtime dependency for the open core; the premium tier requires their hosted
+service.
+
+Sources verified: https://github.com/nextlevelbuilder/ui-ux-pro-max-skill ,
+https://raw.githubusercontent.com/nextlevelbuilder/ui-ux-pro-max-skill/main/README.md ,
+https://raw.githubusercontent.com/nextlevelbuilder/ui-ux-pro-max-skill/main/skill.json ,
+https://raw.githubusercontent.com/nextlevelbuilder/ui-ux-pro-max-skill/main/.claude/skills/ui-ux-pro-max/SKILL.md ,
+https://api.github.com/repos/nextlevelbuilder/ui-ux-pro-max-skill
+
+---
+
+## 2. `Leonxlnx/taste-skill`
+
+**What it is.** Not one skill but a family of ten portable `SKILL.md`
+"implementation" skills plus three image-generation-only skills, installed
+individually via `npx skills add` (the Vercel Labs `agent-skills` CLI
+convention). The flagship (`skills/taste-skill`, install name
+`design-taste-frontend`, currently a v2 rewrite) is a genuinely dense
+anti-slop rulebook for AI-generated frontends: three tunable 1–10 "dials"
+(DESIGN_VARIANCE, MOTION_INTENSITY, VISUAL_DENSITY), a design-system-selection
+step (pick one of Fluent/Carbon/Material/Polaris/shadcn-ui rather than
+inventing custom CSS), canonical Motion/GSAP code skeletons, a redesign-audit
+protocol, and an exhaustive "AI tells" forbidden-pattern list (banned default
+fonts, an absolute em-dash ban, banned default color palettes, logo-wall/CTA
+rules, real-image requirements) enforced by a ~70-point mechanical pre-flight
+checklist. Sibling skills narrow this further: `soft-skill` (calm/premium),
+`minimalist-skill`, `brutalist-skill`, `redesign-skill`, `gpt-tasteskill`
+(GPT/Codex-tuned variant), `output-skill` (anti-truncation), `stitch-skill`
+(Google Stitch export format), plus `imagegen-*`/`brandkit` skills that
+produce reference images only (no code).
+
+**Category.** Aesthetic-direction/taste, squarely — this is the closest
+direct analog to Anthropic's `frontend-design` plugin, just far more
+opinionated/mechanical and React/Tailwind-specific.
+
+**Quality signals.** MIT license. ~77.2k GitHub stars, 54 open issues, created
+2026-02-19, last push 2026-07-23 (recently active; has a CHANGELOG tracking a
+v1→v2 rewrite, plus paid sponsors — Vercel OSS program, IMG.LY, animations.dev
+— which is a decent credibility signal). Structured correctly as Agent Skills
+(real `SKILL.md` with `name`/`description` frontmatter per sub-skill,
+installable one-at-a-time by install name). Content is substantial and
+opinionated, not a thin wrapper — the pre-flight checklist and "AI tells" list
+in particular read as hard-won, specific rules rather than generic advice.
+Caveat: heavily React + Tailwind v4 + Motion/GSAP + Phosphor-icons coded by
+default (Appendix A/B give alternate design-system install commands, but the
+core engineering rules assume a JS/React stack).
+
+**Overlap vs complement.** Directly competes with / could replace or
+supplement `frontend-design` for taste-and-non-templated-ness — arguably more
+rigorous (dial-based tuning, mechanical checklist, explicit banned-pattern
+list) than a prose-only taste guide. It does not touch `screen-specs`'
+buildable-spec/device-frame/MD3-token job, and it doesn't touch
+`user-flow-maps` at all. The redesign-audit protocol and "AI tells" checklist
+are the genuinely new capability: a mechanical, checkable anti-slop QA pass
+that neither `frontend-design` nor `screen-specs` currently provide. Because
+it's decomposed into narrow single-purpose skills, only the relevant slice
+(e.g. just `redesign-skill` or just the anti-slop checklist portion) could be
+adopted without pulling in the GSAP/motion-heavy implementation rules.
+
+**Portability.** Self-contained Markdown, no scripts required — but content
+is stack-opinionated (React/Tailwind/Motion by default) even though Appendix B
+lists alternate systems. No paid service dependency; the image-generation
+skills expect pairing with an external image generator (ChatGPT Images or
+similar), which is optional and outside the code skills.
+
+Sources verified: https://github.com/Leonxlnx/taste-skill ,
+https://raw.githubusercontent.com/Leonxlnx/taste-skill/main/README.md ,
+https://raw.githubusercontent.com/Leonxlnx/taste-skill/main/skills/taste-skill/SKILL.md ,
+https://api.github.com/repos/Leonxlnx/taste-skill
+
+---
+
+## 3. `pbakaus/impeccable`
+
+**What it is.** The most heavyweight of the three: "1 skill, 23 commands,
+live browser iteration, and 59 deterministic detector rules for AI-generated
+frontend design," by Paul Bakaus (ex-Google, a recognizable name in web/design
+tooling circles). Structurally it's a single `SKILL.md` (built from
+`skill/SKILL.src.md`, 11.3KB) that routes to 43 separate reference playbooks
+under `skill/reference/` (`critique.md` 45KB, `new-work.md` 46KB, `live.md`
+36KB, `document.md` 27KB, plus focused files per command: `audit`, `polish`,
+`animate`, `colorize`, `typeset`, `harden`, `optimize`, `adapt`,
+`ios`/`android` variants, etc.) — genuinely deep, not templated boilerplate.
+Behind the prose sits real tooling: `skill/scripts/` has ~40 Node scripts
+(`detect.mjs`, `palette.mjs`, `context-signals.mjs`, a whole `live-*.mjs`
+family for live-browser DOM injection/screenshot/session management via
+`modern-screenshot.umd.js`, plus `agents/` and `lib/`), and a standalone CLI
+(`npx impeccable detect`) that runs the 59 deterministic (non-LLM) anti-pattern
+detectors — e.g. flags "Inter for everything," purple-to-blue gradients, cards
+nested in cards — outputting JSON for CI. Commands span critique/audit
+(evaluate), polish/harden/optimize (refine), animate/colorize/typeset
+(enhance), and a `craft`/`init` onboarding flow that persists project context
+into `PRODUCT.md`/`DESIGN.md`/`design.json`.
+
+**Category.** Primarily UX heuristics/critique + a genuinely distinct
+category the other two lack: automated, deterministic anti-pattern
+*detection* (static analysis of rendered UI, not LLM judgment). Also carries
+aesthetic-direction content (colorize/typeset/animate playbooks) and some
+accessibility coverage, making it the broadest of the three in scope.
+
+**Quality signals.** Apache 2.0 license. ~59.7k GitHub stars (~3.2k forks,
+~40 contributors per public star-history data), 51 open issues, created
+2025-11-16, last push 2026-08-17 (actively maintained, essentially daily-fresh
+at time of research). Author is a named, credible figure (Paul Bakaus,
+ex-Google Web/PageSpeed-adjacent background) rather than an anonymous handle —
+the strongest author-credibility signal of the three. Structured correctly as
+an Agent Skill (`SKILL.md` frontmatter with `name`, `description`,
+`argument-hint`, `allowed-tools`, `license`) and additionally ships a real CLI,
+plugin manifests for Claude Code and Grok Build, and 13+ tool-specific install
+paths (Cursor, Copilot, Gemini CLI, OpenCode, Pi, Kiro, Trae, etc.). By far
+the deepest and most substantively engineered of the three candidates.
+
+**Overlap vs complement.** Least overlapping with `frontend-design` — it's
+detector/critique-first rather than taste-generation-first, so it's more a
+complement (QA layer) than a competitor. It overlaps somewhat with
+`visual-testing` in spirit (both evaluate an already-rendered UI) but via a
+different mechanism: deterministic anti-pattern detection over DOM/CSS rather
+than visual baseline diffing — these are complementary, not duplicative
+(`visual-testing` catches regressions against a baseline; impeccable's
+detectors catch generic "AI slop" patterns even in a first pass with no
+baseline). Its `live.md`/live-browser-iteration commands (inject, poll,
+resume, wrap edits back into source) are a genuinely new capability not
+present anywhere in the existing pipeline: interactive live-DOM iteration
+against a running browser session. Some overlap with `screen-specs` on
+design-token bookkeeping (`design.json`, MD3-adjacent theming rules) but its
+strength is critique/audit, not spec generation.
+
+**Portability.** Self-contained Markdown + Node scripts (`.mjs`), installable
+five ways (CLI installer, git submodule, plugin marketplace, website
+download, or direct copy) across 13+ AI coding tools. The `detect` CLI and
+live-browser features require Node.js and a real browser/DOM runtime
+(scripts reference Puppeteer/CDP-style screenshotting) — heavier runtime
+footprint than the other two, which are closer to pure-prose skills. No paid
+service dependency; it's genuinely open source (Apache 2.0) end to end.
+
+Sources verified: https://github.com/pbakaus/impeccable ,
+https://raw.githubusercontent.com/pbakaus/impeccable/main/README.md ,
+https://raw.githubusercontent.com/pbakaus/impeccable/main/skill/SKILL.src.md ,
+https://api.github.com/repos/pbakaus/impeccable
+
+---
+
+## Ranking
+
+| Repo | Verdict | One-line reason |
+|---|---|---|
+| **pbakaus/impeccable** | **strong** | Deepest, most substantive content (43 reference playbooks, 59 deterministic detectors, real CLI/scripts), credible maintainer, complements rather than duplicates the existing pipeline (adds critique/detection + live-iteration, neither of which exists today). |
+| **Leonxlnx/taste-skill** | **maybe** | Genuinely rigorous anti-slop/taste rulebook that could sharpen or replace `frontend-design`'s aesthetic-direction step, but it's React/Tailwind/Motion-opinionated and its buildable-output ambitions overlap `screen-specs`; adopt narrowly (the checklist/redesign-audit slice) rather than wholesale. |
+| **nextlevelbuilder/ui-ux-pro-max-skill** | **maybe/skip** | Large, well-structured dataset, but its core "generate a design system from a catalog" workflow duplicates `screen-specs` almost one-to-one, it's a commercial open-core product (paid upsell tier), and author credibility is unverified — only the UX-guideline/multi-stack corpus adds anything not already covered. |
+
+---
+
+## Borrowed ideas (from the skips) — 2026-08-17
+
+We skip `taste-skill` and `ui-ux-pro-max` as skills, but mine them for ideas:
+
+| Idea (source) | Target | Status |
+|---|---|---|
+| Tunable **density** knob (taste-skill dials) → `density: compact\|comfortable\|spacious` scaling spacing (screen-specs) | screen-specs | **Blocked on a refactor** — see below |
+| Per-page/per-screen **overrides** (ui-ux-pro-max MASTER.md + page overrides) | screen-specs | **Planned** — validates the deferred per-screen target/style override; needs per-screen token scoping |
+| **Multi-stack implementation notes** (ui-ux-pro-max 22 stacks) → generalize screen-specs' swiftui-only hints to per-stack (Compose/React/Flutter) | screen-specs | Nice-to-have |
+| **"AI tells" anti-slop list** (taste-skill) | — | **Covered better by impeccable** (deterministic detectors); don't rebuild |
+| **redesign-audit protocol** (taste-skill) | — | Covered by impeccable's `audit`/`critique` |
+| **Dependency-free `search.py` over a curated dataset** (ui-ux-pro-max) — query, don't preload | future reference-heavy skills | Meta-pattern to keep in mind |
+
+**Architectural reality for density + per-screen override:** the screen-specs renderer's
+spacing is hardcoded (~373 px literals, only 3 `var(--space*)` uses), and design tokens are
+emitted once per page in a single `<style>` block. So:
+- **density** only becomes real after the renderer's spacing is made token-driven (a sizable,
+  golden-risk refactor — same class as the deferred mobile-styling work).
+- **per-screen style/density override** needs per-screen token scoping (per-screen `:root`-like
+  scopes) rather than one page-global block. Per-screen *device/target* is more tractable.
+Recommendation: do the token-driven-spacing refactor as its own scoped effort, then density +
+per-screen overrides land cheaply on top. Don't half-build them against hardcoded CSS.

--- a/docs/superpowers/specs/2026-08-17-design-story-presentation-uplift.md
+++ b/docs/superpowers/specs/2026-08-17-design-story-presentation-uplift.md
@@ -1,0 +1,106 @@
+# Design-story presentation uplift — spec + plan
+
+**Date:** 2026-08-17
+**Skills:** `bundles/feature-development/skills/{user-flow-maps,screen-specs}`
+**Branch:** feat/designer-impeccable-and-polish
+**Goal:** Turn the two skills' separate outputs (a flow-map poster + an unordered list of screen mocks) into one navigable **design story** that walks a reviewer through the journey.
+
+## Scope (user-approved 2026-08-17)
+
+Build **A + B + C + E**; D (guided walkthrough) deferred. Density knob + per-screen
+override deferred behind the token-driven-spacing refactor (see designer-skill-candidates.md).
+
+- **A. Cross-link flow ↔ screens** — a flow-map node links to its screen's spec page; a screen
+  links back to its flow node + the criterion it satisfies.
+- **B. Journey filmstrip** — screen-specs arranges a flow's screens in journey order (by node id)
+  as a horizontal filmstrip with arrows, at the top of the flow page.
+- **C. Design-story hub** — one landing page: Problem/trigger → Journey (flow map) → Screens →
+  Coverage, walked top to bottom.
+- **E. Coverage view** — a matrix of acceptance criteria × (flow nodes / screens / states), green
+  where realized, red where a gap.
+
+## Shared data (already present)
+
+- Flow-maps: flow `key` (HYP-001), nodes with `id` (whole=main row, decimal=branch), edges with `ac`,
+  `trigger`, `findings`. Output `build-flowmaps.mjs` → `<slug(key)>.html` + `index.html`.
+- Screen-specs: screens with `id` (S-…), `node` (flow node id[s]), `ac`, `states`. Output
+  `build-screens.mjs` → `<slug(flow)>.html` + design-system `index.html`.
+- **Join keys:** flow `key` ↔ screen-specs `flow`; flow node `id` ↔ screen `node`; `ac` on both.
+
+## Architecture — a "design-story site" layout
+
+Today both builds slug from the same id → **filename collision** if emitted to one dir, and neither
+knows the other's URLs. Introduce a shared layout both builds can target:
+
+```
+<out>/
+  index.html          # C — the design-story hub (new, build-story.mjs)
+  coverage.html       # E — the coverage matrix (new, build-story.mjs)
+  flows/<slug>.html    # build-flowmaps.mjs --layout story
+  screens/<slug>.html  # build-screens.mjs --layout story
+```
+
+- Both build CLIs gain an optional `--layout story` (default keeps today's flat output, so existing
+  callers are unaffected). Under `story`, they write into `flows/` / `screens/` and emit cross-links
+  to the sibling namespace (A). A flow node → `../screens/<slug>.html#<screenId>`; a screen → its
+  flow node `../flows/<slug>.html#node-<id>` and its `ac` → `../coverage.html#ac-<id>`.
+- Links are emitted **unconditionally under `story` layout** (relative to the sibling dir); a missing
+  counterpart just 404s. No build needs the other to run first.
+- `build-story.mjs` (new, in screen-specs — the richer data owner) reads BOTH the flow spec(s) and the
+  screen spec(s), and generates `index.html` (hub) + `coverage.html`. It does not re-render mocks; it
+  links to the pages the two builds produced.
+
+## Feature detail
+
+### B — journey filmstrip (build-screens.mjs, `story` and flat)
+Sort a flow's screens by `node` id using the flow-map ordering (whole numbers ascending, then decimals
+under their parent). Render a top strip: each screen a small clickable thumbnail (its default mock at a
+reduced scale, or a labelled card) with an arrow to the next, anchored to the full screen section below.
+Screens with no `node` sort last. This is self-contained in build-screens.mjs (no cross-skill dep) and
+works in both layouts.
+
+### A — cross-links (both builds, `story` layout)
+- flow node (flowmap.js render + build-flowmaps glue): if a node id matches a screen's `node`, wrap the
+  node in a link to `../screens/<screenSlug>.html#<screenId>`.
+- screen (build-screens glue): the screen's "Flow node" traceability value links to
+  `../flows/<flowSlug>.html#node-<id>`; each `ac` chip links to `../coverage.html#ac-<id>`.
+- flowSlug/screenSlug derive from the shared key so both sides compute the same path.
+
+### C — design-story hub (build-story.mjs → index.html)
+Sections, top to bottom: **Problem** (flow `trigger`/`bet`), **Journey** (link + thumbnail to each
+`flows/<slug>.html`), **Screens** (link to each `screens/<slug>.html`, grouped by flow, in journey
+order), **Coverage** (summary counts + link to coverage.html). A real narrative landing, not a nav bar.
+
+### E — coverage matrix (build-story.mjs → coverage.html)
+Collect every `ac` id from: flow edges, screen `ac`, region `ac`, state `ac`. For each criterion, list
+which flow node(s), screen(s), and state(s) realize it. A criterion present in a flow/spec `findings`
+entry but with no screen = a **gap** (red row). Anchor each row `#ac-<id>` (cross-link target from A).
+Pure data transform over the specs — unit-testable without a browser.
+
+## Verification (stdlib node --test + build smoke)
+
+1. **Coverage computation** (`build-story.mjs` pure fn): given fixture flow+screen specs, `computeCoverage()`
+   returns the right criteria→{nodes,screens,states} map and flags gaps. Unit test, no DOM.
+2. **Journey order** (`build-screens.mjs` pure fn): `journeyOrder(screens)` sorts by node id
+   (whole then decimal-under-parent); node-less last. Unit test.
+3. **Build smoke:** `--layout story` on fixtures → `flows/`, `screens/`, `index.html`, `coverage.html`
+   exist; a screen page contains a `../flows/…#node-` link; a flow page contains a `../screens/…#` link;
+   the filmstrip markup is present; coverage.html has an `#ac-` anchor.
+4. **No regression:** default (flat) layout output unchanged — existing screen-specs golden/build tests
+   still pass; flat flow-map build still writes `<slug>.html` at root.
+
+## Plan (bite-sized, subagent-driven)
+
+- **T1 — journey order + filmstrip (build-screens.mjs).** TDD `journeyOrder()`; render the filmstrip
+  strip + anchors in both layouts. Golden/existing screen-specs tests stay green.
+- **T2 — `--layout story` + cross-links (both build CLIs).** Add the `story` layout (flows/ + screens/
+  subdirs) and the sibling cross-links to both `build-flowmaps.mjs` and `build-screens.mjs`; default flat
+  layout unchanged. Build-smoke tests for the links + subdir output.
+- **T3 — build-story.mjs: coverage + hub.** TDD `computeCoverage()`; generate `coverage.html` (E) and
+  `index.html` hub (C) from both spec sets; anchors match A's link targets.
+- **T4 — docs + wiring.** Update both SKILL.md workflows (the `story` layout + `build-story.mjs`); note
+  the linked-site output; `npm test` + `npm run validate` green; regenerate marketplaces if descriptions change.
+- **Final review** — whole-branch.
+
+## Out of scope
+- D guided walkthrough; density/per-screen override; re-rendering mocks in the hub (it links, not renders).

--- a/skills.json
+++ b/skills.json
@@ -260,6 +260,13 @@
       "monorepo": "sdlc-skills",
       "name": "visual-testing",
       "description": "Screenshot rendered UI (a generated static page or a running app driven by existing browser/device automation) and diff each screen against a committed baseline with reg-cli (MIT, no cloud). Agent-driven capture, no bundled headless engine; HTML report plus a pass/fail summary."
+    },
+    {
+      "id": "impeccable",
+      "repo": "pbakaus/impeccable",
+      "ref": "main",
+      "subdir": ".claude/skills/impeccable",
+      "description": "Design critique + a deterministic anti-pattern detector (59 non-LLM rules over rendered UI) + live-browser iteration for AI-generated frontends — audit/polish/harden/animate/colorize/typeset playbooks. Apache-2.0, by Paul Bakaus. Used by the designer as a quality gate beside visual-testing."
     }
   ]
 }


### PR DESCRIPTION
## What this adds

Two extensions to the UI/UX **designer** pipeline, on top of PR #61 (designer role + screen-specs web target + visual-testing).

### 1. `impeccable` adopted as a design-quality gate
Registers [`pbakaus/impeccable`](https://github.com/pbakaus/impeccable) (Apache-2.0, ~60k★) as an **external skill** (`skills.json`, subdir `.claude/skills/impeccable`) on the designer's `skills-on-demand`, so it installs with the bundle (fetched from upstream, never re-distributed — like our other externals). It's the **quality** gate — deterministic anti-pattern detectors ("is it slop?") — complementing `visual-testing`'s **regression** gate ("did it drift?"). Two other suggested skills (`taste-skill`, `ui-ux-pro-max`) were evaluated and **skipped** (they overlap `frontend-design` / `screen-specs`); their borrowable ideas are captured in `docs/superpowers/notes/designer-skill-candidates.md`.

### 2. Design-story presentation uplift
Turns the two generators' separate outputs into **one navigable design story** that walks a reviewer through the journey:

- **Journey filmstrip** — each screen-specs flow page opens with its screens in **journey order** (by flow-node id), click-through to each section.
- **`--layout story` + cross-links** — both build CLIs gain a shared `flows/` + `screens/` site layout where flow nodes ↔ screens ↔ criteria all link. The **default flat layout is byte-unchanged** (golden + existing tests lock it).
- **`build-story.mjs`** — a coverage matrix (`coverage.html`: acceptance-criteria × nodes/screens/states, gaps flagged) + a **design-story hub** (`index.html`: Problem → Journey → Screens → Coverage).
- Docs in both `SKILL.md`s.

## Deferred (recorded, not in this PR)
- **Density knob + per-screen `target`/`style`/`density` override** — blocked on a token-driven-spacing refactor (the renderer's spacing is ~373 hardcoded px); recorded as planned in the notes rather than half-built.
- Multi-stack implementation hints; the "query-don't-preload" reference pattern.

## How it was built
Brainstorm → spec → subagent-driven execution (fresh implementer + independent reviewer per task, golden-locked mobile regression guard), then an opus whole-branch review (**APPROVE-TO-MERGE**). Two review findings fixed: an in-file CJS `new Function` shim → the repo-standard `scripts/package.json {"type":"commonjs"}`; and a `</script>`-breakout guard on inlined JSON for parity with the sibling script.

## Testing
- `npm test` — **527/527 pass** (adds `journeyOrder`, `computeCoverage`, and story-layout build-smoke tests; the screen-specs golden still locks the mobile mock byte-for-byte).
- `npm run validate` — clean (bundles, marketplaces, 28 externals incl. impeccable, dupes). Marketplaces regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
