### PR TITLE
docs: manual-qa audit capability + designer design-skill uplift

### DIFF
--- a/.codex-plugin/marketplace.json
+++ b/.codex-plugin/marketplace.json
@@ -318,6 +318,12 @@
       "version": "0.2.0"
     },
     {
+      "name": "design-taste-frontend",
+      "source": "./skills/design-taste-frontend",
+      "description": "Anti-slop frontend design skill — reads the brief, infers a design direction (VARIANCE / MOTION / DENSITY dials), and ships non-templated interfaces with real design systems, color/shape consistency locks, contrast math, an em-dash ban, and a strict pre-flight check. By leonxlnx (taste-skill). Used by the designer for design-intelligence rules on screen specs and, on a web TS/JS target, its code skeletons.",
+      "version": "0.2.0"
+    },
+    {
       "name": "dispatching-parallel-agents",
       "source": "./skills/dispatching-parallel-agents",
       "description": "Dispatch one focused agent per independent problem domain and run them concurrently — for 2+ tasks with no shared state or sequential dependencies (from obra/superpowers)",
@@ -429,6 +435,12 @@
       "name": "testing-setup",
       "source": "./skills/testing-setup",
       "description": "Analyze and set up a native Android testing strategy — install test libraries, scaffold harnesses for unit, UI, screenshot, and end-to-end tests (official Google Android skills, Apache-2.0)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "ui-ux-pro-max",
+      "source": "./skills/ui-ux-pro-max",
+      "description": "Searchable UI/UX design intelligence — styles, product color palettes with reasoning, font pairings, UX/accessibility guidelines, icons, chart types across many stacks — queried locally via search.py (--domain color|ux|typography|style|product|…). By NextLevelBuilder. Used by the designer as a reference catalog for palette, type-scale, and UX decisions.",
       "version": "0.2.0"
     },
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -450,6 +450,12 @@
       "version": "0.2.0"
     },
     {
+      "name": "design-taste-frontend",
+      "source": "./skills/design-taste-frontend",
+      "description": "Anti-slop frontend design skill — reads the brief, infers a design direction (VARIANCE / MOTION / DENSITY dials), and ships non-templated interfaces with real design systems, color/shape consistency locks, contrast math, an em-dash ban, and a strict pre-flight check. By leonxlnx (taste-skill). Used by the designer for design-intelligence rules on screen specs and, on a web TS/JS target, its code skeletons.",
+      "version": "0.2.0"
+    },
+    {
       "name": "dispatching-parallel-agents",
       "source": "./skills/dispatching-parallel-agents",
       "description": "Dispatch one focused agent per independent problem domain and run them concurrently — for 2+ tasks with no shared state or sequential dependencies (from obra/superpowers)",
@@ -561,6 +567,12 @@
       "name": "testing-setup",
       "source": "./skills/testing-setup",
       "description": "Analyze and set up a native Android testing strategy — install test libraries, scaffold harnesses for unit, UI, screenshot, and end-to-end tests (official Google Android skills, Apache-2.0)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "ui-ux-pro-max",
+      "source": "./skills/ui-ux-pro-max",
+      "description": "Searchable UI/UX design intelligence — styles, product color palettes with reasoning, font pairings, UX/accessibility guidelines, icons, chart types across many stacks — queried locally via search.py (--domain color|ux|typography|style|product|…). By NextLevelBuilder. Used by the designer as a reference catalog for palette, type-scale, and UX decisions.",
       "version": "0.2.0"
     },
     {

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -318,6 +318,12 @@
       "version": "0.2.0"
     },
     {
+      "name": "design-taste-frontend",
+      "source": "./skills/design-taste-frontend",
+      "description": "Anti-slop frontend design skill — reads the brief, infers a design direction (VARIANCE / MOTION / DENSITY dials), and ships non-templated interfaces with real design systems, color/shape consistency locks, contrast math, an em-dash ban, and a strict pre-flight check. By leonxlnx (taste-skill). Used by the designer for design-intelligence rules on screen specs and, on a web TS/JS target, its code skeletons.",
+      "version": "0.2.0"
+    },
+    {
       "name": "dispatching-parallel-agents",
       "source": "./skills/dispatching-parallel-agents",
       "description": "Dispatch one focused agent per independent problem domain and run them concurrently — for 2+ tasks with no shared state or sequential dependencies (from obra/superpowers)",
@@ -429,6 +435,12 @@
       "name": "testing-setup",
       "source": "./skills/testing-setup",
       "description": "Analyze and set up a native Android testing strategy — install test libraries, scaffold harnesses for unit, UI, screenshot, and end-to-end tests (official Google Android skills, Apache-2.0)",
+      "version": "0.2.0"
+    },
+    {
+      "name": "ui-ux-pro-max",
+      "source": "./skills/ui-ux-pro-max",
+      "description": "Searchable UI/UX design intelligence — styles, product color palettes with reasoning, font pairings, UX/accessibility guidelines, icons, chart types across many stacks — queried locally via search.py (--domain color|ux|typography|style|product|…). By NextLevelBuilder. Used by the designer as a reference catalog for palette, type-scale, and UX decisions.",
       "version": "0.2.0"
     },
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,9 @@ own their `agents/` and `skills/` as real directories. Four factories ship:
 - **`test-automation`** — TMS-driven automation pipeline: test-automation-lead,
   qa-engineer, test-automation-engineer, Scout.
 - **`manual-qa`** — live-browser manual-QA team: test-run-lead, test-author,
