### PR TITLE
fix(manual-qa hooks): stop publishing a floor as the bill

### DIFF
--- a/bundles/manual-qa/hooks/scripts/build-run-metrics.mjs
+++ b/bundles/manual-qa/hooks/scripts/build-run-metrics.mjs
@@ -238,8 +238,25 @@ if (preHasData && postHasData) {
     cache_read:    Math.max(0, postSnap.cache_read    - preSnap.cache_read),
   };
 
-  // Keep flat fields for backwards compat
+  // Keep flat fields for backwards compat.
+  //
+  // NOTE: `tokens_coverage` describes only whether the ccusage lookup was
+  // SCOPED to this session id. It has never described whether the token
+  // accounting is COMPLETE, and the name has been read as if it did.
+  //
+  // It cannot be complete. ccusage reads Claude Code's own session logs, which
+  // record conversation turns — not API calls. Auxiliary requests the harness
+  // makes (the "describe your most recent action in 3-5 words" progress
+  // summariser, the permission/safety classifier) never appear there, yet they
+  // bill real tokens. Measured against a Bifrost gateway for RUN-2026-08-18-002:
+  // 5,720 real requests vs 2,309 conversation turns, and $145.87 actual vs
+  // $20.17 reported here — 58.6% of the true cost was auxiliary traffic this
+  // pipeline is structurally blind to.
+  //
+  // So: every total below is a FLOOR. Where a gateway exists, it is the
+  // authority; treat these numbers as a lower bound, never as the bill.
   session.tokens_coverage = tokensCoverage;
+  session.total_tokens_is_floor = true;
   session.total_tokens = delta.total_tokens;
   session.input_tokens = delta.input_tokens;
   session.output_tokens = delta.output_tokens;