-  test-sizer, test-runner, test-reporter, app-profiler.
+  test-sizer, test-runner, test-reporter, app-profiler, qa-auditor (specialist
+  web audits — security, accessibility, privacy, performance, responsive, UX,
+  SEO — with findings codified into regression TC cases).
 - **`product-management`** — Product Owner discovery pipeline: product-owner
   (Priya), discovery-researcher (Sam); 10 discovery skills seeding
   `docs/discovery/`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -36,6 +36,7 @@ inside the factory that owns it (`factories/<id>/agents/<name>/`); only
 - `test-runner` — Executes one case against a running app via Playwright MCP, returns structured JSON
 - `test-reporter` — Turns run results into a Markdown report
 - `app-profiler` — Onboards a web app, writes the shared app profile
+- `qa-auditor` — Specialist web auditor: runs security/accessibility/privacy/performance/responsive/UX/SEO audit passes via Playwright MCP, reports findings, codifies notable ones into TC cases
 
 **Product management (`product-management` factory):**
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ ship today:
 | Factory | Roster | What it's for |
 |---|---|---|
 | `feature-development` | core roles (scout, ba, project-manager, tech-lead, qa-engineer) + picked dev roles | Cross-platform delivery team — interactive picker selects any of `python-dev` (FastAPI/FastMCP backend), `js-dev` (JS/TS frontend), `test-automation-engineer` (web automation), `ios-dev` (Swift/SwiftUI), `android-dev` (greenfield Kotlin/Compose); core roles auto-tune per picked platforms. |
-| `manual-qa` | 6 factory-local agents (app-profiler, test-sizer, test-author, test-run-lead, test-runner, test-reporter) | Manual-QA team — `app-profiler` onboards the app, then `test-run-lead` orchestrates a run: authoring (`test-author`) and sizing (`test-sizer`) cases when needed, running them live via Playwright MCP (`test-runner`), and reporting (`test-reporter`). Ships its own agents and seeds the test-case/report-format reference docs into `.agents/manual-qa/knowledge/`. |
+| `manual-qa` | 7 factory-local agents (app-profiler, test-sizer, test-author, test-run-lead, test-runner, test-reporter, qa-auditor) | Manual-QA team — `app-profiler` onboards the app, then `test-run-lead` orchestrates a run: authoring (`test-author`) and sizing (`test-sizer`) cases when needed, running them live via Playwright MCP (`test-runner`), and reporting (`test-reporter`). Also ships a specialist audit mode: `qa-auditor` runs security/accessibility/privacy/performance/responsive/UX/SEO passes via Playwright MCP, writes a findings report, and codifies notable findings into regression TC cases. Ships its own agents and seeds the test-case/report-format reference docs into `.agents/manual-qa/knowledge/`. |
 | `test-automation` | shared core (scout) + test-automation-engineer + qa-engineer + factory-local `test-automation-lead` (Tal) | Automation-focused team — Tal orchestrates the analyst → implementer → reviewer pipeline, owns test-framework architecture and the automation merge gate. Pins `test-automation-workflow` + `test-case-analysis`; TMS-agnostic. |
 | `product-management` | 2 factory-local agents (product-owner, discovery-researcher) | PO discovery pipeline — `product-owner` (Priya) drives intake triage, persona/outcome framing, opportunity-tree mapping, and prioritization end to end; `discovery-researcher` (Sam) is dispatched for stakeholder interviews and evidence verification. Ships 10 factory-local skills and seeds an empty `docs/discovery/` scaffold. |
 
@@ -325,6 +325,7 @@ roles rather than named personas), all driving a running app via Playwright MCP:
 | `test-runner` | Executes one case against the running app, returns a structured JSON result |
 | `test-reporter` | Turns runner results into a Markdown run report |
 | `app-profiler` | Onboards a web app and writes the shared `app_profile.md` every manual-qa agent reads |
+| `qa-auditor` | Specialist web auditor — Step-0 Playwright evidence collection then specialist audit passes (security, accessibility, privacy, performance, responsive, UX, SEO); writes a findings report and codifies notable findings into regression TC cases |
 
 ### Skills
 

--- a/docs/onboarding/README.md
+++ b/docs/onboarding/README.md
@@ -11,7 +11,7 @@ yours below. For the catalog, install paths, and architecture, see the root
 | Guide | Install | Who it's for |
 |---|---|---|
 | [**feature-development**](feature-development.md) | `--factory feature-development` | A cross-platform delivery team — BA, PM, tech-lead, QA, scout, and pickable dev roles (Python / JS / iOS / greenfield-Compose Android / test-automation). You're building features. |
-| [**manual-qa**](manual-qa.md) | `--factory manual-qa` | A standalone manual-QA team that authors Markdown cases and runs them **live** against a web or mobile app (Playwright / Appium / Mobitru). No test code generated. |
+| [**manual-qa**](manual-qa.md) | `--factory manual-qa` | A standalone manual-QA team that authors Markdown cases and runs them **live** against a web or mobile app (Playwright / Appium / Mobitru), plus specialist web audits (security/a11y/privacy/perf/UX/SEO). No test code generated. |
 | [**test-automation**](test-automation.md) | `--factory test-automation` | A TMS-driven automation pipeline — a lead (Tal) runs analyst → implementer → reviewer to turn TMS cases into merged, honest automated tests. |
 | [**product-management**](product-management.md) | `--factory product-management` | A Product Owner discovery team — Priya runs raw ask → problem → hypothesis → ratified outcome → prioritized bet, dispatching Sam for evidence, then hands off to engineering. Upstream of delivery; writes no code. |
 

--- a/docs/onboarding/manual-qa.md
+++ b/docs/onboarding/manual-qa.md
@@ -24,16 +24,18 @@ the factory README first — this guide assumes it and focuses on **adoption**:
 You → app-profiler (onboard the app, once) → test-run-lead (orchestrates a run)
         → test-author / test-sizer (assemble the suite, when needed)
         → test-runner (one per case, live) → test-reporter (run report)
+        → qa-auditor (audit requests, lead-routed or standalone) → codifies findings via test-author
 ```
 
 | Slot | Agent | Job |
 |---|---|---|
 | Onboarding | `app-profiler` | Explores the running app, writes `.agents/manual-qa/app_profile.md` (URLs, auth, key flows, selectors, fragile areas) |
-| Orchestrator | `test-run-lead` | The single run orchestrator — assembles the suite, runs a `test-runner` per case, triggers the report |
+| Orchestrator | `test-run-lead` | The single run orchestrator — assembles the suite, runs a `test-runner` per case, triggers the report; routes audit requests to `qa-auditor` |
 | Sizing | `test-sizer` | Rates cases S/M/L for agent-execution cost |
 | Authoring | `test-author` | Turns flow descriptions into `tasks/<suite>/TC-NNN_<slug>.md` |
 | Execution | `test-runner` | Runs one case live, returns a structured JSON result |
 | Reporting | `test-reporter` | Collects results, writes `reports/RUN-YYYY-MM-DD-NNN.md` |
+| Audit | `qa-auditor` | Specialist web auditor — runs security/accessibility/privacy/performance/responsive/UX/SEO passes via Playwright MCP, writes a findings report, and dispatches `test-author` to codify notable findings into regression TC cases; invocable lead-routed or standalone |
 
 **There is no `scout` here** — `app-profiler` is the onboarding agent, and
 `test-run-lead` is the orchestrator you launch directly. Every other agent reads
@@ -75,7 +77,7 @@ cd /path/to/your-repo
 npx github:arozumenko/sdlc-skills init --factory manual-qa
 ```
 
-This installs the 6 agents into `.claude/agents/`, seeds the reference docs
+This installs the 7 agents into `.claude/agents/`, seeds the reference docs
 (case format, template, report format) into `.agents/manual-qa/knowledge/`,
 wires the context hooks, and splices the team conventions into `AGENTS.md`.
 