@@ -274,6 +291,7 @@ if (preHasData && postHasData) {
   // once `model` is fully resolved from the report / hardcoded default.
 } else {
   session.tokens_coverage = tokensCoverage;
+  session.total_tokens_is_floor = true;
   session.total_tokens = null;
   session.input_tokens = null;
   session.output_tokens = null;
@@ -308,9 +326,31 @@ session.support_agent_duration_ms = supportDurationMs || null;
 // in the trace file; just never surfaced as its own field before.
 session.subagent_dispatches = tcTraces.length + supportTraces.length;
 
-// Orchestrator overhead = total minus TC runners minus support agents
+// --- Token attribution health (added after RUN-2026-08-18-002) ---
+//
+// Every derived split below subtracts per-dispatch tokens from a session
+// total. That is only meaningful if the dispatches actually reported tokens.
+// When the harness returns `<subagent_tokens>0</subagent_tokens>` (see
+// resolve-subagent-traces.mjs), tcTokens/supportTokens collapse to 0 and the
+// subtraction silently credits 100% of the session to the orchestrator.
+//
+// That is exactly what RUN-2026-08-18-002 published: 57/57 runners attributed
+// 0 tokens, orchestrator_tokens = 90,934,490 of 90,934,806, and
+// orchestrator_cost_pct = 100 — for a run where the orchestrator was ~1% of
+// real usage and the 57 runners did all the work. Emit null rather than a
+// confidently wrong number.
+const allTraces = [...tcTraces, ...supportTraces];
+const attributedCount = allTraces.filter(t => t.tokens_attributed === true || (t.tokens_attributed == null && (t.total_tokens ?? 0) > 0)).length;
+session.tokens_attribution = allTraces.length === 0
+  ? 'none'
+  : attributedCount === allTraces.length ? 'complete'
+  : attributedCount === 0 ? 'none' : 'partial';
+session.tokens_attributed_dispatches = attributedCount;
+
+// Orchestrator overhead = total minus TC runners minus support agents.
+// Only computable when EVERY dispatch reported its tokens.
 const tcTokens = tcTraces.reduce((s, t) => s + (t.total_tokens ?? 0), 0);
-session.orchestrator_tokens = session.total_tokens != null
+session.orchestrator_tokens = (session.total_tokens != null && session.tokens_attribution === 'complete')
   ? Math.max(0, session.total_tokens - tcTokens - supportTokens)
   : null;
 
@@ -745,12 +785,24 @@ if (reportPath && ccusageBlock && costBlock) {
   const { pre, post, delta } = ccusageBlock;
   const fmt = n => n.toLocaleString('en-US');
   const fmtCost = n => `$${n.toFixed(2)}`;
+  // Surface attribution collapse in the report itself. Without this the table
+  // reads as an authoritative bill; RUN-2026-08-18-002 published $20.17 against
+  // a real $145.87 with nothing on the page hinting the number was a floor.
+  const attributionNote = session.tokens_attribution === 'complete' ? '' :
+    `\n> ⚠️ **Token attribution ${session.tokens_attribution}** — ` +
+    `${session.tokens_attributed_dispatches}/${session.subagent_dispatches} dispatches reported tokens. ` +
+    `Per-agent splits and \`orchestrator_cost_pct\` are suppressed.\n`;
+  // Every total here is a FLOOR: auxiliary harness requests (progress
+  // summariser, permission classifier) bill real tokens but never reach the
+  // session log this is derived from. Measured gap on RUN-2026-08-18-002: 7.2x.
+  const floorNote = '\n> ℹ️ **Lower bound, not the bill.** Excludes auxiliary harness requests ' +
+    'invisible to the session log. Where an LLM gateway is available, take cost from it.\n';
   const scopeNote = session.tokens_coverage === 'full_session_unscoped'
     ? ' *(⚠️ unscoped — may include other concurrent Claude Code sessions on this machine)*'
     : '';
 
   const section = `
-## ccusage Session Delta${scopeNote}
+## ccusage Session Delta${scopeNote}${attributionNote}${floorNote}
 
 | Metric | Before | After | Delta |
 |--------|-------:|------:|------:|

--- a/bundles/manual-qa/hooks/scripts/resolve-subagent-traces.mjs
+++ b/bundles/manual-qa/hooks/scripts/resolve-subagent-traces.mjs
@@ -128,11 +128,25 @@ for (const entry of lines) {
       if (!toolUseIdM || !usageM) continue; // no usage block yet (e.g. a non-`completed` notification) — skip
       const toolUseId = toolUseIdM[1];
       const tcIdM = block.match(TC_ID_RE);
+      // A `<subagent_tokens>0</subagent_tokens>` is NOT a measurement of zero —
+      // it is the harness failing to report. A dispatch that ran to `completed`
+      // and issued tool calls cannot have consumed zero tokens. Found in
+      // RUN-2026-08-18-002 (6-suite/55-case regression on a non-Anthropic
+      // gateway): all 57 dispatches reported 0, which downstream was summed as
+      // a real zero — see build-run-metrics.mjs's `tokens_attribution` guard for
+      // what that silently did to orchestrator_cost_pct.
+      //
+      // Record it as null (unmeasured) rather than 0 (measured, empty) so the
+      // distinction survives into the trace file. tool_uses/duration_ms are
+      // reported independently and stay trustworthy.
+      const rawTokens = parseInt(usageM[1], 10);
+      const tokensAttributed = Number.isFinite(rawTokens) && rawTokens > 0;
       byToolUseId.set(toolUseId, {
         tc_id: tcIdM ? tcIdM[1] : null,
         agent_type: dispatchAgentType.get(toolUseId) ?? null,
         role: tcIdM ? 'test-runner' : 'support',
-        total_tokens: parseInt(usageM[1], 10),
+        tokens_attributed: tokensAttributed,
+        total_tokens: tokensAttributed ? rawTokens : null,
         input_tokens: null,
         output_tokens: null,
         cache_creation_input_tokens: null,


### PR DESCRIPTION
## What this fixes

`RUN-2026-08-18-002` — a 6-suite / 55-case iOS regression — published these metrics:

```
session.tokens_coverage      = "full_session"
session.total_tokens         = 90,934,806
session.cost_usd             = 20.16
session.orchestrator_cost_pct = 100
tcs: 57 — with zero/absent total_tokens: 57
```

Measured at the LLM gateway (Bifrost), the same run actually cost **$145.87** — **7.2×** higher — and the orchestrator was roughly **1%** of usage, not 100%. Every one of the 57 runners that did the actual work was credited with **0**.

Nothing in the output hinted at a problem. `tokens_coverage` read `full_session` while 57/57 dispatches reported nothing.

## Two defects, both silent

### 1. A reported zero was treated as a measurement

`resolve-subagent-traces.mjs` took `<subagent_tokens>N</subagent_tokens>` at face value. On a non-Anthropic gateway every dispatch returns `0`. But a dispatch that ran to `completed` and issued tool calls **cannot** have consumed zero tokens — that is the harness failing to report, not an empty run.

Now recorded as `null` with an explicit `tokens_attributed` flag, so *unmeasured* stays distinguishable from *measured empty*. `tool_uses` and `duration_ms` are reported independently and remain trustworthy.

### 2. Zero attribution silently inflated the orchestrator to 100%

```js
orchestrator_tokens = total - tcTokens - supportTokens
```

With every dispatch at zero, `tcTokens` and `supportTokens` collapse to `0` and the subtraction credits the **entire session** to the orchestrator.

This matters beyond one report: `orchestrator_cost_pct` feeds the cost baseline used to compare delivery approaches. A 100% reading is not a rounding error, it inverts the conclusion.

Added `session.tokens_attribution` (`complete` | `partial` | `none`). The orchestrator split and `orchestrator_cost_pct` are suppressed to `null` unless attribution is complete — a null is recoverable, a confident 100 is not.

## The deeper point: these totals can never be complete

`tokens_coverage` has only ever described whether the **ccusage lookup was scoped** to the session id. It has never described whether the **accounting is complete**, and the name invites the second reading.

It cannot be complete. ccusage reads Claude Code's session logs, which record **conversation turns, not API calls**. Auxiliary requests the harness makes bill real tokens and never appear there:

| | |
|---|---:|
| Gateway requests | 5,720 |
| Conversation turns in the logs | 2,309 |
| Invisible auxiliary requests | **3,411** |
| Share of true cost they carry | **58.6%** |

The transcript's own tool-call count (2,543) predicts 75% of those auxiliary requests — one progress-summariser call per tool call — which is what identified the mechanism.

So totals are now flagged `total_tokens_is_floor`, and the generated report carries an attribution warning plus a lower-bound note directing readers to the gateway where one exists.

## Verification

Tested against `RUN-2026-08-18-002`'s real trace shape:

| Case | Before | After |
|---|---|---|
| 59/59 unattributed (this run) | `orchestrator_cost_pct: 100` | `attribution: none`, pct `null` |
| Legacy traces, positive tokens, no new field | unchanged | `attribution: complete`, unchanged |
| Mixed attributed/unattributed | wrong split | `attribution: partial`, suppressed |

Backward compatible: traces predating `tokens_attributed` with positive token counts still read `complete` and compute exactly as before. Both files pass `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)