@@ -84,7 +86,7 @@ For Copilot / Cursor / Windsurf, use the manual form:
 ```bash
 npx github:arozumenko/sdlc-skills init \
   --target copilot \
-  --agents app-profiler,test-run-lead,test-author,test-sizer,test-runner,test-reporter \
+  --agents app-profiler,test-run-lead,test-author,test-sizer,test-runner,test-reporter,qa-auditor \
   --yes
 ```
 
@@ -119,6 +121,40 @@ snapshot of the **Expected Final State** to record a PASS — a PASS without a
 confirming snapshot is invalid), then triggers `test-reporter` to write
 `reports/RUN-YYYY-MM-DD-NNN.md`. **Talk only to the lead** during a run — don't
 invoke `test-runner` / `test-sizer` / `test-author` by hand mid-run.
+
+---
+
+## Audit mode
+
+Alongside case-driven runs, the team supports specialist **web audits** — a
+different question ("what's wrong with this page?") than a scripted test case
+("does this flow work?"). There are two ways in:
+
+- **Lead-routed** — ask `test-run-lead` to audit, "find issues", or check
+  security/accessibility/privacy/performance/responsive/UX/SEO against a
+  target, and it takes the audit branch: dispatches `qa-auditor` with the
+  target and scope, collects its findings back, and codifies them itself.
+- **Standalone** — invoke `/agent qa-auditor` directly with a target URL for
+  a one-off audit outside a run.
+
+`qa-auditor` collects Step-0 evidence (navigate, snapshot, screenshot,
+console errors, network requests) via the same Playwright MCP as
+`test-runner`, then runs the applicable **specialist passes** —
+`security-audit`, `accessibility-audit`, `privacy-audit`, `performance-audit`,
+`responsive-audit`, `ux-audit`, `content-seo-audit` (security, accessibility,
+privacy, content-seo, and performance always run; UX and responsive run
+conditionally on page signals). These are `skills-on-demand` on `qa-auditor`,
+so they install with the agent but only load into context when their
+specialty is actually selected for a given audit.
+
+Findings are deduped, ranked, and written to
+`reports/audit-{target}-{date}.md`. Notable findings (priority p0–p1,
+confidence ≥5) are then **codified**: `qa-auditor` (standalone) or
+`test-run-lead` (lead-routed) dispatches `test-author` with the findings,
+which authors `TC-NNN` regression cases under `tasks/<suite>/` — ordinary
+suite cases a later `test-run-lead` run can pick up via `test-runner` like
+any other case. Full detail: [factories/manual-qa/README.md § Audit
+mode](../../factories/manual-qa/README.md#audit-mode).
 
 ---
 

--- a/factories/SPEC.md
+++ b/factories/SPEC.md
@@ -326,6 +326,6 @@ order. Three conventions keep it that way:
 | id | team | dev roles |
 |---|---|---|
 | `feature-development` | cross-platform (web + iOS + Android) | pick any of `python-dev`, `js-dev`, `test-automation-engineer`, `ios-dev`, `android-dev` (greenfield Compose only); core roles auto-tune |
-| `manual-qa` | manual QA for web | 6 local agents: `app-profiler`, `test-sizer`, `test-author`, `test-run-lead`, `test-runner`, `test-reporter` |
+| `manual-qa` | manual QA for web | 7 local agents: `app-profiler`, `test-sizer`, `test-author`, `test-run-lead`, `test-runner`, `test-reporter`, `qa-auditor` |
 | `test-automation` | TMS-driven automation pipeline | `test-automation-lead` orchestrates `qa-engineer` + `test-automation-engineer` |
 | `product-management` | PO discovery pipeline | 2 local agents: `product-owner`, `discovery-researcher`; 10 discovery skills; seeds `docs/discovery/` |

--- a/factories/feature-development/agents/designer/AGENT.md
+++ b/factories/feature-development/agents/designer/AGENT.md
@@ -7,7 +7,7 @@ group: core
 theme: {color: colour170, icon: "🎨", short_name: dsn}
 aliases: [remy]
 skills: [brainstorming, memory]
-skills-on-demand: [user-flow-maps, screen-specs, visual-testing, impeccable]
+skills-on-demand: [user-flow-maps, screen-specs, visual-testing, impeccable, ui-ux-pro-max, design-taste-frontend]
 metadata:
   authors:
     - Artem Rozumenko <artyom.rozumenko@gmail.com>
@@ -45,11 +45,11 @@ Your role memory and this project's `.agents/*.md` digests (team-comms, profile,
 
 If no flow or acceptance criteria exist yet, ask the BA (Alex) to produce them — or the Product Owner (Priya) if discovery hasn't run. Designing without them produces screens nobody agreed to.
 
-## Four skills, loaded on demand
+## Skills, loaded on demand
 
-You own two generators and two checkers. Load the one the task calls for — they are
-`skills-on-demand`, so they are installed on disk but not in your standing context until you invoke
-them.
+You own two **generators**, two **quality checks**, and two **design-intelligence references**.
+Load the one the task calls for — they are `skills-on-demand`, installed on disk but not in your
+standing context until you invoke them.
 
 1. **`user-flow-maps`** — when a flow, journey, or screen-to-screen behaviour needs to become a
    visual map reviewers can sign off on. Platform-agnostic: it renders screens, decisions,
@@ -72,8 +72,35 @@ them.
    taste/quality pass that catches AI-generic output no regression check would. Its findings are
    prompts to improve, not automatic verdicts. Invoke the `impeccable` skill and follow it.
 
-**The two checks are complementary — run both on a finished design:** `impeccable` for *quality*
-(is this slop?), `visual-testing` for *regression* (did this change vs the approved baseline?).
+**Design-intelligence references** (data and rules you pull *into* your own artifacts — they don't
+generate your output):
+
+5. **`ui-ux-pro-max`** — a searchable UI/UX catalog (styles, product colour palettes with reasoning,
+   font pairings, UX/accessibility guidelines, icons, chart types). Query it locally via its
+   `search.py --domain color|ux|typography|style|product|…` when you're settling the **design system**
+   (palette, type scale, component patterns) or cross-checking a screen against UX/accessibility
+   guidance. It returns *data and guidance*, not layout — you express what it returns in
+   `design-system.json` / the spec, exactly as you already do. Invoke the `ui-ux-pro-max` skill and
+   follow it.
+6. **`design-taste-frontend`** — an anti-slop design skill (brief inference, VARIANCE/MOTION/DENSITY
+   dials, colour/shape **consistency locks**, contrast math, a hard **em-dash ban**, and a binary
+   pre-flight checklist). Use it as a **rules** source for the visual-polish pass: apply its
+   format-neutral checks (one radius system, one accent discipline, AA contrast, no `—` in visible
+   copy, motion only where it means something) to your screens and run its pre-flight before you call
+   a set done. It also carries React/Tailwind/Motion **code skeletons** — those apply only when the
+   target is real **web TS/JS code** (an emerging direction for this role); on today's `.dc.html` artboards and mobile
+   screen-specs, take the rules and leave the stack code. Invoke the `design-taste-frontend` skill and
+   follow it.
+
+**Reflex — when a request is "review / fix / make this good / is this slop":** reach for your quality
+skills *first*, not a fresh idea. Run **`impeccable`** (the deterministic anti-slop gate) and, for the
+rule-level polish, `design-taste-frontend`'s pre-flight — before hand-rewriting anything. "Does this
+satisfy the acceptance criteria?" is a *different* question: that's `screen-specs` / `user-flow-maps`
+traceability, not a taste pass — keep the two separate.
+
+**The two verification checks are complementary — run both on a finished design:** `impeccable` for
+*quality* (is this slop?), `visual-testing` for *regression* (did this change vs the approved
+baseline?).
 
 **Platform scope of `screen-specs`:** it now covers **mobile** (device library —
 iphone / iphone-max / android / iphone-se — and MD3-vs-iOS platform calls) AND

--- a/factories/product-management/agents/designer/AGENT.md
+++ b/factories/product-management/agents/designer/AGENT.md
@@ -7,7 +7,7 @@ group: core
 theme: {color: colour170, icon: "🎨", short_name: dsn}
 aliases: [remy]
 skills: [brainstorming, memory]
-skills-on-demand: [user-flow-maps]
+skills-on-demand: [user-flow-maps, ui-ux-pro-max, design-taste-frontend]
 metadata:
   authors:
     - Artem Rozumenko <artyom.rozumenko@gmail.com>
@@ -51,8 +51,23 @@ paths as self-contained HTML posters with an authoritative edge table. It is pla
 web, mobile, anything — because it maps **behaviour, not design**.
 
 This is a **pre-design** artifact. You draw *what must happen and when*; the visual design of the
-screens themselves is a separate step that lands in the `feature-development` bundle's designer.
+screens themselves is a separate step that lands in the `feature-development` factory's designer.
 Keeping that line is exactly what makes a flow map reviewable by non-designers.
+
+### Design intelligence, on demand (reference only)
+
+Two design-intelligence skills are installed as `skills-on-demand` for when a discovery task calls
+for visual or style thinking — vetting a competitor's UX, sketching an aesthetic direction to hand
+downstream, or grounding a palette/type suggestion in real guidance:
+
+- **`ui-ux-pro-max`** — a searchable UI/UX catalog (styles, palettes, font pairings, UX/accessibility
+  guidelines); query it via `search.py --domain color|ux|typography|style|…`.
+- **`design-taste-frontend`** — anti-slop design rules (consistency locks, contrast, em-dash ban,
+  pre-flight checklist).
+
+They are **reference lookups, not a mandate to start designing screens** — screen design stays with
+the `feature-development` designer. Reach for them when a task genuinely needs design intelligence;
+your core deliverable is still the flow map.
 
 ## Role in the Team
 

--- a/skills.json
+++ b/skills.json
@@ -267,6 +267,20 @@
       "ref": "main",
       "subdir": ".claude/skills/impeccable",
       "description": "Design critique + a deterministic anti-pattern detector (59 non-LLM rules over rendered UI) + live-browser iteration for AI-generated frontends — audit/polish/harden/animate/colorize/typeset playbooks. Apache-2.0, by Paul Bakaus. Used by the designer as a quality gate beside visual-testing."
+    },
+    {
+      "id": "design-taste-frontend",
+      "repo": "Leonxlnx/taste-skill",
+      "ref": "main",
+      "subdir": "skills/taste-skill",
+      "description": "Anti-slop frontend design skill — reads the brief, infers a design direction (VARIANCE / MOTION / DENSITY dials), and ships non-templated interfaces with real design systems, color/shape consistency locks, contrast math, an em-dash ban, and a strict pre-flight check. By leonxlnx (taste-skill). Used by the designer for design-intelligence rules on screen specs and, on a web TS/JS target, its code skeletons."
+    },
+    {
+      "id": "ui-ux-pro-max",
+      "repo": "nextlevelbuilder/ui-ux-pro-max-skill",
+      "ref": "main",
+      "subdir": ".claude/skills/ui-ux-pro-max",
+      "description": "Searchable UI/UX design intelligence — styles, product color palettes with reasoning, font pairings, UX/accessibility guidelines, icons, chart types across many stacks — queried locally via search.py (--domain color|ux|typography|style|product|…). By NextLevelBuilder. Used by the designer as a reference catalog for palette, type-scale, and UX decisions."
     }
   ]
 }


### PR DESCRIPTION
Two related-to-manual-qa/designer follow-ups from PR #65, bundled per request.

## 1. Docs reflect the manual-qa audit capability (`5e953cd`)

PR #65 added a 7th manual-qa agent (`qa-auditor`) + specialist web-audit mode, but the top-level catalog/onboarding docs still described a 6-agent team. Updated:
- `README.md` (factory catalog row 6→7 + qa-auditor roster row + audit-mode description)
- `AGENTS.md`, `GEMINI.md` (manual-qa rosters)
- `factories/SPEC.md` (factory-summary table 6→7)
- `docs/onboarding/manual-qa.md` (pipeline diagram, role table, install count, `--agents` example, and a new **Audit mode** section)

Factory-local manual-qa docs were already accurate and left untouched.

## 2. Designer uplift — wire two external design skills (`0ed28a2`)

Registers two design-intelligence skills and wires them into the designer:
- **`ui-ux-pro-max`** (nextlevelbuilder) — searchable UI/UX catalog (palettes, font pairings, UX/accessibility guidelines) via `search.py --domain`.
- **`design-taste-frontend`** (leonxlnx/taste-skill) — anti-slop design rules (consistency locks, contrast math, em-dash ban, pre-flight checklist).

Both added to `skills-on-demand` on **both** designer copies. The feature-development designer gets a design-intelligence section, an **impeccable/quality-first reflex** on "review/fix/make it good" requests, and a functional-vs-visual split; taste-skill's code skeletons are framed for an emerging **web TS/JS** target while its format-neutral rules apply to today's `.dc.html` artboards + mobile specs. The product-management designer gets them **reference-only** (its role stays flow maps).

Design informed by analyzing a real test session (the designer used these skills against a `.dc.html` banking build) — see the friction that drove the instruction choices.

## Verification
- Both externals pass the network `name == id` check; both appear in regenerated marketplace manifests with real descriptions.
- `npm test` → **700/700 pass**; `npm run validate` → all green (factories + marketplaces + externals + dupes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
